### PR TITLE
CP-614 Refactor WResponse

### DIFF
--- a/example/http/cross_origin_credentials/service.dart
+++ b/example/http/cross_origin_credentials/service.dart
@@ -35,7 +35,7 @@ Future<bool> checkStatus() async {
 
   try {
     WResponse response = await req.get(sessionUrl);
-    return JSON.decode(await response.text)['authenticated'];
+    return JSON.decode(await response.asText())['authenticated'];
   } catch (error) {
     // Server probably isn't running
     return false;
@@ -53,7 +53,7 @@ Future<bool> login() async {
     return false;
   }
   return response.status == 200 &&
-      JSON.decode(await response.text)['authenticated'];
+      JSON.decode(await response.asText())['authenticated'];
 }
 
 /// Logout by sending a request to the /logout endpoint.
@@ -66,7 +66,7 @@ Future<bool> logout() async {
     return false;
   }
   return response.status == 200 &&
-      !JSON.decode(await response.text)['authenticated'];
+      !JSON.decode(await response.asText())['authenticated'];
 }
 
 /// Attempt to make a request that requires credentials.
@@ -78,7 +78,7 @@ Future<String> makeCredentialedRequest() async {
 
   WResponse response;
   response = await req.get(credentialedEndpointUrl);
-  return response.text;
+  return response.asText();
 }
 
 /// Attempt to make a request that requires credentials,
@@ -87,5 +87,5 @@ Future<String> makeCredentialedRequest() async {
 Future<String> makeUncredentialedRequest() async {
   // withCredentials is unset by default, so no need to do anything special here
   WResponse response = await WHttp.get(credentialedEndpointUrl);
-  return response.text;
+  return response.asText();
 }

--- a/example/http/cross_origin_file_transfer/services/remote_files.dart
+++ b/example/http/cross_origin_file_transfer/services/remote_files.dart
@@ -82,7 +82,7 @@ class RemoteFiles {
       WResponse response = await WHttp.get(getFilesEndpointUrl());
 
       // Parse the file list from the response
-      List results = JSON.decode(await response.text)['results'];
+      List results = JSON.decode(await response.asText())['results'];
       List<RemoteFileDescription> files = results
           .map((Map file) =>
               new RemoteFileDescription(file['name'], file['size']))

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -49,7 +49,7 @@ handleFileClick(MouseEvent event) async {
 /// Requests the contents of a file using WRequest.
 Future<String> requestFile(String filePath) async {
   WResponse response = await WHttp.get(Uri.parse(filePath));
-  return response.text;
+  return response.asText();
 }
 
 /// Displays the file contents in the response pane.

--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -82,13 +82,13 @@ int parseResponseStatus(HttpRequest request) => request.status;
 String parseResponseStatusText(HttpRequest request) => request.statusText;
 
 /// Get the response data from the [HttpRequest].
-Future<Object> parseResponseData(HttpRequest request, _, __) async =>
-    request.response;
+Future<Object> parseResponseData(Stream stream) async => stream.first;
 
 /// Get the the response text from the [HttpRequest].
-Future<String> parseResponseText(
-        HttpRequest request, Encoding encoding, _, __) async =>
-    request.responseText;
+Future<String> parseResponseText(Stream stream) async {
+  Object data = await stream.first;
+  return data != null ? data.toString() : null;
+}
 
 /// Create a response stream from an [Iterable] with one element,
 /// the response data from [HttpRequest].
@@ -133,7 +133,7 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
 
   // Listen for request completion/errors.
   request.onLoad.listen((ProgressEvent e) {
-    WResponse response = new WResponse(request, wRequest.encoding);
+    WResponse response = wResponseFactory(request, wRequest.encoding);
     if ((request.status >= 200 && request.status < 300) ||
         request.status == 0 ||
         request.status == 304) {

--- a/lib/src/http/w_http_common.dart
+++ b/lib/src/http/w_http_common.dart
@@ -53,18 +53,12 @@ String parseResponseStatusText(response) => _parseResponseStatusText(response);
 typedef String ResponseStatusTextParser(response);
 ResponseStatusTextParser _parseResponseStatusText;
 
-Future<Object> parseResponseData(response, int total,
-        StreamController<WProgress> downloadProgressController) =>
-    _parseResponseData(response, total, downloadProgressController);
-typedef Future<Object> ResponseDataParser(response, int total,
-    StreamController<WProgress> downloadProgressController);
+Future<Object> parseResponseData(Stream stream) => _parseResponseData(stream);
+typedef Future<Object> ResponseDataParser(Stream stream);
 ResponseDataParser _parseResponseData;
 
-Future<String> parseResponseText(response, Encoding encoding, int total,
-        StreamController<WProgress> downloadProgressController) =>
-    _parseResponseText(response, encoding, total, downloadProgressController);
-typedef Future<String> ResponseTextParser(response, Encoding encoding,
-    int total, StreamController<WProgress> downloadProgressController);
+Future<String> parseResponseText(Stream stream) => _parseResponseText(stream);
+typedef Future<String> ResponseTextParser(Stream stream);
 ResponseTextParser _parseResponseText;
 
 Stream parseResponseStream(response, int total,

--- a/lib/src/http/w_http_server.dart
+++ b/lib/src/http/w_http_server.dart
@@ -94,21 +94,14 @@ String parseResponseStatusText(HttpClientResponse response) =>
 
 /// Get the response data from the [HttpClientResponse] stream
 /// by reducing it into a single [List].
-Future<Object> parseResponseData(HttpClientResponse response, int total,
-    StreamController<WProgress> downloadProgressController) => response
-    .transform(wProgressListener(total, downloadProgressController))
+Future<Object> parseResponseData(Stream stream) => stream
     .reduce((List previous, List element) {
   return new List.from(previous)..addAll(element);
 });
 
 /// Get the the response text from the [HttpClientResponse] stream
 /// by decoding the bytes and joining it into a single [String].
-Future<String> parseResponseText(HttpClientResponse response, Encoding encoding,
-        int total, StreamController<WProgress> downloadProgressController) =>
-    response
-        .transform(wProgressListener(total, downloadProgressController))
-        .transform(encoding.decoder)
-        .join('');
+Future<String> parseResponseText(Stream stream) => stream.join('');
 
 /// Get the response stream from the [HttpClientResponse].
 Stream parseResponseStream(HttpClientResponse response, int total,
@@ -161,7 +154,7 @@ Future<WResponse> send(String method, WRequest wRequest,
 
   // Close the request now that data (if any) has been sent and wait for the response
   HttpClientResponse response = await request.close();
-  WResponse wResponse = new WResponse(response, wRequest.encoding,
+  WResponse wResponse = wResponseFactory(response, wRequest.encoding,
       response.contentLength, downloadProgressController);
   if ((wResponse.status >= 200 && wResponse.status < 300) ||
       wResponse.status == 0 ||

--- a/test/w_http_client_integration_test.dart
+++ b/test/w_http_client_integration_test.dart
@@ -53,7 +53,7 @@ void main() {
       request.path = '/test/http/reflect';
       WResponse response = store(await request.head());
       expect(response.status, equals(200));
-      expect(await response.text, equals(''));
+      expect(await response.asText(), equals(''));
     }));
 
     test('should support a FormData payload', httpTest((store) async {
@@ -80,7 +80,7 @@ void main() {
         }
       });
       WResponse response = await request.post();
-      await response.stream.drain();
+      await response.asStream().drain();
       expect(uploadProgressListenedTo, isTrue);
     });
 
@@ -93,7 +93,7 @@ void main() {
         }
       });
       WResponse response = await request.get();
-      await response.stream.drain();
+      await response.asStream().drain();
       expect(downloadProgressListenedTo, isTrue);
     });
 
@@ -103,7 +103,7 @@ void main() {
         xhr.setRequestHeader('x-configured', 'true');
       });
       WResponse response = await request.get();
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -128,21 +128,17 @@ void main() {
     });
 
     test(
-        'parseResponseData() should return response data from HttpRequest (async)',
+        'parseResponseData() should return response data from the stream (async)',
         () async {
-      HttpRequest request = new MockHttpRequest();
-      when(request.response).thenReturn('data');
-      expect(await w_http_client.parseResponseData(request, null, null),
-          equals('data'));
+      Stream stream = new Stream.fromIterable(['data']);
+      expect(await w_http_client.parseResponseData(stream), equals('data'));
     });
 
     test(
-        'parseResponseText() should return response text from HttpRequest (async)',
+        'parseResponseText() should return response text from the stream (async)',
         () async {
-      HttpRequest request = new MockHttpRequest();
-      when(request.responseText).thenReturn('data');
-      expect(await w_http_client.parseResponseText(request, null, null, null),
-          equals('data'));
+      Stream stream = new Stream.fromIterable(['data']);
+      expect(await w_http_client.parseResponseText(stream), equals('data'));
     });
 
     test(

--- a/test/w_http_common_integration_tests.dart
+++ b/test/w_http_common_integration_tests.dart
@@ -16,6 +16,7 @@
 
 library w_transport.test.w_http_common_tests;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:w_transport/w_http.dart';
@@ -36,14 +37,14 @@ void run(String usage) {
     test('should be able to send a DELETE request', () async {
       WResponse response = await WHttp.delete(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('DELETE'));
     });
 
     test('should be able to send a GET request', () async {
       WResponse response = await WHttp.get(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('GET'));
     });
 
@@ -55,28 +56,28 @@ void run(String usage) {
     test('should be able to send a OPTIONS request', () async {
       WResponse response = await WHttp.options(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('OPTIONS'));
     });
 
     test('should be able to send a PATCH request', () async {
       WResponse response = await WHttp.patch(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('PATCH'));
     });
 
     test('should be able to send a POST request', () async {
       WResponse response = await WHttp.post(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('POST'));
     });
 
     test('should be able to send a PUT request', () async {
       WResponse response = await WHttp.put(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('PUT'));
     });
   });
@@ -144,7 +145,7 @@ void run(String usage) {
       WResponse response = await request.post(
           request.uri.replace(path: '/test/http/reflect'), 'data');
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['body'], equals('data'));
     });
 
@@ -167,37 +168,39 @@ void run(String usage) {
       test('should support a DELETE method', httpTest((store) async {
         var response = store(await request.delete());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('DELETE'));
+        expect(
+            JSON.decode(await response.asText())['method'], equals('DELETE'));
       }));
 
       test('should support a GET method', httpTest((store) async {
         var response = store(await request.get());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('GET'));
+        expect(JSON.decode(await response.asText())['method'], equals('GET'));
       }));
 
       test('should support a OPTIONS method', httpTest((store) async {
         var response = store(await request.options());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('OPTIONS'));
+        expect(
+            JSON.decode(await response.asText())['method'], equals('OPTIONS'));
       }));
 
       test('should support a PATCH method', httpTest((store) async {
         var response = store(await request.patch());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('PATCH'));
+        expect(JSON.decode(await response.asText())['method'], equals('PATCH'));
       }));
 
       test('should support a POST method', httpTest((store) async {
         var response = store(await request.post());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('POST'));
+        expect(JSON.decode(await response.asText())['method'], equals('POST'));
       }));
 
       test('should support a PUT method', httpTest((store) async {
         var response = store(await request.put());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['method'], equals('PUT'));
+        expect(JSON.decode(await response.asText())['method'], equals('PUT'));
       }));
     });
 
@@ -210,19 +213,19 @@ void run(String usage) {
       test('should be supported on a PATCH request', httpTest((store) async {
         var response = store(await request.patch());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['body'], equals('data'));
+        expect(JSON.decode(await response.asText())['body'], equals('data'));
       }));
 
       test('should be supported on a POST request', httpTest((store) async {
         var response = store(await request.post());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['body'], equals('data'));
+        expect(JSON.decode(await response.asText())['body'], equals('data'));
       }));
 
       test('should be supported on a PUT request', httpTest((store) async {
         var response = store(await request.put());
         expect(response.status, equals(200));
-        expect(JSON.decode(await response.text)['body'], equals('data'));
+        expect(JSON.decode(await response.asText())['body'], equals('data'));
       }));
     });
 
@@ -239,7 +242,7 @@ void run(String usage) {
       test('should be supported on a DELETE request', httpTest((store) async {
         var response = store(await request.delete());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -249,7 +252,7 @@ void run(String usage) {
       test('should be supported on a GET request', httpTest((store) async {
         var response = store(await request.get());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -259,7 +262,7 @@ void run(String usage) {
       test('should be supported on a OPTIONS request', httpTest((store) async {
         var response = store(await request.options());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -269,7 +272,7 @@ void run(String usage) {
       test('should be supported on a PATCH request', httpTest((store) async {
         var response = store(await request.patch());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -279,7 +282,7 @@ void run(String usage) {
       test('should be supported on a POST request', httpTest((store) async {
         var response = store(await request.post());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -289,7 +292,7 @@ void run(String usage) {
       test('should be supported on a PUT request', httpTest((store) async {
         var response = store(await request.put());
         expect(response.status, equals(200));
-        Map responseJson = JSON.decode(await response.text);
+        Map responseJson = JSON.decode(await response.asText());
         expect(responseJson['headers']['content-type'],
             equals('application/json'));
         expect(responseJson['headers']['authorization'], equals('test'));
@@ -314,17 +317,32 @@ void run(String usage) {
     });
 
     test('data should be available as a Future', () async {
-      Object data = await response.data;
+      Object data = await response.asFuture();
       expect(data is List<int> || data is String, isTrue);
     });
 
     test('data should be available decoded to text', () async {
-      String text = await response.text;
+      String text = await response.asText();
       expect(text.isNotEmpty, isTrue);
     });
 
     test('data should be available as a Stream', () async {
-      expect((await response.stream.length) > 0, isTrue);
+      expect((await response.asStream().length) > 0, isTrue);
+    });
+
+    test('should cache data to allow multiple accesses', () async {
+      Object data = await response.asFuture();
+      expect(data is List<int> || data is String, isTrue);
+      String text = await response.asText();
+      expect(text.isNotEmpty, isTrue);
+      expect((await response.asStream().length) > 0, isTrue);
+    });
+
+    test('should be able to update the data source', () async {
+      response.update(new Stream.fromIterable([UTF8.encode('updated1')]));
+      expect(await response.asText(), equals('updated1'));
+      response.update('updated2');
+      expect(await response.asText(), equals('updated2'));
     });
   });
 }

--- a/test/w_http_server_integration_test.dart
+++ b/test/w_http_server_integration_test.dart
@@ -46,7 +46,7 @@ void main() {
     test('should be able to send a TRACE request', () async {
       WResponse response = await WHttp.trace(uri);
       expect(response.status, equals(200));
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['method'], equals('TRACE'));
     });
   });
@@ -70,7 +70,7 @@ void main() {
       request.path = '/test/http/reflect';
       WResponse response = store(await request.head());
       expect(response.status, equals(200));
-      expect(await response.stream.length, equals(0));
+      expect(await response.asStream().length, equals(0));
     }));
 
     // Unlike the browser environment, a server app has fewer security restrictions
@@ -79,7 +79,7 @@ void main() {
       request.path = '/test/http/reflect';
       WResponse response = store(await request.trace());
       expect(response.status, equals(200));
-      expect(JSON.decode(await response.text)['method'], equals('TRACE'));
+      expect(JSON.decode(await response.asText())['method'], equals('TRACE'));
     }));
 
     test('should allow a String data payload', () {
@@ -120,7 +120,7 @@ void main() {
         }
       });
       WResponse response = await request.post();
-      await response.stream.drain();
+      await response.asStream().drain();
       expect(uploadProgressListenedTo, isTrue);
     });
 
@@ -133,7 +133,7 @@ void main() {
         }
       });
       WResponse response = await request.get();
-      await response.stream.drain();
+      await response.asStream().drain();
       expect(downloadProgressListenedTo, isTrue);
     });
 
@@ -143,7 +143,7 @@ void main() {
         req.headers.set('x-configured', 'true');
       });
       WResponse response = await request.get();
-      Map data = JSON.decode(await response.text);
+      Map data = JSON.decode(await response.asText());
       expect(data['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -148,25 +148,20 @@ void main() {
     });
 
     test(
-        'parseResponseData() should return response data from HttpClientResponse (async)',
+        'parseResponseData() should return response data from the stream (async)',
         () async {
-      var data = [[10, 48, 28, 30], [999, 394, 1, 2], [239, 0, 20, 88],];
-      HttpClientResponse response =
-          new MockHttpClientResponseFromStream(new Stream.fromIterable(data));
-      expect(await w_http_server.parseResponseData(
-              response, 0, new StreamController()),
-          equals([10, 48, 28, 30, 999, 394, 1, 2, 239, 0, 20, 88]));
+      var data = [[10, 48, 28, 30], [999, 394, 1, 2], [239, 0, 20, 88]];
+      Stream stream = new Stream.fromIterable(data);
+      expect(await w_http_server.parseResponseData(stream), equals(data.reduce(
+          (previous, value) => new List.from(previous)..addAll(value))));
     });
 
     test(
-        'parseResponseText() should return response text from HttpRequest (async)',
+        'parseResponseText() should return response text from the stream (async)',
         () async {
-      Stream dataStream = new Stream.fromIterable(
-          [UTF8.encode('chunk1'), UTF8.encode('chunk2')]);
-      HttpClientResponse response =
-          new MockHttpClientResponseFromStream(dataStream);
-      expect(await w_http_server.parseResponseText(
-          response, UTF8, 0, new StreamController()), equals('chunk1chunk2'));
+      Stream dataStream = new Stream.fromIterable(['chunk1', 'chunk2']);
+      expect(await w_http_server.parseResponseText(dataStream),
+          equals('chunk1chunk2'));
     });
 
     test(

--- a/tool/server/proxy.dart
+++ b/tool/server/proxy.dart
@@ -54,7 +54,7 @@ class FilesProxy extends Handler {
       ..headers = request.headers;
 
     WResponse proxyResponse = await proxyRequest.get(filesEndpoint);
-    return new shelf.Response.ok(proxyResponse.stream,
+    return new shelf.Response.ok(proxyResponse.asStream(),
         headers: proxyResponse.headers);
   }
 
@@ -63,7 +63,7 @@ class FilesProxy extends Handler {
       ..headers = request.headers;
 
     WResponse proxyResponse = await proxyRequest.delete(filesEndpoint);
-    return new shelf.Response.ok(proxyResponse.stream,
+    return new shelf.Response.ok(proxyResponse.asStream(),
         headers: proxyResponse.headers);
   }
 }
@@ -84,7 +84,7 @@ class UploadProxy extends Handler {
     });
 
     WResponse proxyResponse = await proxyRequest.post(uploadEndpoint);
-    return new shelf.Response.ok(proxyResponse.stream,
+    return new shelf.Response.ok(proxyResponse.asStream(),
         headers: proxyResponse.headers);
   }
 }
@@ -106,7 +106,7 @@ class DownloadProxy extends Handler {
     });
 
     WResponse proxyResponse = await proxyRequest.get();
-    return new shelf.Response.ok(proxyResponse.stream,
+    return new shelf.Response.ok(proxyResponse.asStream(),
         headers: proxyResponse.headers);
   }
 }


### PR DESCRIPTION
## Issue
- Need to be able to update/replace the data source on a `WResponse` instance
- Need to be able to access response data multiple times
- Should always try to decode response data

## Changes
**Source:**
- Refactor `WResponse` such that all data access paths are based off of a single data source stream that can be updated and accessed multiple times.
  - Add a caching stream transformer
  - Add a getter for the single data source stream that returns original source stream on first access and then a new stream from the cached response on subsequent accesses
  - Add an `update()` method for replacing the stream (will invalidate cache)
  - Change simple data access property getters to be methods to make it more apparent that they are async
    - `data` --> `asFuture()`
    - `text` --> `asText()`
    - `stream` --> `asStream()`

**Tests:**
- All tests updated to match new API
- Tests added for:
  - multiple data accesses on a `WResponse`
  - updating the data source on a `WResponse`

## Areas of Regression
- Anything that deals with a request response, so all of the examples.

## Testing
- Tests pass.
- Examples still work as expected.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
