### PR TITLE
CP-612 w_transport Enable Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: dart
+dart:
+  - stable
+with_content_shell: true
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+script:
+  - dart --checked test/run_tests.dart -p vm -p content-shell --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-w_transport
+w_transport [![Build Status](https://travis-ci.org/Workiva/w_transport.svg?branch=travis-ci)](https://travis-ci.org/Workiva/w_transport)
 ===========
 
 > A fluent-style, platform-agnostic library with ready to use transport classes for sending and receiving data over HTTP.


### PR DESCRIPTION
## Issue
- Now that w_transport is public, we need to enable Travis-CI.

## Changes
**Source:**
- Add `.travis.yml`
- Add build status badge to readme.

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- Travis-CI should pass and show up on this PR
- Badge should be visible on the readme

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
