### PR TITLE
CP-618 Make request cancellations cause failure (throw error)

### DIFF
--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -139,11 +139,13 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
         request.status == 304) {
       completer.complete(response);
     } else {
-      completer.completeError(new WHttpException(method, wRequest, response));
+      completer.completeError(
+          new WHttpException(method, wRequest.uri, wRequest, response));
     }
   });
   request.onError.listen((error) {
-    completer.completeError(new WHttpException(method, wRequest, null, error));
+    completer.completeError(
+        new WHttpException(method, wRequest.uri, wRequest, null, error));
   });
 
   // Allow the caller to configure the request.

--- a/lib/src/http/w_http_server.dart
+++ b/lib/src/http/w_http_server.dart
@@ -161,7 +161,7 @@ Future<WResponse> send(String method, WRequest wRequest,
       wResponse.status == 304) {
     return wResponse;
   } else {
-    throw new WHttpException(method, wRequest, wResponse);
+    throw new WHttpException(method, wRequest.uri, wRequest, wResponse);
   }
 }
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,17 @@
+library w_transport.test.utils;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+Future<Object> expectThrowsAsync(Future f()) async {
+  var exception;
+  try {
+    await f();
+  } catch (e) {
+    exception = e;
+  }
+  if (exception == null) throw new Exception(
+      'Expected function to throw asynchronously, but did not.');
+  return exception;
+}

--- a/test/w_http_common_integration_tests.dart
+++ b/test/w_http_common_integration_tests.dart
@@ -22,6 +22,7 @@ import 'dart:convert';
 import 'package:w_transport/w_http.dart';
 import 'package:test/test.dart';
 
+import './utils.dart';
 import './w_http_utils.dart';
 
 /// These are HTTP integration tests that should work from client or server.
@@ -300,11 +301,33 @@ void run(String usage) {
       }));
     });
 
-    test('should allow request cancellation', () async {
-      try {
-        await request.get();
-      } catch (e) {}
-      request.abort();
+    group('request cancellation', () {
+      test('should be supported', () async {
+        try {
+          await request.get();
+        } catch (e) {}
+        request.abort();
+      });
+
+      test('should cause request to fail', () async {
+        Exception exception = await expectThrowsAsync(() async {
+          Future future = request.get();
+          request.abort();
+          await future;
+        });
+        expect(exception is WHttpException, isTrue);
+        expect(exception.toString().contains('cancelled'), isTrue);
+      });
+
+      test('should allow a custom exception', () async {
+        Exception exception = await expectThrowsAsync(() async {
+          Future future = request.get();
+          request.abort(new Exception('Custom cancellation.'));
+          await future;
+        });
+        expect(exception is WHttpException, isTrue);
+        expect(exception.toString().contains('Custom cancellation'), isTrue);
+      });
     });
   });
 

--- a/test/w_http_common_test.dart
+++ b/test/w_http_common_test.dart
@@ -41,10 +41,9 @@ void main() {
 
   group('WHttpException', () {
     test('should include the original error if given', () {
-      WRequest request = new MockWRequest();
-      WHttpException exception =
-          new WHttpException('GET', request, null, new Exception('original'));
-      expect(exception.toString().contains('origina'), isTrue);
+      WHttpException exception = new WHttpException(
+          'GET', null, null, null, new Exception('original'));
+      expect(exception.toString().contains('original'), isTrue);
     });
   });
 }

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 
-if [ -d "./lcov_report" ]; then
-    rm -rf ./lcov_report
+# Clean out old coverage artifacts
+if [ -d "./coverage_report" ]; then
+    rm -rf ./coverage_report
 fi
-if [ -f "./lcov_coverage.lcov" ]; then
-    rm ./lcov_coverage.lcov
+if [ -f "./coverage.lcov" ]; then
+    rm ./coverage.lcov
 fi
 
-./tool/test.sh --coverage "$@"
+# Collect coverage and generate report
+pub get
+pub run dart_codecov_generator --report-on=lib/ "$@" test/unit/
+
+# Open HTML report if successful
+if [ $? -eq 0 ]; then
+    open coverage_report/index.html
+fi


### PR DESCRIPTION
## Issue
There are certain scenarios where multiple consumers will be working with a single request, and in those scenarios there is currently no way to be made aware of a request cancellation. Only the consumers who cancels the request will be aware of that action.

## Changes
**Source:**
- Check for cancellation before opening request, before sending request, and before delivering the response.
- Cause a request failure by throwing an exception if a cancellation was detected (this replaces the previous behavior of just never completing the request).
- `WHttpException` modified slightly to account for a null request.
- Did some reordering/alphabetizing in the `WRequest` class

**Tests:**
- Tests updated
- New test added to verify a cancellation causes a failure

## Areas of Regression
- Request cancellation

## Testing
- Tests pass
- Examples still work as expected
  - In particular, request cancellation should work (file transfer example - can cancel uploads and downloads)

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
