### PR TITLE
CP-623 Change entry point to w_transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ w_transport [![Build Status](https://travis-ci.org/Workiva/w_transport.svg?branc
 ---
 
 ## Platform Agnostic
-The main library (`w_transport/w_http.dart`) depends on neither `dart:html` nor `dart:io`, making it platform agnostic.
-This means you can use the `w_http` library to build components, libraries, or APIs that will be reusable in the browser
+The main library (`w_transport/w_transport.dart`) depends on neither `dart:html` nor `dart:io`, making it platform agnostic.
+This means you can use the `w_transport` library to build components, libraries, or APIs that will be reusable in the browser
 AND on the server.
 
 The end consumer will make the decision between client and server, most likely in a main() block.
@@ -33,9 +33,6 @@ void main() {
 ---
 
 ## HTTP
-There is one entry point for HTTP usage:
-
-- `w_transport/w_http.dart`: platform-agnostic HTTP classes.
 
 All standard HTTP methods are supported:
 

--- a/example/common/global_example_menu_component.dart
+++ b/example/common/global_example_menu_component.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:react/react.dart' as react;
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 const int _pollingInterval = 4; // 4 seconds
 

--- a/example/http/cross_origin_credentials/dom.dart
+++ b/example/http/cross_origin_credentials/dom.dart
@@ -19,7 +19,7 @@ library w_transport.example.http.cross_origin_credentials.dom;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:w_transport/w_http.dart' show WHttpException;
+import 'package:w_transport/w_transport.dart' show WHttpException;
 
 import './service.dart' as service;
 import './status.dart' as status;

--- a/example/http/cross_origin_credentials/service.dart
+++ b/example/http/cross_origin_credentials/service.dart
@@ -19,7 +19,7 @@ library w_transport.example.http.cross_origin_credentials.service;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 /// URLs for this cross origin credentials example.
 Uri authenticationServerUrl = Uri.parse('http://localhost:8024');

--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -17,7 +17,6 @@
 library w_transport.example.http.cross_origin_file_transfer.components.download_page;
 
 import 'dart:async';
-import 'dart:html';
 import 'dart:math' as math;
 
 import 'package:react/react.dart' as react;

--- a/example/http/cross_origin_file_transfer/services/file_transfer.dart
+++ b/example/http/cross_origin_file_transfer/services/file_transfer.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math' as math;
 
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 import './proxy.dart';
 import './remote_files.dart';

--- a/example/http/cross_origin_file_transfer/services/remote_files.dart
+++ b/example/http/cross_origin_file_transfer/services/remote_files.dart
@@ -19,7 +19,7 @@ library w_transport.example.http.cross_origin_file_transfer.services.remote_file
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 import './proxy.dart';
 

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:react/react_client.dart' as react_client;
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/w_transport_client.dart'
     show configureWTransportForBrowser;
 

--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -35,7 +35,7 @@ import 'w_http_common.dart' as common;
 ///
 /// For simple requests, use the static methods on [WHttp]:
 ///
-///     import 'package:w_transport/w_http.dart';
+///     import 'package:w_transport/w_transport.dart';
 ///
 ///     void main() {
 ///       Uri uri = Uri.parse('example.com');
@@ -54,7 +54,7 @@ import 'w_http_common.dart' as common;
 /// instance and use it to create and send requests.
 ///
 ///     import 'dart:async';
-///     import 'package:w_transport/w_http.dart';
+///     import 'package:w_transport/w_transport.dart';
 ///
 ///     WHttp http;
 ///     Timer timer;
@@ -80,7 +80,7 @@ import 'w_http_common.dart' as common;
 /// This shuts down the underlying [HttpClient] and closes idle network
 /// connections.
 ///
-///     import 'package:w_transport/w_http.dart';
+///     import 'package:w_transport/w_transport.dart';
 ///
 ///     void main() {
 ///       WHttp http = new WHttp();
@@ -179,7 +179,7 @@ class WHttpException implements Exception {
 /// A class for creating and sending HTTP requests.
 ///
 ///     import 'dart:convert';
-///     import 'package:w_transport/w_http.dart';
+///     import 'package:w_transport/w_transport.dart';
 ///
 ///     main() async {
 ///       var data = ...;

--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -19,14 +19,13 @@
 library w_transport.src.http.w_http_client;
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:html';
 import 'dart:typed_data';
 
 import './w_http.dart';
 import './w_http_common.dart' as common;
 
-/// Configure w_transport/w_http library for use in the browser.
+/// Configure w_transport/w_transport HTTP library for use in the browser.
 void configureWHttpForBrowser() {
   common.configureWHttp(abort, getNewHttpClient, parseResponseHeaders,
       parseResponseStatus, parseResponseStatusText, parseResponseData,

--- a/lib/src/http/w_http_common.dart
+++ b/lib/src/http/w_http_common.dart
@@ -18,7 +18,6 @@
 library w_transport.lib.src.http.w_http_common;
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'w_http.dart';
 

--- a/lib/src/http/w_http_server.dart
+++ b/lib/src/http/w_http_server.dart
@@ -19,13 +19,12 @@
 library w_transport.src.http.w_http_server;
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import './w_http.dart';
 import './w_http_common.dart' as common;
 
-/// Configure w_transport/w_http library for use on the server.
+/// Configure w_transport/w_transport HTTP library for use on the server.
 void configureWHttpForServer() {
   common.configureWHttp(abort, getNewHttpClient, parseResponseHeaders,
       parseResponseStatus, parseResponseStatusText, parseResponseData,

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -14,10 +14,13 @@
  *  limitations under the License.
  */
 
-/// A fluent-style, platform-agnostic HTTP request library.
-/// Supports simple request construction and response handling,
-/// with the option to configure the outgoing request for more
-/// advanced use cases.
+/// A fluent-style, platform-agnostic transport library.
+/// Currently supports HTTP with plans to support WebSocket
+/// soon.
+///
+/// HTTP API features simple request construction and response
+/// handling, with the option to configure the outgoing request
+/// for more advanced use cases.
 library w_transport.w_http;
 
 export 'src/http/w_http.dart'

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,8 +2,6 @@ library w_transport.test.utils;
 
 import 'dart:async';
 
-import 'package:test/test.dart';
-
 Future<Object> expectThrowsAsync(Future f()) async {
   var exception;
   try {

--- a/test/w_http_client_integration_test.dart
+++ b/test/w_http_client_integration_test.dart
@@ -21,7 +21,7 @@ import 'dart:convert';
 import 'dart:html';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/w_transport_client.dart'
     show configureWTransportForBrowser;
 

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -23,7 +23,7 @@ import 'dart:html';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_transport/src/http/w_http_client.dart' as w_http_client;
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 class MockProgressEvent extends Mock implements ProgressEvent {
   final bool lengthComputable;

--- a/test/w_http_common_integration_tests.dart
+++ b/test/w_http_common_integration_tests.dart
@@ -19,7 +19,7 @@ library w_transport.test.w_http_common_tests;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 import 'package:test/test.dart';
 
 import './utils.dart';

--- a/test/w_http_common_test.dart
+++ b/test/w_http_common_test.dart
@@ -18,7 +18,7 @@ library w_transport.test.w_http_common_test;
 
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 class MockWRequest extends Mock implements WRequest {}
 

--- a/test/w_http_server_integration_test.dart
+++ b/test/w_http_server_integration_test.dart
@@ -22,7 +22,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/w_transport_server.dart'
     show configureWTransportForServer;
 

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -24,7 +24,7 @@ import 'dart:io';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_transport/src/http/w_http_server.dart' as w_http_server;
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 
 class MockHttpClientRequest extends Mock implements HttpClientRequest {}
 class MockHttpClientResponse extends Mock implements HttpClientResponse {}

--- a/tool/server/proxy.dart
+++ b/tool/server/proxy.dart
@@ -19,7 +19,7 @@ library w_transport.tool.server.proxy;
 import 'dart:async';
 
 import 'package:shelf/shelf.dart' as shelf;
-import 'package:w_transport/w_http.dart';
+import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/w_transport_server.dart'
     show configureWTransportForServer;
 


### PR DESCRIPTION
## Issue
Originally I created a `w_transport/w_http.dart` entry point that I intended to be separate from the socket one, but with Dart's tree-shaking that's an anti-pattern. Instead, everything should be consolidated into a single self-named entry point.

## Changes
**Source:**
- Rename `w_transport/w_http.dart` entry point to `w_transport/w_transport.dart`
- Update imports
- Update docs/comments

**Tests:**
- Update imports

## Areas of Regression
- Everything (main import changed)

## Testing
- Tests should pass
- Examples should still run as expected

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
