### PR TITLE
CP-631 Allow request data to be set to null

### DIFF
--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -170,7 +170,8 @@ void validateDataType(Object data) {
   if (data is! ByteBuffer &&
       data is! Document &&
       data is! FormData &&
-      data is! String) {
+      data is! String &&
+      data != null) {
     throw new ArgumentError(
         'WRequest body must be a String, FormData, ByteBuffer, or Document.');
   }

--- a/lib/src/http/w_http_server.dart
+++ b/lib/src/http/w_http_server.dart
@@ -169,7 +169,7 @@ Future<WResponse> send(String method, WRequest wRequest,
 ///
 /// Throws an [ArgumentError] if [data] is invalid.
 void validateDataType(Object data) {
-  if (data is! String && data is! Stream) {
+  if (data is! String && data is! Stream && data != null) {
     throw new ArgumentError('WRequest body must be a String or a Stream.');
   }
 }

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -180,5 +180,9 @@ void main() {
         w_http_client.validateDataType(new Stream.fromIterable([]));
       }, throwsArgumentError);
     });
+
+    test('validateDataType() should not throw an ArgumentError on null data', () {
+      w_http_client.validateDataType(null);
+    });
   });
 }

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -147,6 +147,10 @@ void main() {
       }, throwsArgumentError);
     });
 
+    test('validateDataType() should not throw an ArgumentError on null data', () {
+      w_http_server.validateDataType(null);
+    });
+
     test(
         'parseResponseData() should return response data from the stream (async)',
         () async {

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -9,8 +9,7 @@ if [ -f "./coverage.lcov" ]; then
 fi
 
 # Collect coverage and generate report
-pub get
-pub run dart_codecov_generator --report-on=lib/ "$@" test/unit/
+./tool/test.sh --coverage "$@"
 
 # Open HTML report if successful
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Issue
- An `ArgumentError` is thrown when trying to set a `WRequest`'s data to null.

## Changes
**Source:**
- Update the data validation methods to allow null data.

**Tests:**
- 2 new tests added to cover that scenario

**Additional Changes:**
- Fixed the `coverage.sh` script (bad copy paste)

## Areas of Regression
- Setting data on `WRequest`

## Testing
- All tests pass

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
