### PR TITLE
CP-641 Listen for Request Cancellation in Client

### DIFF
--- a/example/http/cross_origin_file_transfer/services/file_transfer.dart
+++ b/example/http/cross_origin_file_transfer/services/file_transfer.dart
@@ -67,8 +67,7 @@ class FileTransfer {
   /// Cancel the request (will do nothing if the request has already finished).
   void cancel(String reason) {
     _cancelled = true;
-    _request.abort();
-    _doneCompleter.completeError(reason != null ? new Exception(reason) : null);
+    _request.abort(reason != null ? new Exception(reason) : null);
   }
 
   void _progressListener(WProgress progress) {

--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -370,12 +370,13 @@ class WRequest extends Object with FluriMixin {
       _checkForCancellation();
       response = await common.send(method, this, _request,
           _downloadProgressController, _uploadProgressController, _configure);
-      _checkForCancellation(response: response);
     } catch (e) {
       cleanUp();
+      _checkForCancellation(response: response);
       throw e;
     }
     cleanUp();
+    _checkForCancellation(response: response);
     return response;
   }
 

--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -132,19 +132,28 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
 
   // Listen for request completion/errors.
   request.onLoad.listen((ProgressEvent e) {
-    WResponse response = wResponseFactory(request, wRequest.encoding);
-    if ((request.status >= 200 && request.status < 300) ||
-        request.status == 0 ||
-        request.status == 304) {
-      completer.complete(response);
-    } else {
-      completer.completeError(
-          new WHttpException(method, wRequest.uri, wRequest, response));
+    if (!completer.isCompleted) {
+      WResponse response = wResponseFactory(request, wRequest.encoding);
+      if ((request.status >= 200 && request.status < 300) ||
+      request.status == 0 ||
+      request.status == 304) {
+        completer.complete(response);
+      } else {
+        completer.completeError(
+            new WHttpException(method, wRequest.uri, wRequest, response));
+      }
     }
   });
   request.onError.listen((error) {
-    completer.completeError(
-        new WHttpException(method, wRequest.uri, wRequest, null, error));
+    if (!completer.isCompleted) {
+      completer.completeError(
+          new WHttpException(method, wRequest.uri, wRequest, null, error));
+    }
+  });
+  request.onAbort.listen((error) {
+    if (!completer.isCompleted) {
+      completer.completeError(new WHttpException(method, wRequest.uri, wRequest, null, error));
+    }
   });
 
   // Allow the caller to configure the request.

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -164,6 +164,7 @@ void main() {
       when(xhr.onLoad)
           .thenReturn(new Stream.fromIterable([new MockProgressEvent(false)]));
       when(xhr.onError).thenReturn(new Stream.fromIterable([]));
+      when(xhr.onAbort).thenReturn(new Stream.fromIterable([]));
 
       await w_http_client.send(
           'GET', request, xhr, new StreamController(), new StreamController());

--- a/tool/server/proxy.dart
+++ b/tool/server/proxy.dart
@@ -17,6 +17,7 @@
 library w_transport.tool.server.proxy;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:w_transport/w_transport.dart';
@@ -83,9 +84,15 @@ class UploadProxy extends Handler {
       print('Uploading: ${progress.percent}%');
     });
 
-    WResponse proxyResponse = await proxyRequest.post(uploadEndpoint);
-    return new shelf.Response.ok(proxyResponse.asStream(),
-        headers: proxyResponse.headers);
+    WResponse proxyResponse;
+    try {
+      proxyResponse = await proxyRequest.post(uploadEndpoint);
+      return new shelf.Response.ok(proxyResponse.asStream(),
+      headers: proxyResponse.headers);
+    } on HttpException catch (e) {
+      proxyRequest.abort(e);
+      return new shelf.Response.internalServerError();
+    }
   }
 }
 
@@ -105,9 +112,15 @@ class DownloadProxy extends Handler {
           'Downloading ${request.url.queryParameters['file']}: ${progress.percent}%');
     });
 
-    WResponse proxyResponse = await proxyRequest.get();
-    return new shelf.Response.ok(proxyResponse.asStream(),
-        headers: proxyResponse.headers);
+    WResponse proxyResponse;
+    try {
+      proxyResponse = await proxyRequest.get();
+      return new shelf.Response.ok(proxyResponse.asStream(),
+      headers: proxyResponse.headers);
+    } on HttpException catch (e) {
+      proxyRequest.abort(e);
+      return new shelf.Response.internalServerError();
+    }
   }
 }
 


### PR DESCRIPTION
## Issue
- Request cancellation should cause the request to fail (throw an error async) in all scenarios. Currently, this works if the request is cancelled before being sent or after the response has been returned. If request cancellation occurs while the request is open, the request is cancelled but it does not result in an error being thrown.

## Changes
**Source:**
- Listen to `request.onAbort` in the client implementation to capture request cancellation while the request is open and throw a `WHttpException`.

**Tests:**
- One test updated, examples updated to utilize this new behavior.

## Areas of Regression
- Request cancellation.

## Testing
- Tests pass.
- In the File Transfer example, verify that canceling an upload and canceling a download still triggers the visual feedback (red background) that it did before. Previously, the visual feedback was triggered manually, but now it listens for an error to be thrown and then triggers the visual feedback. If this works as expected, it proves that this change works.

## Code Review
@maxwellpeterson-wf 

fyi: @trentgrover-wf 