### PR TITLE
CP-658 Report coverage to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 script:
   - dart --checked test/run_tests.dart -p vm -p content-shell --verbose
+  - dart --checked test/run_tests.dart -p vm -p content-shell --verbose --coverage --only-lcov
+  - pub run dart_codecov coverage.lcov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-w_transport [![Build Status](https://travis-ci.org/Workiva/w_transport.svg?branch=travis-ci)](https://travis-ci.org/Workiva/w_transport) [![Pub](https://img.shields.io/pub/v/w_transport.svg)](https://pub.dartlang.org/packages/w_transport)
+w_transport [![Pub](https://img.shields.io/pub/v/w_transport.svg)](https://pub.dartlang.org/packages/w_transport) [![Build Status](https://travis-ci.org/Workiva/w_transport.svg?branch=travis-ci)](https://travis-ci.org/Workiva/w_transport) [![codecov.io](http://codecov.io/github/Workiva/w_transport/coverage.svg?branch=master)](http://codecov.io/github/Workiva/w_transport?branch=master)
 ===========
 
 > A fluent-style, platform-agnostic library with ready to use transport classes for sending and receiving data over HTTP.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,14 @@ dev_dependencies:
     git:
       url: https://github.com/ekweible/coverage.git
       ref: 796a265
+  dart_codecov:
+    git:
+      url: https://github.com/ekweible/dart_codecov.git
+      ref: 0.1.0
   dart_codecov_generator:
     git:
       url: https://github.com/ekweible/dart_codecov_generator.git
-      ref: 0.3.0
+      ref: content-shell
   dart_style: '>=0.1.8 <0.2.0'
   http_server: '>=0.9.5+1 <0.10.0'
   mime: '>=0.9.3 <0.10.0'

--- a/test/run_tests.dart
+++ b/test/run_tests.dart
@@ -82,6 +82,7 @@ main(List<String> args) async {
   ArgParser parser = new ArgParser()
     ..addOption('platform', abbr: 'p', allowMultiple: true)
     ..addFlag('coverage', negatable: false)
+    ..addFlag('only-lcov', negatable: false)
     ..addFlag('server', defaultsTo: true)
     ..addFlag('verbose', abbr: 'v', negatable: false);
   ArgResults env = parser.parse(args);
@@ -106,6 +107,9 @@ main(List<String> args) async {
       List coverageArgs = ['run', 'dart_codecov_generator', '--report-on=lib/'];
       if (env['verbose']) {
         coverageArgs.add('-v');
+      }
+      if (env['only-lcov']) {
+        coverageArgs.add('--no-html');
       }
       coverage = await Process.start('pub', coverageArgs);
 


### PR DESCRIPTION
## Issue
- We need to generate and report code coverage to codecov.io

## Changes
**Source:**
- n/a

**Tools:**
- Update test script to allow an option for only generating .lcov file
- Update travis.yml to generate and report code coverage

**Tests:**
- [List/summary of changes to tests, addition of examples, etc]

**Other:**
- Add codecov badge to readme.

## Areas of Regression
- n/a

## Testing
- Coverage badge should be visible on README (will report "unknown" coverage until merged)
- Travis-ci should pass and this output should be visible in the logs towards the bottom:

    ```
    The command "pub run dart_codecov_generator --report-on=lib/ --no-html --verbose" exited with 0.
    pub run dart_codecov coverage.lcov
    Running dart_codecov...
    Coverage sent to codecov.io successfully.
    ```

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@jayudey-wf 