### PR TITLE
CP-664 Validate data type when sending, not before

### DIFF
--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -231,12 +231,7 @@ class WRequest extends Object with FluriMixin {
   ///
   ///   - `Stream`
   ///   - `String`
-  void set data(Object data) {
-    common.validateDataType(data);
-    _data = data;
-  }
-  Object get data => _data;
-  Object _data;
+  Object data;
 
   /// [WProgress] stream for this HTTP request's download.
   Stream<WProgress> get downloadProgress => _downloadProgressController.stream;
@@ -357,6 +352,7 @@ class WRequest extends Object with FluriMixin {
     if (data != null) {
       this.data = data;
     }
+    common.validateDataType(this.data);
 
     void cleanUp() {
       if (_single && _client != null) {

--- a/test/w_http_server_integration_test.dart
+++ b/test/w_http_server_integration_test.dart
@@ -94,11 +94,17 @@ void main() {
       expect(await (req.data as Stream).join(''), equals('data'));
     });
 
-    test('should throw on invalid data payload', () {
+    test('should throw on invalid data payload', () async {
       WRequest req = new WRequest();
-      expect(() {
-        req.data = 10;
-      }, throwsArgumentError);
+      req.data = 10;
+      req.uri = Uri.parse('/');
+      var error;
+      try {
+        await req.get();
+      } catch (e) {
+        error = e;
+      }
+      expect(error, isArgumentError);
     });
 
     test('should have an upload progress stream', () async {


### PR DESCRIPTION
## Issue
- We should not immediately validate the data type; should validate it just before sending, instead.
- Without this change, it's not possible to set an intermediate version of a data payload (like w_service does) that may eventually get transformed into a valid data type

## Changes
**Source:**
- Move the data type validation step from the setter of the `data` property to the `_send` method. This allows the data to be set to anything, but only valid data types will actually be sent. Invalid data types will still throw an exception, just a bit later.

**Tests:**
- Tests updated.

## Areas of Regression
- Request data payload type validation

## Testing
- Tests pass.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 