### PR TITLE
CP-660 Use dartanalyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
   - dart --checked test/run_tests.dart -p vm -p content-shell --verbose
   - dart --checked test/run_tests.dart -p vm -p content-shell --verbose --coverage --only-lcov
   - pub run dart_codecov coverage.lcov
+  - ./tool/analyze.sh

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dartanalyzer --fatal-warnings --no-hints example/*.dart lib/*.dart


### PR DESCRIPTION
## Issue
- We're not using dartanalyzer

## Changes
**Source:**
- n/a

**Tests:**
- n/a

**Tools:**
- Added a `analyze.sh` tool that runs the dartanalyzer

## Areas of Regression
- n/a

## Testing
- Travis-CI passes and the dartanalyzer output can be found at the end of the build logs

    ```
    $ ./tool/analyze.sh
    Analyzing [lib/fluri.dart, test/fluri_test.dart]...
    No issues found
    No issues found
    ```

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 