### PR TITLE
CP-661 Reorganize class elements

### DIFF
--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -135,8 +135,8 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
     if (!completer.isCompleted) {
       WResponse response = wResponseFactory(request, wRequest.encoding);
       if ((request.status >= 200 && request.status < 300) ||
-      request.status == 0 ||
-      request.status == 304) {
+          request.status == 0 ||
+          request.status == 304) {
         completer.complete(response);
       } else {
         completer.completeError(
@@ -152,7 +152,8 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
   });
   request.onAbort.listen((error) {
     if (!completer.isCompleted) {
-      completer.completeError(new WHttpException(method, wRequest.uri, wRequest, null, error));
+      completer.completeError(
+          new WHttpException(method, wRequest.uri, wRequest, null, error));
     }
   });
 

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -182,7 +182,8 @@ void main() {
       }, throwsArgumentError);
     });
 
-    test('validateDataType() should not throw an ArgumentError on null data', () {
+    test('validateDataType() should not throw an ArgumentError on null data',
+        () {
       w_http_client.validateDataType(null);
     });
   });

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -147,7 +147,8 @@ void main() {
       }, throwsArgumentError);
     });
 
-    test('validateDataType() should not throw an ArgumentError on null data', () {
+    test('validateDataType() should not throw an ArgumentError on null data',
+        () {
       w_http_server.validateDataType(null);
     });
 

--- a/tool/server/proxy.dart
+++ b/tool/server/proxy.dart
@@ -88,7 +88,7 @@ class UploadProxy extends Handler {
     try {
       proxyResponse = await proxyRequest.post(uploadEndpoint);
       return new shelf.Response.ok(proxyResponse.asStream(),
-      headers: proxyResponse.headers);
+          headers: proxyResponse.headers);
     } on HttpException catch (e) {
       proxyRequest.abort(e);
       return new shelf.Response.internalServerError();
@@ -116,7 +116,7 @@ class DownloadProxy extends Handler {
     try {
       proxyResponse = await proxyRequest.get();
       return new shelf.Response.ok(proxyResponse.asStream(),
-      headers: proxyResponse.headers);
+          headers: proxyResponse.headers);
     } on HttpException catch (e) {
       proxyRequest.abort(e);
       return new shelf.Response.internalServerError();


### PR DESCRIPTION
## Issue
- #19 
- In an effort to be organized and consistent, the elements in a class should follow this order:
  - static variables
  - static methods
  - public variables
  - private variables
  - constructors (main first, named next, private named last)
  - public methods
  - private methods

## Changes
**Source:**
- Reorganize all the classes
- Add some missing documentation on private elements

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- Travis-CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 