### PR TITLE
CP-663 Use package: imports for src/ files, w_transport

### DIFF
--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -27,7 +27,7 @@ import 'dart:convert';
 
 import 'package:fluri/fluri.dart';
 
-import 'w_http_common.dart' as common;
+import 'package:w_transport/src/http/w_http_common.dart' as common;
 
 /// An HTTP client useful for quickly sending HTTP requests.
 /// If used on the server side, an [HttpClient] is used internally, allowing

--- a/lib/src/http/w_http_client.dart
+++ b/lib/src/http/w_http_client.dart
@@ -22,8 +22,8 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';
 
-import './w_http.dart';
-import './w_http_common.dart' as common;
+import 'package:w_transport/src/http/w_http.dart';
+import 'package:w_transport/src/http/w_http_common.dart' as common;
 
 /// Configure w_transport/w_transport HTTP library for use in the browser.
 void configureWHttpForBrowser() {
@@ -135,8 +135,8 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
     if (!completer.isCompleted) {
       WResponse response = wResponseFactory(request, wRequest.encoding);
       if ((request.status >= 200 && request.status < 300) ||
-      request.status == 0 ||
-      request.status == 304) {
+          request.status == 0 ||
+          request.status == 304) {
         completer.complete(response);
       } else {
         completer.completeError(
@@ -152,7 +152,8 @@ Future<WResponse> send(String method, WRequest wRequest, HttpRequest request,
   });
   request.onAbort.listen((error) {
     if (!completer.isCompleted) {
-      completer.completeError(new WHttpException(method, wRequest.uri, wRequest, null, error));
+      completer.completeError(
+          new WHttpException(method, wRequest.uri, wRequest, null, error));
     }
   });
 

--- a/lib/src/http/w_http_common.dart
+++ b/lib/src/http/w_http_common.dart
@@ -19,7 +19,7 @@ library w_transport.lib.src.http.w_http_common;
 
 import 'dart:async';
 
-import 'w_http.dart';
+import 'package:w_transport/src/http/w_http.dart';
 
 bool _configurationSet = false;
 

--- a/lib/src/http/w_http_server.dart
+++ b/lib/src/http/w_http_server.dart
@@ -21,8 +21,8 @@ library w_transport.src.http.w_http_server;
 import 'dart:async';
 import 'dart:io';
 
-import './w_http.dart';
-import './w_http_common.dart' as common;
+import 'package:w_transport/src/http/w_http.dart';
+import 'package:w_transport/src/http/w_http_common.dart' as common;
 
 /// Configure w_transport/w_transport HTTP library for use on the server.
 void configureWHttpForServer() {

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -23,5 +23,5 @@
 /// for more advanced use cases.
 library w_transport.w_http;
 
-export 'src/http/w_http.dart'
+export 'package:w_transport/src/http/w_http.dart'
     show WHttp, WHttpException, WProgress, WRequest, WResponse;

--- a/lib/w_transport_client.dart
+++ b/lib/w_transport_client.dart
@@ -19,7 +19,8 @@
 /// to make HTTP requests.
 library w_transport.w_transport_client;
 
-import 'src/http/w_http_client.dart' show configureWHttpForBrowser;
+import 'package:w_transport/src/http/w_http_client.dart'
+    show configureWHttpForBrowser;
 
 /// Configure w_transport for use in the browser.
 ///

--- a/lib/w_transport_server.dart
+++ b/lib/w_transport_server.dart
@@ -19,7 +19,8 @@
 /// [HttpClientRequest], and [HttpClientResponse] to make HTTP requests.
 library w_transport.w_transport_server;
 
-import 'src/http/w_http_server.dart' show configureWHttpForServer;
+import 'package:w_transport/src/http/w_http_server.dart'
+    show configureWHttpForServer;
 
 /// Configure w_transport for use on the server.
 ///

--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -182,7 +182,8 @@ void main() {
       }, throwsArgumentError);
     });
 
-    test('validateDataType() should not throw an ArgumentError on null data', () {
+    test('validateDataType() should not throw an ArgumentError on null data',
+        () {
       w_http_client.validateDataType(null);
     });
   });

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -147,7 +147,8 @@ void main() {
       }, throwsArgumentError);
     });
 
-    test('validateDataType() should not throw an ArgumentError on null data', () {
+    test('validateDataType() should not throw an ArgumentError on null data',
+        () {
       w_http_server.validateDataType(null);
     });
 

--- a/tool/server/proxy.dart
+++ b/tool/server/proxy.dart
@@ -88,7 +88,7 @@ class UploadProxy extends Handler {
     try {
       proxyResponse = await proxyRequest.post(uploadEndpoint);
       return new shelf.Response.ok(proxyResponse.asStream(),
-      headers: proxyResponse.headers);
+          headers: proxyResponse.headers);
     } on HttpException catch (e) {
       proxyRequest.abort(e);
       return new shelf.Response.internalServerError();
@@ -116,7 +116,7 @@ class DownloadProxy extends Handler {
     try {
       proxyResponse = await proxyRequest.get();
       return new shelf.Response.ok(proxyResponse.asStream(),
-      headers: proxyResponse.headers);
+          headers: proxyResponse.headers);
     } on HttpException catch (e) {
       proxyRequest.abort(e);
       return new shelf.Response.internalServerError();


### PR DESCRIPTION
## Issue
- #25 
- https://twitter.com/sethladd/status/603641186826477568
- It's recommended to use `package:` imports instead of relative imports

## Changes
**Source:**
- Update imports to use `package:` syntax whenever possible

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- Travis-CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 