### PR TITLE
CP-671 Add changelog, w_transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 1.0.1
+**Bug Fixes:**
+
+- Allow request data to be set to `null`.
+- Canceling an in-flight request now properly results in the returned Future completing with an error.
+- Request data type validation now happens when sending the request instead of upon assignment, allowing intermediate data assignments.
+- Verify w_transport configuration has been set before constructing a `WHttp` instance.
+
+## 1.0.0
+- Initial version of w_transport: a fluent-style, platform-agnostic library with ready to use transport classes for sending and receiving data over HTTP.


### PR DESCRIPTION
## Issue
- #20 
- We need a changelog file, especially since it's displayed on pub.dartlang.org

## Changes
> Documentation only change

- Added `CHANGELOG.md`

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@jayudey-wf 

---

I will keep this open until we're ready for the next release, at which point I'll finalize updates and get one last round of reviews. After that's merged and the release is cut, I'll reopen and repeat the process.