### PR TITLE
CP-685 cancelled --> canceled, w_transport

### DIFF
--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -145,7 +145,7 @@ class DownloadPage extends react.Component {
       react.h2({}, 'File Downloads'),
       react.p({
         'className': 'note'
-      }, 'Note: Loading large files into memory will crash the browser tab. For this reason, downloads will be cancelled automatically if a concurrent file transfer size of 75 MB is exceeded.'),
+      }, 'Note: Loading large files into memory will crash the browser tab. For this reason, downloads will be canceled automatically if a concurrent file transfer size of 75 MB is exceeded.'),
       fileTransferListComponent({
         'transfers': this.state['downloads'],
         'onTransferDone': _removeDownload

--- a/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -67,7 +67,7 @@ class DropZoneComponent extends react.Component {
   }
 
   void hideDropTarget(e) {
-    // Delay this action slightly to allow it to be cancelled.
+    // Delay this action slightly to allow it to be canceled.
     // This helps prevent a flicker when moving from the drop zone
     // to the drop target.
     _hideDropTargetTimer = new Timer(new Duration(milliseconds: 100), () {

--- a/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
+++ b/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
@@ -52,7 +52,7 @@ class FileTransferListItemComponent extends react.Component {
   void _cancelTransfer(e) {
     e.preventDefault();
     if (this.props['transfer'] == null || this.state['done']) return;
-    this.props['transfer'].cancel('User cancelled the file transfer.');
+    this.props['transfer'].cancel('User canceled the file transfer.');
     this.setState({'done': true, 'success': false});
   }
 

--- a/example/http/cross_origin_file_transfer/services/file_transfer.dart
+++ b/example/http/cross_origin_file_transfer/services/file_transfer.dart
@@ -38,11 +38,11 @@ int _concurrentFileTransferSize = 0;
 /// Encapsulates the file upload to or file download from the server.
 class FileTransfer {
   WRequest _request;
-  bool _cancelled;
+  bool _canceled;
 
   FileTransfer(this.name)
       : id = 'fileTransfer${_transferNum++}',
-        _cancelled = false,
+        _canceled = false,
         _doneCompleter = new Completer(),
         _percentComplete = 0.0 {}
 
@@ -66,12 +66,12 @@ class FileTransfer {
 
   /// Cancel the request (will do nothing if the request has already finished).
   void cancel(String reason) {
-    _cancelled = true;
+    _canceled = true;
     _request.abort(reason != null ? new Exception(reason) : null);
   }
 
   void _progressListener(WProgress progress) {
-    if (_cancelled) return;
+    if (_canceled) return;
     _percentComplete = progress.percent;
   }
 }
@@ -128,7 +128,7 @@ class Download extends FileTransfer {
     _progressStream.listen(_progressListener);
 
     _progressStream.listen((WProgress progress) {
-      if (_cancelled) return;
+      if (_canceled) return;
 
       if (progress.lengthComputable) {
         int delta = progress.loaded - _bytesLoaded;

--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -224,8 +224,8 @@ class WRequest extends Object with FluriMixin {
   /// Error associated with a cancellation.
   Object _cancellationError;
 
-  /// Whether or not the request has been cancelled by the caller.
-  bool _cancelled = false;
+  /// Whether or not the request has been canceled by the caller.
+  bool _canceled = false;
 
   /// HTTP client (if any) used to send requests.
   dynamic _client;
@@ -297,7 +297,7 @@ class WRequest extends Object with FluriMixin {
     if (_request != null) {
       common.abort(_request);
     }
-    _cancelled = true;
+    _canceled = true;
     _cancellationError = error;
   }
 
@@ -359,11 +359,11 @@ class WRequest extends Object with FluriMixin {
   }
 
   void _checkForCancellation({WResponse response}) {
-    if (_cancelled) {
+    if (_canceled) {
       throw new WHttpException(_method, this.uri, this, response,
           _cancellationError != null
               ? _cancellationError
-              : new Exception('Request cancelled.'));
+              : new Exception('Request canceled.'));
     }
   }
 

--- a/test/w_http_common_integration_tests.dart
+++ b/test/w_http_common_integration_tests.dart
@@ -316,7 +316,7 @@ void run(String usage) {
           await future;
         });
         expect(exception is WHttpException, isTrue);
-        expect(exception.toString().contains('cancelled'), isTrue);
+        expect(exception.toString().contains('canceled'), isTrue);
       });
 
       test('should allow a custom exception', () async {


### PR DESCRIPTION
## Issue
- #27 

## Changes
**Source:**
- Changed all instances of `cancelled` to `canceled`

**Tests:**
- Changed all instances of `cancelled` to `canceled`

## Areas of Regression
- n/a

## Testing
- Smithy passes.
- Example still works as expected.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 