### PR TITLE
CP-688 Use dart analyzer on test directory.

### DIFF
--- a/test/w_http_client_test.dart
+++ b/test/w_http_client_test.dart
@@ -30,11 +30,23 @@ class MockProgressEvent extends Mock implements ProgressEvent {
   final int loaded;
   final int total;
   MockProgressEvent(this.lengthComputable, [this.loaded, this.total]);
+
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
 }
 
-class MockHttpRequest extends Mock implements HttpRequest {}
+class MockHttpRequest extends Mock implements HttpRequest {
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
 
-class MockHttpRequestUpload extends Mock implements HttpRequestUpload {}
+class MockHttpRequestUpload extends Mock implements HttpRequestUpload {
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
 
 void main() {
   group('w_http_client', () {

--- a/test/w_http_common_test.dart
+++ b/test/w_http_common_test.dart
@@ -20,7 +20,11 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 
-class MockWRequest extends Mock implements WRequest {}
+class MockWRequest extends Mock implements WRequest {
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
 
 void main() {
   group('WHttp', () {

--- a/test/w_http_server_test.dart
+++ b/test/w_http_server_test.dart
@@ -26,8 +26,18 @@ import 'package:test/test.dart';
 import 'package:w_transport/src/http/w_http_server.dart' as w_http_server;
 import 'package:w_transport/w_transport.dart';
 
-class MockHttpClientRequest extends Mock implements HttpClientRequest {}
-class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+class MockHttpClientRequest extends Mock implements HttpClientRequest {
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
+
 class MockHttpClientResponseFromStream extends Stream
     implements HttpClientResponse {
   Stream _stream;
@@ -37,6 +47,9 @@ class MockHttpClientResponseFromStream extends Stream
     return _stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
+  // this tells Dart analyzer you meant not to implement all methods,
+  // and not to hint/warn that methods are missing
+  noSuchMethod(i) => super.noSuchMethod(i);
 }
 
 void main() {

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-dartanalyzer --fatal-warnings --no-hints example/*.dart lib/*.dart
+dartanalyzer --fatal-warnings --no-hints example/*.dart lib/*.dart test/*.dart


### PR DESCRIPTION
## Issue
- #28 
- Dart analyzer tool already existed and was in the CI build, but it should also include the test/ directory.

## Changes
**Source:**
- n/a

**Tests:**
- Added the `noSuchMethod` implementation to all Mock classes to calm the compiler.

## Areas of Regression
- n/a

## Testing
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 