### PR TITLE
CP-702 Verify config is set before constructing WHttp

### DIFF
--- a/lib/src/http/w_http.dart
+++ b/lib/src/http/w_http.dart
@@ -119,14 +119,15 @@ class WHttp {
   dynamic _client;
 
   /// Whether or not the HTTP client has been closed.
-  bool _closed;
+  bool _closed = false;
 
   /// Construct a new WHttp instance. If used on the server,
   /// an underlying [HttpClient] instance will be used to cache
   /// network connections.
-  WHttp()
-      : _client = common.getNewHttpClient(),
-        _closed = false;
+  WHttp() {
+    common.verifyWHttpConfigurationIsSet();
+    _client = common.getNewHttpClient();
+  }
 
   /// Closes the client, cancelling or closing any outstanding connections.
   void close() {

--- a/test/w_http_common_test.dart
+++ b/test/w_http_common_test.dart
@@ -28,7 +28,13 @@ class MockWRequest extends Mock implements WRequest {
 
 void main() {
   group('WHttp', () {
-    test('should throw if configuration has not been set', () {
+    test('constructor should throw if configuration has not been set', () {
+      expect(() {
+        new WHttp();
+      }, throwsStateError);
+    });
+
+    test('static methods should throw if configuration has not been set', () {
       expect(() {
         WHttp.get(Uri.parse('/'));
       }, throwsStateError);
@@ -36,7 +42,7 @@ void main() {
   });
 
   group('WRequest', () {
-    test('should throw if configuration has not been set', () {
+    test('constructor should throw if configuration has not been set', () {
       expect(() {
         new WRequest();
       }, throwsStateError);


### PR DESCRIPTION
## Issue
- If you try to construct a `WHttp` instance before setting the configuration, you will receive a non-helpful exception instead of the descriptive "w_transport configuration must be set.." error.
- #35 

## Changes
**Source:**
- Add a check to the `WHttp` constructor before initializing.

**Tests:**
- Add a test to verify this use case.

## Areas of Regression
- n/a

## Testing
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
