### PR TITLE
CP-714 Temporarily remove code coverage dependencies, w_transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 script:
   - dart --checked test/run_tests.dart -p vm -p content-shell --verbose
-  - dart --checked test/run_tests.dart -p vm -p content-shell --verbose --coverage --only-lcov
-  - pub run dart_codecov coverage.lcov
   - ./tool/analyze.sh
   - ./tool/dartfmt.sh -e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,18 +13,6 @@ dev_dependencies:
   ansicolor: '>=0.0.9 <0.1.0'
   args: '>=0.12.1 <0.14.0'
   browser: any
-  coverage:
-    git:
-      url: https://github.com/ekweible/coverage.git
-      ref: 796a265
-  dart_codecov:
-    git:
-      url: https://github.com/ekweible/dart_codecov.git
-      ref: 0.1.0
-  dart_codecov_generator:
-    git:
-      url: https://github.com/ekweible/dart_codecov_generator.git
-      ref: content-shell
   dart_style: '>=0.1.8 <0.2.0'
   http_server: '>=0.9.5+1 <0.10.0'
   mime: '>=0.9.3 <0.10.0'


### PR DESCRIPTION
## Issue
- Still waiting on https://github.com/dart-lang/coverage/pull/67

## Changes
- Temporarily remove the code coverage dependencies so that we can cut a release.

## Areas of Regression
- n/a

## Testing
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 