### PR TITLE
CP-979 Add mocks for WRequest and WResponse

### DIFF
--- a/lib/mocks.dart
+++ b/lib/mocks.dart
@@ -1,0 +1,4 @@
+library w_transport.mocks;
+
+export 'package:w_transport/src/mocks/mock_w_request.dart' show MockWRequest;
+export 'package:w_transport/src/mocks/mock_w_response.dart' show MockWResponse;

--- a/lib/src/mocks/mock_w_request.dart
+++ b/lib/src/mocks/mock_w_request.dart
@@ -1,0 +1,62 @@
+library w_transport.src.mocks.mock_w_request;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:fluri/fluri.dart' show FluriMixin;
+import 'package:w_transport/mocks.dart' show MockWResponse;
+import 'package:w_transport/w_transport.dart'
+    show WHttpException, WProgress, WRequest, WResponse;
+
+part 'package:w_transport/src/mocks/source/w_request_source.dart';
+
+class MockWRequest extends WRequestSource implements WRequest {
+  Completer<MockWResponse> _completer = new Completer<MockWResponse>();
+
+  Completer _sent = new Completer();
+
+  Future get sent => _sent.future;
+
+  void complete({MockWResponse response}) {
+    if (response == null) {
+      response = new MockWResponse.ok();
+    }
+    sent.then((_) {
+      _checkForCancellation(response: response);
+      _completer.complete(response);
+    }).catchError(_completer.completeError);
+  }
+
+  void completeError({Object error, MockWResponse response}) {
+    sent.then((_) {
+      _completer.completeError(
+          new WHttpException(_method, uri, this, response, error));
+    });
+  }
+
+  void _abortRequest(request) {
+    _canceled = true;
+  }
+
+  Future<WResponse> _getResponse() {
+    _sent.complete();
+    return _completer.future;
+  }
+
+  Future<WResponse> _send(String method, [Uri uri, Object data]) async {
+    _uploadProgressController.add(new WProgress(0, 1));
+    _downloadProgressController.add(new WProgress(0, 1));
+
+    WResponse response = await super._send(method, uri, data);
+
+    _uploadProgressController.add(new WProgress(1, 1));
+    _downloadProgressController.add(new WProgress(1, 1));
+
+    return response;
+  }
+
+  void _validateData() {
+    // Currently assuming that given data is valid.
+    // TODO: Consider actually validating - will require dependency on dart:html/dart:io
+  }
+}

--- a/lib/src/mocks/mock_w_response.dart
+++ b/lib/src/mocks/mock_w_response.dart
@@ -1,0 +1,90 @@
+library w_transport.src.mocks.mock_w_response;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:w_transport/w_transport.dart' show WProgress, WResponse;
+
+import 'package:w_transport/src/http/w_http.dart' show decodeAttempt;
+
+part 'package:w_transport/src/mocks/source/w_response_source.dart';
+
+class MockWResponse extends WResponseSource implements WResponse {
+  MockWResponse(int status,
+      {Map<String, String> headers, String statusText, body})
+      : super(new Stream.fromIterable([]), status,
+          statusText != null ? statusText : _mapStatusToText(status),
+          headers != null ? headers : {}) {
+    if (body != null) {
+      update(body);
+    }
+  }
+
+  MockWResponse.ok({Map<String, String> headers, String statusText, body})
+      : this(200, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.badRequest(
+      {Map<String, String> headers, String statusText, body})
+      : this(400, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.unauthorized(
+      {Map<String, String> headers, String statusText, body})
+      : this(401, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.forbidden(
+      {Map<String, String> headers, String statusText, body})
+      : this(403, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.notFound({Map<String, String> headers, String statusText, body})
+      : this(404, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.methodNotAllowed(
+      {Map<String, String> headers, String statusText, body})
+      : this(405, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.internalServerError(
+      {Map<String, String> headers, String statusText, body})
+      : this(500, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.notImplemented(
+      {Map<String, String> headers, String statusText, body})
+      : this(501, headers: headers, statusText: statusText, body: body);
+
+  MockWResponse.badGateway(
+      {Map<String, String> headers, String statusText, body})
+      : this(502, headers: headers, statusText: statusText, body: body);
+
+  set mock(dynamic body) {
+    update(body);
+  }
+
+  Future<Object> _getFuture() => asStream().single;
+
+  Future<String> _getText() =>
+      asStream().transform(decodeAttempt(_encoding)).join('');
+}
+
+String _mapStatusToText(int status) {
+  switch (status) {
+    case 200:
+      return 'OK';
+    case 400:
+      return 'BAD REQUEST';
+    case 401:
+      return 'UNAUTHORIZED';
+    case 403:
+      return 'FORBIDDEN';
+    case 404:
+      return 'NOT FOUND';
+    case 405:
+      return 'METHOD NOT ALLOWED';
+    case 500:
+      return 'INTERNAL SERVER ERROR';
+    case 501:
+      return 'NOT IMPLEMENTED';
+    case 502:
+      return 'BAD GATEWAY';
+    default:
+      return '';
+  }
+}

--- a/lib/src/mocks/source/w_request_source.dart
+++ b/lib/src/mocks/source/w_request_source.dart
@@ -1,0 +1,115 @@
+part of w_transport.src.mocks.mock_w_request;
+
+abstract class WRequestSource extends Object with FluriMixin
+    implements WRequest {
+  int contentLength;
+  Object data;
+  Encoding encoding = UTF8;
+  Map<String, String> headers = {};
+  bool withCredentials = false;
+  Object _cancellationError;
+  bool _canceled = false;
+  dynamic _client;
+  Function _configure;
+  Object _data;
+  StreamController<WProgress> _downloadProgressController =
+      new StreamController<WProgress>();
+  String _method;
+  dynamic _request;
+  StreamController<WProgress> _uploadProgressController =
+      new StreamController<WProgress>();
+  bool _single;
+
+  WRequestSource()
+      : super(),
+        _single = true;
+
+  Stream<WProgress> get downloadProgress => _downloadProgressController.stream;
+  String get method => _method;
+  Stream<WProgress> get uploadProgress => _uploadProgressController.stream;
+
+  void abort([Object error]) {
+    if (_request != null) {
+      _abortRequest(_request);
+    }
+    _canceled = true;
+    _cancellationError = error;
+  }
+
+  void configure(configure(request)) {
+    _configure = configure;
+  }
+
+  Future<WResponse> delete([Uri uri]) {
+    return _send('DELETE', uri);
+  }
+
+  Future<WResponse> get([Uri uri]) {
+    return _send('GET', uri);
+  }
+
+  Future<WResponse> head([Uri uri]) {
+    return _send('HEAD', uri);
+  }
+
+  Future<WResponse> options([Uri uri]) {
+    return _send('OPTIONS', uri);
+  }
+
+  Future<WResponse> patch([Uri uri, Object data]) {
+    return _send('PATCH', uri, data);
+  }
+
+  Future<WResponse> post([Uri uri, Object data]) {
+    return _send('POST', uri, data);
+  }
+
+  Future<WResponse> put([Uri uri, Object data]) {
+    return _send('PUT', uri, data);
+  }
+
+  Future<WResponse> trace([Uri uri]) {
+    return _send('TRACE', uri);
+  }
+
+  void _abortRequest(request);
+
+  void _checkForCancellation({WResponse response}) {
+    if (_canceled) {
+      throw new WHttpException(_method, this.uri, this, response,
+          _cancellationError != null
+              ? _cancellationError
+              : new Exception('Request canceled.'));
+    }
+  }
+
+  void _cleanUp() {
+    if (_single && _client != null) {
+      _client.close();
+    }
+  }
+
+  Future<WResponse> _getResponse();
+
+  void _initializeRequestInfo(String method, [Uri uri, Object data]) {
+    _method = method;
+    if (uri != null) {
+      this.uri = uri;
+    }
+    if (this.uri == null || this.uri.toString() == '') {
+      throw new StateError('WRequest: Cannot send a request without a URL.');
+    }
+    if (data != null) {
+      this.data = data;
+    }
+  }
+
+  Future<WResponse> _send(String method, [Uri uri, Object data]) async {
+    _initializeRequestInfo(method, uri, data);
+    _validateData();
+    _checkForCancellation();
+    return _getResponse();
+  }
+
+  void _validateData();
+}

--- a/lib/src/mocks/source/w_response_source.dart
+++ b/lib/src/mocks/source/w_response_source.dart
@@ -1,0 +1,57 @@
+part of w_transport.src.mocks.mock_w_response;
+
+abstract class WResponseSource implements WResponse {
+  final Map<String, String> headers;
+  final int status;
+  final String statusText;
+  bool _cached = false;
+  List<Object> _cachedResponse = [];
+  Encoding _encoding;
+  Stream _source;
+
+  WResponseSource(this._source, this.status, this.statusText, this.headers);
+
+  Future<Object> asFuture() => _getFuture();
+  Stream asStream() => _getStream();
+  Future<String> asText() => _getText();
+
+  void update(dynamic dataSource) {
+    if (dataSource is! Stream) {
+      dataSource = new Stream.fromIterable([dataSource]);
+    }
+    _cached = false;
+    _cachedResponse = [];
+    _source = (dataSource as Stream).transform(_cache());
+  }
+
+  StreamTransformer<Object, Object> _cache() =>
+      new StreamTransformer<Object, Object>((Stream<Object> input,
+          bool cancelOnError) {
+    StreamController<Object> controller;
+    StreamSubscription<Object> subscription;
+    controller = new StreamController<Object>(onListen: () {
+      _cached = true;
+      subscription = input.listen((Object value) {
+        controller.add(value);
+        _cachedResponse.add(value);
+      },
+          onError: controller.addError,
+          onDone: controller.close,
+          cancelOnError: cancelOnError);
+    }, onPause: () {
+      subscription.pause();
+    }, onResume: () {
+      subscription.resume();
+    }, onCancel: () {
+      subscription.cancel();
+    });
+    return controller.stream.listen(null);
+  });
+
+  Future<Object> _getFuture();
+
+  Stream _getStream() =>
+      _cached ? new Stream.fromIterable(_cachedResponse) : _source;
+
+  Future<String> _getText();
+}

--- a/test/mock_w_request_test.dart
+++ b/test/mock_w_request_test.dart
@@ -3,7 +3,8 @@ library w_transport.test.mock_w_request_test;
 import 'dart:async';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport.dart' show WHttpException, WRequest, WResponse;
+import 'package:w_transport/w_transport.dart'
+    show WHttpException, WRequest, WResponse;
 import 'package:w_transport/mocks.dart' show MockWRequest, MockWResponse;
 
 void main() {
@@ -11,11 +12,11 @@ void main() {
     MockWRequest request;
 
     setUp(() {
-      request = new MockWRequest()
-        ..path = '/test/';
+      request = new MockWRequest()..path = '/test/';
     });
 
-    test('complete() should complete the request with a 200 OK by default', () async {
+    test('complete() should complete the request with a 200 OK by default',
+        () async {
       request.complete();
       WResponse response = await request.get();
       expect(response.status, equals(200));

--- a/test/mock_w_request_test.dart
+++ b/test/mock_w_request_test.dart
@@ -1,0 +1,110 @@
+library w_transport.test.mock_w_request_test;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart' show WHttpException, WRequest, WResponse;
+import 'package:w_transport/mocks.dart' show MockWRequest, MockWResponse;
+
+void main() {
+  group('MockWRequest', () {
+    MockWRequest request;
+
+    setUp(() {
+      request = new MockWRequest()
+        ..path = '/test/';
+    });
+
+    test('complete() should complete the request with a 200 OK by default', () async {
+      request.complete();
+      WResponse response = await request.get();
+      expect(response.status, equals(200));
+      expect(response.statusText, equals('OK'));
+    });
+
+    test('complete() should accept a mock response', () async {
+      request.complete(response: new MockWResponse.unauthorized());
+      WResponse response = await request.get();
+      expect(response.status, equals(401));
+      expect(response.statusText, equals('UNAUTHORIZED'));
+    });
+
+    test('completeError() should complete the request with an error', () async {
+      request.completeError();
+      WHttpException exception;
+      try {
+        await request.get();
+      } on WHttpException catch (e) {
+        exception = e;
+      }
+      expect(exception, isNotNull);
+      expect(exception.method, equals('GET'));
+      expect(exception.uri.path, equals('/test/'));
+    });
+
+    test('completeError() should accept a custom error', () async {
+      request.completeError(error: new Exception('Custom error.'));
+      WHttpException exception;
+      try {
+        await request.get();
+      } on WHttpException catch (e) {
+        exception = e;
+      }
+      expect(exception, isNotNull);
+      expect(exception.toString(), contains('Custom error.'));
+    });
+
+    test('completeError() should accept a mock response', () async {
+      request.completeError(response: new MockWResponse.internalServerError());
+      WHttpException exception;
+      try {
+        await request.get();
+      } on WHttpException catch (e) {
+        exception = e;
+      }
+      expect(exception, isNotNull);
+      expect(exception.response.status, equals(500));
+      expect(exception.response.statusText, equals('INTERNAL SERVER ERROR'));
+    });
+
+    test('abort() should still cancel the request', () async {
+      request.abort();
+      WHttpException exception;
+      try {
+        await request.get();
+      } on WHttpException catch (e) {
+        exception = e;
+      }
+      expect(exception, isNotNull);
+      expect(exception.toString(), contains('Request canceled.'));
+    });
+
+    test('uploadProgress stream should go from 0 to 100%', () async {
+      Completer uploadComplete = new Completer();
+
+      request.uploadProgress.listen((progress) {
+        if (progress.percent == 100.0) {
+          uploadComplete.complete();
+        }
+      });
+
+      request.complete();
+      await request.get();
+      await uploadComplete.future;
+    });
+
+    test('downloadProgress stream should go from 0 to 100%', () async {
+      Completer downloadComplete = new Completer();
+
+      request.downloadProgress.listen((progress) {
+        if (progress.percent == 100.0) {
+          downloadComplete.complete();
+        }
+      });
+
+      request.complete();
+      await request.get();
+      await downloadComplete.future;
+    });
+  });
+}

--- a/test/mock_w_response_test.dart
+++ b/test/mock_w_response_test.dart
@@ -3,7 +3,8 @@ library w_transport.test.mock_w_response_test;
 import 'dart:async';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport.dart' show WHttpException, WRequest, WResponse;
+import 'package:w_transport/w_transport.dart'
+    show WHttpException, WRequest, WResponse;
 import 'package:w_transport/mocks.dart' show MockWRequest, MockWResponse;
 
 void main() {
@@ -13,11 +14,13 @@ void main() {
     });
 
     test('statusText should be mockable', () {
-      expect(new MockWResponse.ok(statusText: 'GREAT').statusText, equals('GREAT'));
+      expect(new MockWResponse.ok(statusText: 'GREAT').statusText,
+          equals('GREAT'));
     });
 
     test('headers should be mockable', () {
-      WResponse response = new MockWResponse.ok(headers: {'content-type': 'application/json'});
+      WResponse response =
+          new MockWResponse.ok(headers: {'content-type': 'application/json'});
       expect(response.headers['content-type'], equals('application/json'));
     });
 
@@ -32,7 +35,8 @@ void main() {
     });
 
     test('body should be mockable as stream', () async {
-      WResponse response = new MockWResponse.ok(body: new Stream.fromIterable(['success']));
+      WResponse response =
+          new MockWResponse.ok(body: new Stream.fromIterable(['success']));
       expect(await response.asStream().single, equals('success'));
     });
   });

--- a/test/mock_w_response_test.dart
+++ b/test/mock_w_response_test.dart
@@ -1,0 +1,39 @@
+library w_transport.test.mock_w_response_test;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart' show WHttpException, WRequest, WResponse;
+import 'package:w_transport/mocks.dart' show MockWRequest, MockWResponse;
+
+void main() {
+  group('MockWResponse', () {
+    test('status should be mockable', () {
+      expect(new MockWResponse(300).status, equals(300));
+    });
+
+    test('statusText should be mockable', () {
+      expect(new MockWResponse.ok(statusText: 'GREAT').statusText, equals('GREAT'));
+    });
+
+    test('headers should be mockable', () {
+      WResponse response = new MockWResponse.ok(headers: {'content-type': 'application/json'});
+      expect(response.headers['content-type'], equals('application/json'));
+    });
+
+    test('body should be mockable as untyped object', () async {
+      WResponse response = new MockWResponse.ok(body: {'result': 'success'});
+      expect(await response.asFuture(), equals({'result': 'success'}));
+    });
+
+    test('body should be mockable as string', () async {
+      WResponse response = new MockWResponse.ok(body: 'success');
+      expect(await response.asText(), equals('success'));
+    });
+
+    test('body should be mockable as stream', () async {
+      WResponse response = new MockWResponse.ok(body: new Stream.fromIterable(['success']));
+      expect(await response.asStream().single, equals('success'));
+    });
+  });
+}


### PR DESCRIPTION
## Issue
- We should provide mocks for the classes supplied in w_transport to make testing easier for consumers
- #32 

## Changes
**Source:**
- `WRequest` and `WResponse`
  - Break logic into more manageable pieces in order to make mocking easier
- `WRequestSource` and `WResponseSource`
  - Copy of original classes, minus some small pieces that are meant to be mocked out
  - Ideally, these should be generated
- `MockWRequest` and `MockWResponse`
  - Extends from the `Source` classes above
  - Mocks out a small selection of functionality
  - Adds an API for controlling the behavior


**Tests:**
- Add tests for the controllable behavior of the mocks

## Areas of Regression
- Sending of requests (existing tests should cover)

## Testing
- Tests pass
- The mocks should be easy to use in testing w_service (I will test this)

## TODO
- [ ] Mock for `WHttp`

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@jayudey-wf 

I mainly want to get feedback on this approach. I'm not convinced this is the best solution, at least not until I can research the possibility of generating the `Source` classes in more depth.