### PR TITLE
CP-751 Add SDK constraint, w_transport

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,17 +8,19 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_transport
 dependencies:
-  fluri: '>=1.0.0 <2.0.0'
+  fluri: "^1.0.0"
 dev_dependencies:
-  ansicolor: '>=0.0.9 <0.1.0'
-  args: '>=0.12.1 <0.14.0'
-  browser: any
-  dart_style: '>=0.1.8 <0.2.0'
-  http_server: '>=0.9.5+1 <0.10.0'
-  mime: '>=0.9.3 <0.10.0'
-  mockito: '>=0.9.0 <0.10.0'
-  path: '>=1.3.5 <2.0.0'
-  react: '>=0.6.1 <0.7.0'
-  shelf: '>=0.6.1+1 <0.7.0'
-  test: '>=0.12.0 <0.13.0'
-  uuid: '>=0.5.0 <0.6.0'
+  ansicolor: "^0.0.9"
+  args: "^0.13.0"
+  browser: "^0.10.0+2"
+  dart_style: "^0.1.8"
+  http_server: "^0.9.5+1"
+  mime: "^0.9.3"
+  mockito: "^0.9.0"
+  path: "^1.3.5"
+  react: "^0.6.1"
+  shelf: "^0.6.1+1"
+  test: "^0.12.3+5"
+  uuid: "^0.5.0"
+environment:
+  sdk: ">=1.9.0 <2.0.0"

--- a/tool/dartium.sh
+++ b/tool/dartium.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Opens dartium to localhost, port 8080 by default.
-# You can pass in a different port like so:
-# ./tool/dartium 9000
-dartium --checked http://localhost:${1-8080}


### PR DESCRIPTION
## Issue
- #39 

## Changes
- Add a Dart SDK constraint to pubspec.yaml.
- Also allows use to use the `^` syntax for dependencies
- Removed `dartium.sh` tool because it wasn't really useful.

## Areas of Regression
- n/a

## Testing
- `pub publish --dry-run` shows no warnings

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 