### PR TITLE
CP-754 Update tests to run with content shell instead of dartium

### DIFF
--- a/test/run_tests.dart
+++ b/test/run_tests.dart
@@ -122,7 +122,7 @@ main(List<String> args) async {
       if (env['platform'].length > 0) {
         testArgs.addAll((env['platform'] as List).map((p) => '--platform=$p'));
       } else {
-        testArgs.addAll(['-p', 'vm', '-p', 'dartium']);
+        testArgs.addAll(['-p', 'vm', '-p', 'content-shell']);
       }
       print('pub ${testArgs.join(' ')}');
       tests = await Process.start('pub', testArgs);


### PR DESCRIPTION
## Issue
- When using the test script if you have multiple versions of dartium installed you will get failed results when running the integration tests.

## Changes
**Source:**
- Updated test runner to use content shell

**Tests:**
- n/a

## Areas of Regression
- the test.sh script

## Testing
- run the test.sh script to ensure that it's still working

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf