### PR TITLE
Updating typing in download_page.dart

### DIFF
--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -25,9 +25,9 @@ import '../services/file_transfer.dart';
 import '../services/remote_files.dart';
 import './file_transfer_list_component.dart';
 
-final double _gb = math.pow(2, 30);
-final double _mb = math.pow(2, 20);
-final double _kb = math.pow(2, 10);
+final num _gb = math.pow(2, 30);
+final num _mb = math.pow(2, 20);
+final num _kb = math.pow(2, 10);
 
 var downloadPage = react.registerComponent(() => new DownloadPage());
 class DownloadPage extends react.Component {


### PR DESCRIPTION
## Issue
- When running dartium in checked mode the cross origin file transfer example errors due to a typing mis-match.

## Changes
**Source:**
- Update types

**Tests:**
- Change is to an example and not source code

## Areas of Regression
- N/A

## Testing
- Run the affected example in checked mode and review the console for no errors.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf