### PR TITLE
CP-930 Add "Development" section to readme, w_transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,10 @@ property for convenience. `WProgress` is platform-agnostic, unlike `ProgressEven
 
 ## WHttpException
 `WHttpException` is a custom exception that is raised when a request responds with a non-successful status code.
+
+## Development
+
+This project leverages [the dart_dev package](https://github.com/Workiva/dart_dev)
+for most of its tooling needs, including static analysis, code formatting,
+running tests, collecting coverage, and serving examples. Check out the dart_dev
+readme for more information.


### PR DESCRIPTION
## Issue
#55 - forgot to add a section to the readme about dev when updating w_transport to use dart_dev.

## Changes
Add "development" section to readme.

## Areas of Regression
n/a

## Testing
n/a

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf