### PR TITLE
CP-1089 Allow headers, withCredentials to be set on Client

### DIFF
--- a/lib/src/http/browser/client.dart
+++ b/lib/src/http/browser/client.dart
@@ -31,7 +31,7 @@ class BrowserClient extends CommonClient implements Client {
   FormRequest newFormRequest() {
     verifyNotClosed();
     FormRequest request = new BrowserFormRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -41,7 +41,7 @@ class BrowserClient extends CommonClient implements Client {
   JsonRequest newJsonRequest() {
     verifyNotClosed();
     JsonRequest request = new BrowserJsonRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -51,7 +51,7 @@ class BrowserClient extends CommonClient implements Client {
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
     MultipartRequest request = new BrowserMultipartRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -61,7 +61,7 @@ class BrowserClient extends CommonClient implements Client {
   Request newRequest() {
     verifyNotClosed();
     Request request = new BrowserPlainTextRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -71,7 +71,7 @@ class BrowserClient extends CommonClient implements Client {
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
     StreamedRequest request = new BrowserStreamedRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 }

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -20,8 +20,17 @@ import 'package:w_transport/src/platform_adapter.dart';
 abstract class Client {
   factory Client() => PlatformAdapter.retrieve().newClient();
 
+  /// Get and set request headers that will be applied to all requests created
+  /// by this HTTP client.
+  Map<String, String> headers;
+
   /// Whether or not the HTTP client has been closed.
   bool get isClosed;
+
+  /// Whether or not to send requests from this client with credentials. Only
+  /// applicable to requests in the browser, but does not adversely affect any
+  /// other platform.
+  bool withCredentials;
 
   /// Closes the client, cancelling or closing any outstanding connections.
   void close();

--- a/lib/src/http/mock/client.dart
+++ b/lib/src/http/mock/client.dart
@@ -30,7 +30,7 @@ class MockClient extends CommonClient implements Client {
   FormRequest newFormRequest() {
     verifyNotClosed();
     FormRequest request = new MockFormRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -40,7 +40,7 @@ class MockClient extends CommonClient implements Client {
   JsonRequest newJsonRequest() {
     verifyNotClosed();
     JsonRequest request = new MockJsonRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -50,7 +50,7 @@ class MockClient extends CommonClient implements Client {
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
     MultipartRequest request = new MockMultipartRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -60,7 +60,7 @@ class MockClient extends CommonClient implements Client {
   Request newRequest() {
     verifyNotClosed();
     Request request = new MockPlainTextRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -70,7 +70,7 @@ class MockClient extends CommonClient implements Client {
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
     StreamedRequest request = new MockStreamedRequest();
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 }

--- a/lib/src/http/vm/client.dart
+++ b/lib/src/http/vm/client.dart
@@ -42,7 +42,7 @@ class VMClient extends CommonClient implements Client {
   FormRequest newFormRequest() {
     verifyNotClosed();
     FormRequest request = new VMFormRequest.withClient(_client);
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -52,7 +52,7 @@ class VMClient extends CommonClient implements Client {
   JsonRequest newJsonRequest() {
     verifyNotClosed();
     JsonRequest request = new VMJsonRequest.withClient(_client);
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -62,7 +62,7 @@ class VMClient extends CommonClient implements Client {
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
     MultipartRequest request = new VMMultipartRequest.withClient(_client);
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -72,7 +72,7 @@ class VMClient extends CommonClient implements Client {
   Request newRequest() {
     verifyNotClosed();
     Request request = new VMPlainTextRequest.withClient(_client);
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 
@@ -82,7 +82,7 @@ class VMClient extends CommonClient implements Client {
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
     StreamedRequest request = new VMStreamedRequest.withClient(_client);
-    registerRequest(request);
+    registerAndDecorateRequest(request);
     return request;
   }
 }


### PR DESCRIPTION
## Issue
- To reduce repetition (and to make `Client` more useful), you should be able to set headers and the `withCredentials` flag on a `Client` and have those applied to all requests created by that client.

## Changes
**Source:**
- Add `headers` and `withCredentials` getters/setters to `Client`
- Apply values to all requests created by `Client`

**Tests:**
- Unit tests added to verify this `Client` behavior

## Areas of Regression
- n/a, new functionality

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 