### PR TITLE
CP-1106 Support usage of SockJS, w_transport.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
+  - npm install
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test --integration

--- a/README.md
+++ b/README.md
@@ -550,3 +550,6 @@ This project leverages [the `dart_dev` package](https://github.com/Workiva/dart_
 for most of its tooling needs, including static analysis, code formatting,
 running tests, collecting coverage, and serving examples. Check out the dart_dev
 readme for more information.
+
+> **Note:** to run integration tests, you'll need two JS dependencies for a
+> SockJS server. Run an `npm install` to download them.

--- a/lib/src/browser_adapter.dart
+++ b/lib/src/browser_adapter.dart
@@ -21,6 +21,7 @@ import 'package:w_transport/src/http/browser/requests.dart';
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
+import 'package:w_transport/src/web_socket/browser/sockjs.dart';
 import 'package:w_transport/src/web_socket/browser/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 
@@ -28,6 +29,21 @@ import 'package:w_transport/src/web_socket/w_socket.dart';
 /// classes that return browser-specific implementations that leverage
 /// dart:html.
 class BrowserAdapter implements PlatformAdapter {
+  final bool _useSockJS;
+  final bool _sockJSDebug;
+  final bool _sockJSNoCredentials;
+  final List<String> _sockJSProtocolsWhitelist;
+
+  BrowserAdapter(
+      {bool useSockJS: false,
+      bool sockJSNoCredentials: false,
+      bool sockJSDebug: false,
+      List<String> sockJSProtocolsWhitelist})
+      : _useSockJS = useSockJS == true,
+        _sockJSDebug = sockJSDebug == true,
+        _sockJSProtocolsWhitelist = sockJSProtocolsWhitelist,
+        _sockJSNoCredentials = sockJSNoCredentials == true;
+
   /// Construct a new [BrowserClient] instance that implements [Client].
   Client newClient() => new BrowserClient();
 
@@ -53,6 +69,15 @@ class BrowserAdapter implements PlatformAdapter {
 
   /// Construct a new [ClientWSocket] instance that implements [WSocket].
   Future<WSocket> newWSocket(Uri uri,
-          {Iterable<String> protocols, Map<String, dynamic> headers}) =>
-      BrowserWSocket.connect(uri, protocols: protocols, headers: headers);
+      {Iterable<String> protocols, Map<String, dynamic> headers}) {
+    if (_useSockJS) {
+      return SockJSSocket.connect(uri,
+          debug: _sockJSDebug,
+          noCredentials: _sockJSNoCredentials,
+          protocolsWhitelist: _sockJSProtocolsWhitelist);
+    } else {
+      return BrowserWSocket.connect(uri,
+          protocols: protocols, headers: headers);
+    }
+  }
 }

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -1,0 +1,107 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.src.web_socket.browser.sockjs;
+
+import 'dart:async';
+
+import 'package:sockjs_client/sockjs_client.dart' as sockjs;
+
+import 'package:w_transport/src/web_socket/common/w_socket.dart';
+import 'package:w_transport/src/web_socket/w_socket.dart';
+import 'package:w_transport/src/web_socket/w_socket_close_event.dart';
+import 'package:w_transport/src/web_socket/w_socket_exception.dart';
+
+class SockJSSocket extends CommonWSocket implements WSocket {
+  static Future<WSocket> connect(Uri uri,
+      {bool debug: false,
+      bool noCredentials: false,
+      List<String> protocolsWhitelist}) async {
+    if (uri.scheme == 'ws') {
+      uri = uri.replace(scheme: 'http');
+    } else if (uri.scheme == 'wss') {
+      uri = uri.replace(scheme: 'https');
+    }
+
+    sockjs.Client client = new sockjs.Client(uri.toString(),
+        debug: debug == true,
+        noCredentials: noCredentials == true,
+        protocolsWhitelist: protocolsWhitelist);
+
+    // Listen for and store the close event. This will determine whether or
+    // not the socket connected successfully, and will also be used later
+    // to handle the web socket closing.
+    var closed = client.onClose.first;
+
+    // Will complete if the socket successfully opens, or complete with
+    // an error if the socket moves straight to the closed state.
+    Completer connected = new Completer();
+    client.onOpen.first.then(connected.complete);
+    closed.then((_) {
+      if (!connected.isCompleted) {
+        connected
+            .completeError(new WSocketException('Could not connect to $uri'));
+      }
+    });
+
+    await connected.future;
+    return new SockJSSocket._(client, closed);
+  }
+
+  /// The underlying SockJS Client instance.
+  sockjs.Client _socket;
+
+  /// The close event Future from the SockJS Client onClose stream.
+  var _socketClosed;
+
+  SockJSSocket._(sockjs.Client this._socket, this._socketClosed) : super() {
+    // The outgoing communication will be handled by this stream controller.
+    // The sink from this controller will be used by [add] and [addStream].
+    outgoing = new StreamController();
+    outgoing.stream.listen((message) {
+      // Pipe messages through to the underlying socket.
+      _socket.send(message);
+    }, onError: handleOutgoingError, onDone: handleOutgoingDone);
+
+    // Map events from the underlying socket to the incoming controller.
+    incoming = new StreamController();
+    _socket.onMessage.listen((messageEvent) {
+      // Pipe messages from the socket through to the stream.
+      incoming.add(messageEvent.data);
+    });
+    _socketClosed.then((closeEvent) {
+      // Now that the socket has closed, capture the close code and reason.
+      var wCloseEvent =
+          new WSocketCloseEvent(closeEvent.code, closeEvent.reason);
+      handleSocketDone(wCloseEvent);
+    });
+  }
+
+  @override
+  void closeSocket(int code, String reason) {
+    _socket.close(code, reason);
+  }
+
+  /// Validate the WebSocket message data type. When using SockJS, only [String]
+  /// messages are valid.
+  ///
+  /// Throws an [ArgumentError] if [data] is invalid.
+  @override
+  void validateDataType(Object data) {
+    if (data is! String) {
+      throw new ArgumentError(
+          'WSocket data type must be a String when using SockJS.');
+    }
+  }
+}

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -173,7 +173,7 @@ abstract class CommonWSocket extends Stream implements WSocket {
     if (_isSinkClosed) {
       _allClosed.complete();
     } else {
-      outgoing.close();
+      outgoing.close().catchError((_) {});
     }
   }
 

--- a/lib/w_transport_browser.dart
+++ b/lib/w_transport_browser.dart
@@ -39,6 +39,14 @@ import 'package:w_transport/src/browser_adapter.dart';
 import 'package:w_transport/src/platform_adapter.dart';
 
 /// Configures w_transport for use in the browser via dart:html.
-void configureWTransportForBrowser() {
-  adapter = new BrowserAdapter();
+void configureWTransportForBrowser(
+    {bool useSockJS: false,
+    bool sockJSDebug: false,
+    bool sockJSNoCredentials: false,
+    List<String> sockJSProtocolsWhitelist}) {
+  adapter = new BrowserAdapter(
+      useSockJS: useSockJS,
+      sockJSDebug: sockJSDebug,
+      sockJSNoCredentials: sockJSNoCredentials,
+      sockJSProtocolsWhitelist: sockJSProtocolsWhitelist);
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "w_transport",
+  "version": "1.0.1",
+  "devDependencies": {
+    "http": "0.0.0",
+    "sockjs": "^0.3.15"
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,10 @@ dependencies:
   fluri: "^1.0.0"
   http_parser: "^1.0.0"
   mime: "^0.9.3"
+  sockjs_client:
+    git:
+      url: https://github.com/Workiva/sockjs-dart-client.git
+      ref: cors
   stack_trace: "^1.4.0"
 dev_dependencies:
   ansicolor: "^0.0.9"

--- a/test/integration/browser_integration_test.dart
+++ b/test/integration/browser_integration_test.dart
@@ -32,6 +32,7 @@ import 'http/streamed_request/browser_test.dart'
 import 'platforms/browser_platform_test.dart' as browser_platform_adapter_test;
 
 import 'ws/browser_test.dart' as ws_browser;
+import 'ws/sockjs_test.dart' as ws_sockjs;
 
 void main() {
   http_client_browser.main();
@@ -46,4 +47,5 @@ void main() {
   browser_platform_adapter_test.main();
 
   ws_browser.main();
+  ws_sockjs.main();
 }

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -1,0 +1,103 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+library w_transport.test.integration.ws.sockjs_test;
+
+import 'dart:html';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_browser.dart';
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+const int sockjsPort = 8026;
+
+void main() {
+  Naming wsNaming = new Naming()
+    ..platform = platformBrowserSockjsWS
+    ..testType = testTypeIntegration
+    ..topic = topicWebSocket;
+
+  Naming xhrNaming = new Naming()
+    ..platform = platformBrowserSockjsXhr
+    ..testType = testTypeIntegration
+    ..topic = topicWebSocket;
+
+  group(wsNaming.toString(), () {
+    setUp(() {
+      configureWTransportForBrowser(
+          useSockJS: true,
+          sockJSNoCredentials: true,
+          sockJSProtocolsWhitelist: ['websocket']);
+    });
+
+    sockJSSuite();
+  });
+
+  group(xhrNaming.toString(), () {
+    setUp(() {
+      configureWTransportForBrowser(
+          useSockJS: true,
+          sockJSNoCredentials: true,
+          sockJSProtocolsWhitelist: ['xhr-streaming']);
+    });
+
+    sockJSSuite();
+  });
+}
+
+sockJSSuite() {
+  runCommonWebSocketIntegrationTests(port: sockjsPort);
+
+  var echoUri = IntegrationPaths.echoUri.replace(port: sockjsPort);
+  var pingUri = IntegrationPaths.pingUri.replace(port: sockjsPort);
+
+  test('should not support Blob', () async {
+    Blob blob = new Blob(['one', 'two']);
+    WSocket socket = await WSocket.connect(pingUri);
+    expect(() {
+      socket.add(blob);
+    }, throwsArgumentError);
+    socket.close();
+  });
+
+  test('should support String', () async {
+    String data = 'data';
+    WSocket socket = await WSocket.connect(echoUri);
+    socket.add(data);
+    socket.close();
+  });
+
+  test('should not support TypedData', () async {
+    TypedData data = new Uint16List.fromList([1, 2, 3]);
+    WSocket socket = await WSocket.connect(echoUri);
+    expect(() {
+      socket.add(data);
+    }, throwsArgumentError);
+    socket.close();
+  });
+
+  test('should throw when attempting to send invalid data', () async {
+    WSocket socket = await WSocket.connect(pingUri);
+    expect(() {
+      socket.add(true);
+    }, throwsArgumentError);
+    socket.close();
+  });
+}

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -16,6 +16,8 @@ library w_transport.test.naming;
 
 /// Platforms.
 const String platformBrowser = 'browser';
+const String platformBrowserSockjsWS = 'browser (SockJS WS)';
+const String platformBrowserSockjsXhr = 'browser (SockJS XHR)';
 const String platformMock = 'mock';
 const String platformVM = 'vm';
 

--- a/tool/server/sockjs.js
+++ b/tool/server/sockjs.js
@@ -1,0 +1,81 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    var http = require('http');
+    var sockjs = require('sockjs');
+} catch (e) {
+    console.error('Missing NPM dependencies: "http" and "sockjs".\nRun `npm install`.');
+    process.exit(1);
+}
+
+
+var echo = sockjs.createServer();
+echo.on('connection', function(conn) {
+    conn.on('data', function(message) {
+        console.log('[echo] "' + message + '"');
+        conn.write(message);
+    });
+    conn.on('close', function() {
+        console.log('[echo] closed.');
+    });
+});
+
+var closeOnRequest = sockjs.createServer();
+closeOnRequest.on('connection', function(conn) {
+    conn.on('data', function(message) {
+        if (message.substr(0, 'close'.length) === 'close') {
+            var parts = message.split(':');
+            var code;
+            var reason;
+            if (parts.length >= 2) {
+                code = parseInt(parts[1], 10);
+            }
+            if (parts.length >= 3) {
+                reason = parts[2];
+            }
+            console.log('[cor] close request received');
+            conn.close(code, reason);
+        }
+    });
+    conn.on('close', function() {
+        console.log('[cor] closed.');
+    });
+});
+
+var ping = sockjs.createServer();
+ping.on('connection', function(conn) {
+    conn.on('data', function(message) {
+        message = message.replace('ping', '');
+        var numPongs = 1;
+        if (message.length > 0) {
+            try {
+                numPongs = parseInt(message, 10);
+            } catch (e) {}
+        }
+        for (var i = 0; i < numPongs; i++) {
+            conn.write('pong');
+            console.log('[ping] pong');
+        }
+    });
+    conn.on('close', function() {
+        console.log('[ping] closed.');
+    });
+});
+
+var server = http.createServer();
+closeOnRequest.installHandlers(server, {prefix: '/test/ws/close'});
+echo.installHandlers(server, {prefix: '/test/ws/echo'});
+ping.installHandlers(server, {prefix: '/test/ws/ping'});
+server.listen(8026, 'localhost');


### PR DESCRIPTION
Resolves #68.

## Issue
- Not all browsers support native WebSockets. SockJS provides the ability to fallback to XHR-streaming if this is the case, but currently w_transport is not compatible with SockJS.

## Changes
**Source:**
- Add an additional implementation of the `WSocket` class that utilizes [SockJS client](https://github.com/Workiva/sockjs-dart-client) instead of the native `WebSocket` class directly.
  - This is almost identical to the browser implementation (in fact I may try to merge some of the common code)
- Add optional parameters to the `configureWTransportForBrowser()` method for enabling SockJS.

To use SockJS in the browser:
```dart
import 'package:w_transport/w_transport.dart';
import 'package:w_transport/w_transport_browser.dart';

main() async {
  configureWTransportForBrowser(useSockJS: true, sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
  WSocket socket = await WSocket.connect(Uri.parse('ws://localhost:8000/path/to/sockjs/server'));
}
```

**Tests:**
- New SockJS integration server added that runs during tests/coverage
- Integration tests added to test 

## Areas of Regression
- n/a

## TODO
- [x] ~~Combine common code from the browser implementation and the SockJS implementation~~ The amount of common code here is small enough that I'm going to leave it. It would be overkill to create another super class just for a few lines of common code.
- [x] Apply common unit test suite for `WSocket` to the two SockJS configurations (websocket and xhr-streaming)
- [x] Fix coverage (currently fails on SockJS's XHR-streaming configuration because the origin header is null in content-shell)
- [x] Make the sockjs-dart-client lib public

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @stevenosborne-wf @tylertreat-wf 