### PR TITLE
CP-1113 Add stream static methods to Http

### DIFF
--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -133,7 +133,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
       reader.readAsArrayBuffer(
           _request.response != null ? _request.response : new Blob([]));
       List<int> bytes = await result.future;
-      var byteStream = new Stream.fromIterable(bytes);
+      var byteStream = new Stream.fromIterable([bytes]);
       response = new StreamedResponse.fromByteStream(_request.status,
           _request.statusText, _request.responseHeaders, byteStream);
     } else {

--- a/lib/src/http/http.dart
+++ b/lib/src/http/http.dart
@@ -103,7 +103,96 @@ class Http {
           headers: headers,
           withCredentials: withCredentials).send(method);
 
-  static _createRequest(Uri uri,
+  /// Sends a DELETE request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamDelete(Uri uri,
+          {Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri, headers: headers, withCredentials: withCredentials)
+          .streamDelete();
+
+  /// Sends a GET request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamGet(Uri uri,
+          {Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri, headers: headers, withCredentials: withCredentials)
+          .streamGet();
+
+  /// Sends a HEAD request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamHead(Uri uri,
+          {Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri, headers: headers, withCredentials: withCredentials)
+          .streamHead();
+
+  /// Sends an OPTIONS request to [uri] and returns a [StreamedResponse].
+  /// Includes request [headers] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamOptions(Uri uri,
+          {Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri, headers: headers, withCredentials: withCredentials)
+          .streamOptions();
+
+  /// Sends a PATCH request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] and a request [body] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamPatch(Uri uri,
+          {String body, Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri,
+          body: body,
+          headers: headers,
+          withCredentials: withCredentials).streamPatch();
+
+  /// Sends a POST request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] and a request [body] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamPost(Uri uri,
+          {String body, Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri,
+          body: body,
+          headers: headers,
+          withCredentials: withCredentials).streamPost();
+
+  /// Sends a PUT request to [uri] and returns a [StreamedResponse]. Includes
+  /// request [headers] and a request [body] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamPut(Uri uri,
+          {String body, Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri,
+          body: body,
+          headers: headers,
+          withCredentials: withCredentials).streamPut();
+
+  /// Sends a request to [uri] using the HTTP method specified by [method] and
+  /// returns a [StreamedResponse]. Includes request [headers] and a request
+  /// [body] if given.
+  ///
+  /// Secure cookies (credentials) will be included (in the browser) if
+  /// [withCredentials] is true.
+  static Future<StreamedResponse> streamSend(String method, Uri uri,
+          {String body, Map<String, String> headers, bool withCredentials}) =>
+      _createRequest(uri,
+          body: body,
+          headers: headers,
+          withCredentials: withCredentials).streamSend(method);
+
+  static Request _createRequest(Uri uri,
       {String body, Map<String, String> headers, bool withCredentials}) {
     var request = new Request()..uri = uri;
     if (body != null) {

--- a/test/integration/http/http_static/suite.dart
+++ b/test/integration/http/http_static/suite.dart
@@ -14,6 +14,10 @@
 
 library w_transport.test.integration.http.http_static.suite;
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 
@@ -198,6 +202,211 @@ void runHttpStaticSuite() {
       Response response = await Http
           .send('COPY', IntegrationPaths.echoEndpointUri, body: 'body');
       expect(response.body.asString(), equals('body'));
+    });
+
+    Future<String> _decodeStreamedResponseToString(
+        StreamedResponse response) async {
+      Uint8List bytes = await response.body.toBytes();
+      return response.encoding.decode(bytes.toList());
+    }
+
+    Future<Map> _decodeStreamedResponseToJson(StreamedResponse response) async {
+      return JSON.decode(await _decodeStreamedResponseToString(response));
+    }
+
+    test('streamed DELETE request', () async {
+      StreamedResponse response =
+          await Http.streamDelete(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('DELETE'));
+    });
+
+    test('streamed DELETE request with headers', () async {
+      StreamedResponse response = await Http.streamDelete(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('DELETE'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed GET request', () async {
+      StreamedResponse response =
+          await Http.streamGet(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('GET'));
+    });
+
+    test('streamed GET request with headers', () async {
+      StreamedResponse response = await Http.streamGet(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('GET'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed HEAD request', () async {
+      StreamedResponse response =
+          await Http.streamHead(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+    });
+
+    test('streamed HEAD request with headers', () async {
+      StreamedResponse response = await Http.streamHead(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+    });
+
+    test('streamed OPTIONS request', () async {
+      StreamedResponse response =
+          await Http.streamOptions(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('OPTIONS'));
+    });
+
+    test('streamed OPTIONS request with headers', () async {
+      StreamedResponse response = await Http.streamOptions(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('OPTIONS'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed PATCH request', () async {
+      StreamedResponse response =
+          await Http.streamPatch(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('PATCH'));
+    });
+
+    test('streamed PATCH request with headers', () async {
+      StreamedResponse response = await Http.streamPatch(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('PATCH'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed PATCH request with body', () async {
+      StreamedResponse response = await Http
+          .streamPatch(IntegrationPaths.echoEndpointUri, body: 'body');
+      String body = await _decodeStreamedResponseToString(response);
+      expect(body, equals('body'));
+    });
+
+    test('streamed POST request', () async {
+      StreamedResponse response =
+          await Http.streamPost(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('POST'));
+    });
+
+    test('streamed POST request with headers', () async {
+      StreamedResponse response = await Http.streamPost(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('POST'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed POST request with body', () async {
+      StreamedResponse response =
+          await Http.streamPost(IntegrationPaths.echoEndpointUri, body: 'body');
+      String body = await _decodeStreamedResponseToString(response);
+      expect(body, equals('body'));
+    });
+
+    test('streamed PUT request', () async {
+      StreamedResponse response =
+          await Http.streamPut(IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('PUT'));
+    });
+
+    test('streamed PUT request with headers', () async {
+      StreamedResponse response = await Http.streamPut(
+          IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('PUT'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed PUT request with body', () async {
+      StreamedResponse response =
+          await Http.streamPut(IntegrationPaths.echoEndpointUri, body: 'body');
+      String body = await _decodeStreamedResponseToString(response);
+      expect(body, equals('body'));
+    });
+
+    test('streamed custom HTTP method request', () async {
+      StreamedResponse response =
+          await Http.streamSend('COPY', IntegrationPaths.reflectEndpointUri);
+      expect(response.status, equals(200));
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('COPY'));
+    });
+
+    test('streamed custom HTTP method request with headers', () async {
+      StreamedResponse response = await Http.streamSend(
+          'COPY', IntegrationPaths.reflectEndpointUri,
+          headers: new Map.from(headers));
+      expect(response.status, equals(200));
+
+      Map json = await _decodeStreamedResponseToJson(response);
+      expect(json['method'], equals('COPY'));
+      expect(json['headers'],
+          containsPair('authorization', headers['authorization']));
+      expect(json['headers'], containsPair('x-custom', headers['x-custom']));
+      expect(json['headers'], containsPair('x-tokens', headers['x-tokens']));
+    });
+
+    test('streamed custom HTTP method request with body', () async {
+      StreamedResponse response = await Http
+          .streamSend('COPY', IntegrationPaths.echoEndpointUri, body: 'body');
+      String body = await _decodeStreamedResponseToString(response);
+      expect(body, equals('body'));
     });
   });
 }


### PR DESCRIPTION
## Issue
Resolves #73 

## Changes
**Source:**
- Add streamed variants of the request methods on the `Http` class to make it easy to get a streamed response for simple requests.
- Bug fix: the browser implementation of streamed response was not constructing the byte stream correctly

**Tests:**
- Integration tests added

## Areas of Regression
- n/a

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 