### PR TITLE
CP-716 Release w_transport 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 1.0.1
+version: 2.0.0
 description: A fluent-style, platform-agnostic library with ready to use transport classes for sending and receiving data over HTTP.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-716

JIRA and PR's included in this release: 


 CP-751  - Add SDK constraint, w_transport  - https://github.com/Workiva/w_transport/pull/42
 CP-754  - Update tests to run with content shell instead of dartium  - https://github.com/Workiva/w_transport/pull/43
 CP-819  - Refactor internal source code organization  - https://github.com/Workiva/w_transport/pull/51
 CP-830  - Updating typing in download_page.dart  - https://github.com/Workiva/w_transport/pull/52
 CP-871  - Utilize dart_dev for tooling, refactor server component  - https://github.com/Workiva/w_transport/pull/53
 CP-884  - Ensure license is applied to all source files, w_transport  - https://github.com/Workiva/w_transport/pull/54
 CP-930 Add "Development" section to readme, w_transport - https://github.com/Workiva/w_transport/pull/59
 CP-931 Move badges to separate line, w_transport - https://github.com/Workiva/w_transport/pull/58
 CP-919  - Add support for WebSocket, w_transport  - https://github.com/Workiva/w_transport/pull/56
 CP-987  - Remove old tooling scripts  - https://github.com/Workiva/w_transport/pull/62
 CP-977  - Add HTTP and WS Mocks. Refactor tests.  - https://github.com/Workiva/w_transport/pull/61
 CP-1058  - HTTP API redesign, w_transport  - https://github.com/Workiva/w_transport/pull/67
 CP-1089  - Allow headers, withCredentials to be set on Client  - https://github.com/Workiva/w_transport/pull/69
 CP-1092  - Cleanup WSocket, handle errors correctly, naming changes  - https://github.com/Workiva/w_transport/pull/71
 CP-1093  - Increase HTTP coverage. Consistent test naming.  - https://github.com/Workiva/w_transport/pull/72
 CP-1113  - Add stream static methods to Http  - https://github.com/Workiva/w_transport/pull/76
 CP-1111  - Revamp documentation, w_transport  - https://github.com/Workiva/w_transport/pull/75
 CP-1106  - Support usage of SockJS, w_transport.  - https://github.com/Workiva/w_transport/pull/74
 CP-1137  - Update changelog for 2.0.0, w_transport  - https://github.com/Workiva/w_transport/pull/78
 CP-1141  - Add section about mocks to README, w_transport  - https://github.com/Workiva/w_transport/pull/79

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/1.0.1...CP-716_release_2.0.0

