### PR TITLE
CP-1147 Target sockjs-dart-client release 0.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
-      ref: cors
+      ref: 0.3.0
   stack_trace: "^1.4.0"
 dev_dependencies:
   ansicolor: "^0.0.9"


### PR DESCRIPTION
## Issue
- We are targeting a branch of the `sockjs-dart-client` repo

## Changes
- Target the 0.3.0 release of `sockjs-dart-client`

## Areas of Regression
- n/a

## Testing
- n/a

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 