### PR TITLE
CP-1142 Release w_transport 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.0.0
+version: 2.0.1
 description: A fluent-style, platform-agnostic library with ready to use transport classes for sending and receiving data over HTTP.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1142

JIRA and PR's included in this release: 


 CP-1147  - Target sockjs-dart-client release 0.3.0  - https://github.com/Workiva/w_transport/pull/83

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.0.0...CP-1142_release_2.0.1

