### PR TITLE
CP-1154 HTTP: support timeout threshold.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     - [Bytes](#bytes)
     - [Content-Length, Content-Type and Encoding](#content-length-content-type-and-encoding)
     - [Canceling a Request](#canceling-a-request)
+    - [Timeout Threshold](#timeout-threshold)
     - [Credentials (browser only)](#credentials-browser-only)
   - [Request Types](#request-types)
     - [JsonRequest](#jsonrequest)
@@ -292,6 +293,18 @@ Request request = new Request();
 request.get(Uri.parse('/notes/'));
 ...
 request.abort();
+```
+
+##### Timeout Threshold
+A timeout threshold can be set on any request. If the request takes longer than
+the set duration, the request will be canceled.
+
+```dart
+Request request = new Request()
+  ..uri = Uri.parse('/notes/')
+  ..timeoutThreshold = new Duration(seconds: 15);
+request.get();
+// This will throw if the request takes longer than 15 seconds.
 ```
 
 ##### Credentials (browser only)

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -63,6 +63,12 @@ abstract class BaseRequest implements FluriMixin, RequestDispatchers {
   /// sent via one of the request dispatch methods.
   String get method;
 
+  /// Amount of time to wait for the request to finish before canceling it and
+  /// considering it "timed out" (results in a [RequestException] being thrown).
+  ///
+  /// If null, no timeout threshold will be enforced.
+  Duration timeoutThreshold;
+
   /// [RequestProgress] stream for this HTTP request's upload.
   Stream<RequestProgress> get uploadProgress;
 

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -31,6 +31,13 @@ abstract class Client {
   /// Whether or not the HTTP client has been closed.
   bool get isClosed;
 
+  /// Amount of time to wait for a request created by this client to finish
+  /// before canceling it and considering it "timed out" (results in a
+  /// [RequestException] being thrown).
+  ///
+  /// If null, no timeout threshold will be enforced.
+  Duration timeoutThreshold;
+
   /// Whether or not to send requests from this client with credentials. Only
   /// applicable to requests in the browser, but does not adversely affect any
   /// other platform.

--- a/lib/src/http/common/client.dart
+++ b/lib/src/http/common/client.dart
@@ -38,6 +38,13 @@ abstract class CommonClient implements Client {
   @override
   bool get isClosed => _isClosed;
 
+  /// Amount of time to wait for the request to finish before canceling it and
+  /// considering it "timed out" (results in a [RequestException] being thrown).
+  ///
+  /// If null, no timeout threshold will be enforced.
+  @override
+  Duration timeoutThreshold;
+
   /// Whether or not to send the request with credentials. Only applicable to
   /// requests in the browser, but does not adversely affect any other platform.
   @override
@@ -64,7 +71,9 @@ abstract class CommonClient implements Client {
   /// adding headers that are set on this client and setting the withCredentials
   /// flag.
   void registerAndDecorateRequest(BaseRequest request) {
-    request.headers = _headers;
+    request
+      ..headers = _headers
+      ..timeoutThreshold = timeoutThreshold;
     if (withCredentials == true) {
       request.withCredentials = true;
     }

--- a/lib/src/http/request_exception.dart
+++ b/lib/src/http/request_exception.dart
@@ -20,6 +20,9 @@ import 'package:w_transport/src/http/response.dart';
 /// An exception that is raised when a response to a request returns with
 /// an unsuccessful status code.
 class RequestException implements Exception {
+  /// Original error, if any.
+  final error;
+
   /// HTTP method.
   final String method;
 
@@ -32,13 +35,10 @@ class RequestException implements Exception {
   /// URL of the attempted/unsuccessful request.
   final Uri uri;
 
-  /// Original error, if any.
-  var _error;
-
   /// Construct a new instance of [WHttpException] using information from
   /// an HTTP request and response.
   RequestException(this.method, this.uri, this.request, this.response,
-      [this._error]);
+      [this.error]);
 
   /// Descriptive error message that includes the request method & URL and the response status.
   String get message {
@@ -47,8 +47,8 @@ class RequestException implements Exception {
       msg += ' ${response.status} ${response.statusText}';
     }
     msg += ' $uri';
-    if (_error != null) {
-      msg += '\n\t$_error';
+    if (error != null) {
+      msg += '\n\t$error';
     }
     return msg;
   }

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -380,5 +380,21 @@ void _runCommonRequestSuiteFor(
       request.abort();
       expect(future, throwsA(new isInstanceOf<RequestException>()));
     });
+
+    test('timeoutThreshold does nothing if request completes in time',
+        () async {
+      BaseRequest request = requestFactory()
+        ..timeoutThreshold = new Duration(seconds: 5);
+      await request.get(uri: IntegrationPaths.pingEndpointUri);
+    });
+
+    test('timeoutThreshold cancels the request if exceeded', () async {
+      BaseRequest request = requestFactory()
+        ..timeoutThreshold = new Duration(milliseconds: 250);
+      expect(request.get(uri: IntegrationPaths.timeoutEndpointUri),
+          throwsA(predicate((error) {
+        return error is RequestException && error.error is TimeoutException;
+      })));
+    });
   });
 }

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -127,6 +127,22 @@ void main() {
         var headers = {'x-custom1': 'value', 'x-custom2': 'value2'};
         Client client = new Client()..headers = headers;
         expect(client.headers, equals(headers));
+        expect(client.newFormRequest().headers, equals(headers));
+        expect(client.newJsonRequest().headers, equals(headers));
+        expect(client.newMultipartRequest().headers, equals(headers));
+        expect(client.newRequest().headers, equals(headers));
+        expect(client.newStreamedRequest().headers, equals(headers));
+      });
+
+      test('timeoutThreshold', () async {
+        Duration tt = new Duration(seconds: 1);
+        Client client = new Client()..timeoutThreshold = tt;
+        expect(client.timeoutThreshold, equals(tt));
+        expect(client.newFormRequest().timeoutThreshold, equals(tt));
+        expect(client.newJsonRequest().timeoutThreshold, equals(tt));
+        expect(client.newMultipartRequest().timeoutThreshold, equals(tt));
+        expect(client.newRequest().timeoutThreshold, equals(tt));
+        expect(client.newStreamedRequest().timeoutThreshold, equals(tt));
       });
 
       test('close()', () async {

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -271,6 +271,35 @@ void _runCommonRequestSuiteFor(
       await first;
     });
 
+    test('timeoutThreshold is not enforced if not set', () async {
+      Uri uri = Uri.parse('/test');
+      BaseRequest request = requestFactory();
+      Future future = request.get(uri: uri);
+      await new Future.delayed(new Duration(milliseconds: 250));
+      MockTransports.http.completeRequest(request);
+      await future;
+    });
+
+    test('timeoutThreshold does nothing if request completes in time',
+        () async {
+      Uri uri = Uri.parse('/test');
+      BaseRequest request = requestFactory()
+        ..timeoutThreshold = new Duration(milliseconds: 500);
+      Future future = request.get(uri: uri);
+      await new Future.delayed(new Duration(milliseconds: 250));
+      MockTransports.http.completeRequest(request);
+      await future;
+    });
+
+    test('timeoutThreshold cancels the request if exceeded', () async {
+      Uri uri = Uri.parse('/test');
+      BaseRequest request = requestFactory()
+        ..timeoutThreshold = new Duration(milliseconds: 500);
+      expect(request.get(uri: uri), throwsA(predicate((error) {
+        return error is RequestException && error.error is TimeoutException;
+      })));
+    });
+
     test('configure() should throw if called after request has been sent',
         () async {
       Uri uri = Uri.parse('/test');


### PR DESCRIPTION
## Issue
- Missing support for setting an explicit timeout threshold on HTTP requests.

## Changes
**Source:**
- `BaseRequest` now includes a `timeoutThreshold` property of type `Duration`
  - `timeoutThreshold = null` means no threshold is enforced
- Prior to sending a request, a timer will be set that will cancel the request if it doesn't complete within the threshold
- `Client` now includes a `timeoutThreshold` property that serves as the default value for all requests created from a `Client` instance
- Example error message from a request timeout:

    ```
    RequestException: GET /test
        TimeoutException after 0:00:00.500000: Request took too long to complete.
    ```

**Tests:**
- Unit tests and integration tests added to ensure that
  - timeout threshold is not enforced if not set
  - timeout threshold does nothing if request completes in time
  - timeout threshold cancels the request if it doesn't complete in time

## Areas of Regression
- Normal request flow (integration tests should cover)

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 