### PR TITLE
CP-1177 Support request, response interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,21 @@
 
 ## 2.1.0
 
-**Features:**
+### Features
 
 - Added a `baseUri` field to `Client` that all requests from the client will
   inherit.
+
+- All request classes now support a timeout threshold via the `timeoutTreshold`
+  field. This was also added to the `Client` class and all requests created from
+  a client will inherit this value.
+
+- Request and response interception is now supported. This can be done directly
+  on a request instance, but more usefully through a `Client` instance. See
+  ["request & response interception"](README.md#request--response-interception)
+  and ["intercepting requests & responses from a client"](README.md#intercepting-requests--responses-from-a-client)
+  in the README.
+
 
 ## 2.0.0
 
@@ -79,6 +90,7 @@ This has been greatly improved by switching to two different response classes:
 - `StreamedResponse` - response meta data available synchronously, body
   available as a stream of bytes
 
+
 ## 1.0.1
 **Bug Fixes:**
 
@@ -89,6 +101,7 @@ This has been greatly improved by switching to two different response classes:
   upon assignment, allowing intermediate data assignments.
 - Verify w_transport configuration has been set before constructing a `WHttp`
   instance.
+
 
 ## 1.0.0
 - Initial version of w_transport: a fluent-style, platform-agnostic library with

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -14,6 +14,7 @@
 
 library w_transport.src.http.client;
 
+import 'package:w_transport/src/http/http_interceptor.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
 
@@ -47,6 +48,8 @@ abstract class Client {
   /// applicable to requests in the browser, but does not adversely affect any
   /// other platform.
   bool withCredentials;
+
+  void addInterceptor(HttpInterceptor interceptor);
 
   /// Closes the client, cancelling or closing any outstanding connections.
   void close();

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -1,0 +1,87 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.src.http.http_interceptor;
+
+import 'dart:async';
+
+import 'package:w_transport/w_transport.dart';
+
+/// Base class representing an interceptor that can be registered with a
+/// [Client] instance to intercept HTTP requests and responses in order to
+/// modify or augment them prior to dispatch and delivery, respectively.
+class HttpInterceptor {
+  Future<RequestPayload> interceptRequest(RequestPayload payload) async {
+    return payload;
+  }
+
+  Future<ResponsePayload> interceptResponse(ResponsePayload payload) async {
+    return payload;
+  }
+}
+
+/// Representation of a request payload. Currently only contains the request
+/// instance, but may contain more contextual information in the future.
+///
+/// The [request] instance can be type checked and cast to [FormRequest],
+/// [JsonRequest], [MultipartRequest], [Request], or [StreamedRequest] as
+/// necessary.
+class RequestPayload {
+  final BaseRequest request;
+  RequestPayload(BaseRequest this.request);
+}
+
+/// Representation of a response payload. Contains the [response] instance, the
+/// finalized [request] that initiated the response, and an [exception] if one
+/// occurred.
+///
+/// The [response] instance can be type checked and cast to [Response] or
+/// [StreamedResponse] as necessary.
+class ResponsePayload {
+  final FinalizedRequest request;
+  BaseResponse response;
+  final RequestException exception;
+  ResponsePayload(FinalizedRequest this.request, BaseResponse this.response,
+      [RequestException this.exception]);
+}
+
+/// Representation of a pathway on which..
+///
+/// 1. payloads of a certain type travel, and
+/// 2. a set of interceptors can be attached.
+///
+/// As a payload travels a pathway, each interceptor (in the order they were
+/// attached) has the opportunity to process, evaluate, modify, augment, or
+/// replace the payload. This interception can be synchronous or asynchronous -
+/// the pathway ensures that each interceptor is applied serially.
+///
+/// Simply put, a pathway accepts a payload and asynchronously returns a
+/// payload.
+class Pathway<T> {
+  List<Function> _interceptors = [];
+
+  bool get hasInterceptors => _interceptors.isNotEmpty;
+
+  void addInterceptor(/* T | Future<T> */ interceptor(T payload)) {
+    _interceptors.add(interceptor);
+  }
+
+  Future<T> process(T payload) async {
+    for (var interceptor in _interceptors) {
+      var result = interceptor(payload);
+      payload = (result is Future) ? await result : result;
+    }
+    return payload;
+  }
+}

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -91,9 +91,13 @@ library w_transport.w_http;
 
 export 'package:w_transport/src/http/base_request.dart' show BaseRequest;
 export 'package:w_transport/src/http/client.dart' show Client;
+export 'package:w_transport/src/http/finalized_request.dart'
+    show FinalizedRequest;
 export 'package:w_transport/src/http/http.dart' show Http;
 export 'package:w_transport/src/http/http_body.dart'
     show HttpBody, StreamedHttpBody;
+export 'package:w_transport/src/http/http_interceptor.dart'
+    show HttpInterceptor, RequestPayload, ResponsePayload;
 export 'package:w_transport/src/http/multipart_file.dart' show MultipartFile;
 export 'package:w_transport/src/http/request_exception.dart'
     show RequestException;
@@ -102,7 +106,7 @@ export 'package:w_transport/src/http/request_progress.dart'
 export 'package:w_transport/src/http/requests.dart'
     show FormRequest, JsonRequest, MultipartRequest, Request, StreamedRequest;
 export 'package:w_transport/src/http/response.dart'
-    show Response, StreamedResponse;
+    show BaseResponse, Response, StreamedResponse;
 
 export 'package:w_transport/src/web_socket/w_socket.dart' show WSocket;
 export 'package:w_transport/src/web_socket/w_socket_close_event.dart'

--- a/test/unit/http/http_interceptor_test.dart
+++ b/test/unit/http/http_interceptor_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm || browser')
+library w_transport.test.unit.http.http_interceptor_test;
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_mock.dart';
+
+import '../../naming.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..testType = testTypeUnit
+    ..topic = topicHttp;
+
+  group(naming.toString(), () {
+    group('HttpInterceptor', () {
+      setUp(() {
+        configureWTransportForTest();
+        MockTransports.reset();
+      });
+
+      test('default implementations should not modify the payloads', () async {
+        var req = new Request()..uri = Uri.parse('/test');
+        var body =
+            new HttpBody.fromString(new MediaType('text', 'plain'), 'body');
+        var finalizedReq =
+            new FinalizedRequest('GET', req.uri, {}, body, false);
+        var resp = new MockResponse.ok();
+        var reqPayload = new RequestPayload(new Request());
+        var respPayload = new ResponsePayload(finalizedReq, resp);
+
+        var interceptor = new HttpInterceptor();
+        expect(
+            identical(
+                reqPayload, await interceptor.interceptRequest(reqPayload)),
+            isTrue);
+        expect(
+            identical(
+                respPayload, await interceptor.interceptResponse(respPayload)),
+            isTrue);
+      });
+    });
+  });
+}

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -20,6 +20,7 @@ import 'package:test/test.dart';
 import 'http/client_test.dart' as http_client_test;
 import 'http/form_request_test.dart' as http_form_request_test;
 import 'http/http_body_test.dart' as http_body_test;
+import 'http/http_interceptor_test.dart' as http_interceptor_test;
 import 'http/http_static_test.dart' as http_static_test;
 import 'http/json_request_test.dart' as http_json_request_test;
 import 'http/multipart_file_test.dart' as http_multipart_file_test;
@@ -42,6 +43,7 @@ import 'ws/w_socket_test.dart' as ws_w_socket_test;
 void main() {
   http_client_test.main();
   http_body_test.main();
+  http_interceptor_test.main();
   http_form_request_test.main();
   http_json_request_test.main();
   http_multipart_file_test.main();


### PR DESCRIPTION
## Issue
- To support more advanced functionality in an http `Client`, we need a way to intercept requests right before dispatch and responses right before delivery.

## Changes
**Source:**
- Add a `requestInterceptor` field to `BaseRequest` that, if set, will be applied right before dispatching the request.
  - Signature:

    ```
    Future<Null> RequestInterceptor(BaseRequest request)
    ```

- Add a `responseInterceptor` field to `BaseRequest` that, if set, will be applied right after the response is received but before it's delivered to the caller.
  - Signature:
    
    ```
    Future<BaseResponse> ResponseInterceptor(
        FinalizedRequest request, BaseResponse response,
        [RequestException error])
    ```

- Add a `Pathway<T>` class that defines a path on which a payload of type `T` travels and on which interceptors can be registered.

- Add an `HttpInterceptor` class as a way to encapsulate both request and response interception in a single class (with default implementations that simply return the given payload sans-modification)

- Add `RequestPayload` and `ResponsePayload` classes to encapsulate the information needed by request and response interceptors.

- Add an `addInterceptor()` method to `Client` to allow the registration of multiple interceptors that will be applied serially to every request created from the `Client` instance as well as their responses (thus accomplishing the original goal)

**Tests:**
- Unit tests added to cover all of the added functionality.

## Areas of Regression
- Requests when `requestInterceptor` and/or `responseInterceptor` are not set (should be covered by the request tests that already exist).

## Testing
- CI passes
- Examples function as expected

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 