### PR TITLE
CP-1179 Add a `baseUri` field to `Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.1.0
+
+**Features:**
+
+- Added a `baseUri` field to `Client` that all requests from the client will
+  inherit.
+
 ## 2.0.0
 
 > The 2.0.0 release is a major breaking release. While many of the patterns from

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -26,6 +26,9 @@ import 'package:w_transport/src/platform_adapter.dart';
 abstract class Client {
   factory Client() => PlatformAdapter.retrieve().newClient();
 
+  /// A base URI that all requests from this client should inherit.
+  Uri baseUri;
+
   /// Get and set request headers that will be applied to all requests created
   /// by this HTTP client.
   Map<String, String> headers;

--- a/lib/src/http/common/client.dart
+++ b/lib/src/http/common/client.dart
@@ -21,6 +21,23 @@ import 'package:w_transport/src/http/client.dart';
 
 /// HTTP client logic that can be shared across platforms.
 abstract class CommonClient implements Client {
+  /// A base URI that all requests created by this client should inherit.
+  @override
+  Uri baseUri;
+
+  /// Amount of time to wait for the request to finish before canceling it and
+  /// considering it "timed out" (results in a [RequestException] being thrown).
+  ///
+  /// If null, no timeout threshold will be enforced.
+  @override
+  Duration timeoutThreshold;
+
+  /// Whether or not to send the request with credentials. Only applicable to
+  /// requests in the browser, but does not adversely affect any other platform.
+  @override
+  bool withCredentials;
+
+  /// Headers to be inherited by all requests created from this client.
   CaseInsensitiveMap<String> _headers = new CaseInsensitiveMap();
 
   /// Whether or not this HTTP client has been closed.
@@ -37,18 +54,6 @@ abstract class CommonClient implements Client {
   /// Whether or not this HTTP client has been closed.
   @override
   bool get isClosed => _isClosed;
-
-  /// Amount of time to wait for the request to finish before canceling it and
-  /// considering it "timed out" (results in a [RequestException] being thrown).
-  ///
-  /// If null, no timeout threshold will be enforced.
-  @override
-  Duration timeoutThreshold;
-
-  /// Whether or not to send the request with credentials. Only applicable to
-  /// requests in the browser, but does not adversely affect any other platform.
-  @override
-  bool withCredentials;
 
   /// Closes the client, canceling or closing any outstanding connections.
   @override
@@ -72,6 +77,7 @@ abstract class CommonClient implements Client {
   /// flag.
   void registerAndDecorateRequest(BaseRequest request) {
     request
+      ..uri = baseUri
       ..headers = _headers
       ..timeoutThreshold = timeoutThreshold;
     if (withCredentials == true) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_transport
 dependencies:
-  fluri: "^1.0.0"
+  fluri: "^1.1.0"
   http_parser: "^1.0.0"
   mime: "^0.9.3"
   sockjs_client:


### PR DESCRIPTION
Resolves #91.

## Issue
- #91 `Client` should have a `baseUri` that all requests inherit

## Changes
**Source:**
- Bumped version of Fluri to be at least 1.1.0 since [new URI methods](https://github.com/Workiva/fluri/blob/master/CHANGELOG.md#110) were added with the intent that they would be used to build off of a base URI.
- Add `baseUri` to `Client` abstract and `CommonClient` implementation
- Requests created by a client now inherit this `baseUri`

**Tests:**
- Unit test added to test that each type of request properly inherits the base URI

## Areas of Regression
- n/a

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 