### PR TITLE
CP-1186 Automatic retrying for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@
   and ["intercepting requests & responses from a client"](README.md#intercepting-requests--responses-from-a-client)
   in the README.
 
+- All request classes and the `Client` class now include an API for automatic
+  retrying via the `autoRetry` field. See ["automatic request retrying"](README.md#automatic-request-retrying)
+  in the README.
+
 ### Bug Fixes
 
 - Headers passed into a request's dispatch method (ex: `.get(headers: {...})`)
   are now merged with any existing headers on the request (previously they were
   being ignored).
+
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     - [Content-Length, Content-Type and Encoding](#content-length-content-type-and-encoding)
     - [Timeout Threshold](#timeout-threshold)
     - [Request & Response Interception](#request--response-interception)
+    - [Automatic Request Retrying](#automatic-request-retrying)
   - [Request Types](#request-types)
     - [JsonRequest](#jsonrequest)
     - [FormRequest](#formrequest)
@@ -351,6 +352,24 @@ request.responseInterceptor =
 > _cannot_ do this because the request creator's reference would then be
 > incorrect. For this reason, request interceptors must modify the request in
 > place.
+
+#### Automatic Request Retrying
+All of the request classes have an `autoRetry` API for enabling and configuring
+automatic request retrying. For example, the following request is configured
+to automatically retry up to 3 times for non-mutation requests that fail with
+a 500 or a 502:
+
+```dart
+Request request = new Request();
+request.autoRetry
+  ..enabled = true
+  ..maxRetries = 3
+  ..forHttpMethods = ['GET', 'HEAD', 'OPTIONS']
+  ..forStatusCodes = [500, 502];
+```
+
+See the documentation for more information.
+
 
 
 ### Request Types

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -1,0 +1,147 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.src.http.auto_retry;
+
+import 'dart:async';
+
+import 'package:w_transport/src/http/base_request.dart';
+import 'package:w_transport/src/http/finalized_request.dart';
+import 'package:w_transport/src/http/request_exception.dart';
+import 'package:w_transport/src/http/requests.dart';
+import 'package:w_transport/src/http/response.dart';
+
+typedef Future<bool> RetryTest(
+    FinalizedRequest request, BaseResponse response, bool willRetry);
+
+/// Deciding whether or not to retry a failed request is determined by the
+/// settings defined in fields in this class.
+///
+/// To turn automatic retrying on, set [enabled] to `true`.
+///
+/// The decision to retry a request or not can usually be made based solely on
+/// the request method and the response status code. For this reason, the
+/// [forHttpMethods] and [forStatusCodes] fields define a list of methods and
+/// status codes, respectively, for which retrying is acceptable.
+///
+/// There is also a [test] field for a custom test function that can make the
+/// decision based on more information.
+///
+/// If [test] is defined (not null), then it is called with:
+///
+/// 1. A [FinalizedRequest] instance,
+/// 2. A [BaseResponse] instance, and
+/// 3. A `willRetry` boolean representing whether or not the HTTP method and
+///    status code checks passed.
+///
+/// The [test] then makes the final decision (retry or no retry) by
+/// asynchronously returning a boolean.
+///
+/// If, however, [test] is null, then the decision is made based solely on
+/// whether or not the HTTP method and status code checks passed.
+class AutoRetryConfig {
+  /// Whether or not automatic retrying is enabled.
+  bool enabled = false;
+
+  /// The set of HTTP methods that are considered eligible for retrying.
+  ///
+  /// By default, non-mutable HTTP methods included here (GET, HEAD, OPTIONS).
+  /// This is to avoid issues with requests that may not be idempotent.
+  List<String> forHttpMethods = ['GET', 'HEAD', 'OPTIONS'];
+
+  /// The set of status codes that are considered eligible for retrying.
+  ///
+  /// By default, 500, 502, 503, and 504 are included here because they
+  /// represent server errors that may be transient.
+  List<int> forStatusCodes = [500, 502, 503, 504];
+
+  /// Maximum number of retries to attempt. This excludes the original request.
+  /// For example, a request with `maxRetries = 2` will produce up to 3 requests
+  /// total - the first request and 2 retries.
+  int maxRetries = 2;
+
+  /// A custom [test] function that decides whether or not a request should be
+  /// retried. It will be called with:
+  ///
+  /// 1. A [FinalizedRequest] instance,
+  /// 2. A [BaseResponse] instance, and
+  /// 3. A `willRetry` boolean representing whether or not the HTTP method and
+  ///    status code checks passed.
+  ///
+  /// The [test] then makes the final decision (retry or no retry) by
+  /// asynchronously returning a boolean.
+  ///
+  ///     // Example of auto retry with a custom check for a CSRF failure that
+  ///     // can only be identified by a message in the response body.
+  ///
+  ///     var request = new Request();
+  ///     request.autoRetry
+  ///       ..enabled = true
+  ///       ..test = (FinalizedRequest request, BaseResponse response,
+  ///           bool willRetry) async {
+  ///         // Check for a special case (CSRF failure) by reading the body.
+  ///         // If it's determined that it is a CSRF failure, return `true`
+  ///         // to indicate the request should be retried.
+  ///         if (response is Response &&
+  ///             response.status == 403 &&
+  ///             response.body.asString().contains('CSRF failure')) return true;
+  ///
+  ///         // Otherwise, return whatever the value of `willRetry` is.
+  ///         // In other words, we defer to the HTTP method & status code checks.
+  ///         return willRetry;
+  ///       };
+  RetryTest test;
+}
+
+/// Representation of a single request's auto-retry configuration along with
+/// contextual information about the retries. This extends [AutoRetryConfig] and
+/// thus inherits the same configuration fields.
+///
+/// The additional fields include information like the number of attempts made,
+/// previous failures, and whether or not request retrying is supported for the
+/// associated [BaseRequest] instance.
+class RequestAutoRetry extends AutoRetryConfig {
+  /// Get a list of the [RequestException] instances for each failed attempt.
+  List<RequestException> failures = [];
+
+  /// The number of attempts for this request, including the original request.
+  /// This will be incremented each time an attempt is sent.
+  int numAttempts = 0;
+
+  /// The _original_ request instance with which this information is associated.
+  BaseRequest _request;
+
+  /// Construct an [RequestAutoRetry] instance to be associated with [request].
+  RequestAutoRetry(BaseRequest request) : _request = request;
+
+  /// Whether or not the number of attempts has exceeded the maximum.
+  bool get didExceedMaxNumberOfAttempts => numAttempts > maxRetries;
+
+  /// Whether or not retrying is supported for this request instance. This
+  /// depends on the type of request (Form, Multipart, Streamed, etc) and the
+  /// type of data in the request body.
+  ///
+  /// [StreamedRequest]s cannot be retried because the streamed request body can
+  /// only be read once.
+  ///
+  /// [MultipartRequest]s can be retried only if all of the parts are `String`
+  /// field/value pairs. If the request contains files (byte streams or blobs),
+  /// it cannot be retried because they cannot be read more than once.
+  bool get supported {
+    if (_request is StreamedRequest) return false;
+    if (_request is MultipartRequest &&
+        (_request as MultipartRequest).files.isNotEmpty) return false;
+    return true;
+  }
+}

--- a/lib/src/http/browser/client.dart
+++ b/lib/src/http/browser/client.dart
@@ -30,7 +30,7 @@ class BrowserClient extends CommonClient implements Client {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new BrowserFormRequest();
+    FormRequest request = new BrowserFormRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -40,7 +40,7 @@ class BrowserClient extends CommonClient implements Client {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new BrowserJsonRequest();
+    JsonRequest request = new BrowserJsonRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -50,7 +50,7 @@ class BrowserClient extends CommonClient implements Client {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new BrowserMultipartRequest();
+    MultipartRequest request = new BrowserMultipartRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -60,7 +60,7 @@ class BrowserClient extends CommonClient implements Client {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new BrowserPlainTextRequest();
+    Request request = new BrowserPlainTextRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -70,7 +70,7 @@ class BrowserClient extends CommonClient implements Client {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new BrowserStreamedRequest();
+    StreamedRequest request = new BrowserStreamedRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -23,6 +23,7 @@ import 'package:http_parser/http_parser.dart'
 
 import 'package:w_transport/src/http/browser/form_data_body.dart';
 import 'package:w_transport/src/http/browser/request_mixin.dart';
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/multipart_file.dart';
 import 'package:w_transport/src/http/requests.dart';
@@ -32,7 +33,8 @@ class BrowserMultipartRequest extends CommonRequest
     with BrowserRequestMixin
     implements MultipartRequest {
   BrowserMultipartRequest() : super();
-  BrowserMultipartRequest.withClient(client) : super.withClient(client);
+  BrowserMultipartRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
 
   Map<String, String> _fields = {};
 
@@ -59,8 +61,25 @@ class BrowserMultipartRequest extends CommonRequest
   Map<String, String> get fields =>
       isSent ? new Map.unmodifiable(_fields) : _fields;
 
+  set fields(Map<String, String> fields) {
+    verifyUnsent();
+    _fields = new Map.from(fields);
+  }
+
   Map<String, dynamic> get files =>
       isSent ? new Map.unmodifiable(_files) : _files;
+
+  set files(Map<String, dynamic> files) {
+    verifyUnsent();
+    _files = new Map.from(files);
+  }
+
+  @override
+  MultipartRequest clone() {
+    return (super.clone() as MultipartRequest)
+      ..fields = fields
+      ..files = files;
+  }
 
   @override
   Map<String, String> finalizeHeaders() {

--- a/lib/src/http/browser/requests.dart
+++ b/lib/src/http/browser/requests.dart
@@ -15,6 +15,7 @@
 library w_transport.src.http.browser.requests;
 
 import 'package:w_transport/src/http/browser/request_mixin.dart';
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';
 import 'package:w_transport/src/http/common/json_request.dart';
 import 'package:w_transport/src/http/common/plain_text_request.dart';
@@ -23,12 +24,28 @@ import 'package:w_transport/src/http/common/streamed_request.dart';
 export 'package:w_transport/src/http/browser/multipart_request.dart'
     show BrowserMultipartRequest;
 
-class BrowserFormRequest extends CommonFormRequest with BrowserRequestMixin {}
+class BrowserFormRequest extends CommonFormRequest with BrowserRequestMixin {
+  BrowserFormRequest() : super();
+  BrowserFormRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
-class BrowserJsonRequest extends CommonJsonRequest with BrowserRequestMixin {}
+class BrowserJsonRequest extends CommonJsonRequest with BrowserRequestMixin {
+  BrowserJsonRequest() : super();
+  BrowserJsonRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
 class BrowserPlainTextRequest extends CommonPlainTextRequest
-    with BrowserRequestMixin {}
+    with BrowserRequestMixin {
+  BrowserPlainTextRequest() : super();
+  BrowserPlainTextRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
 class BrowserStreamedRequest extends CommonStreamedRequest
-    with BrowserRequestMixin {}
+    with BrowserRequestMixin {
+  BrowserStreamedRequest() : super();
+  BrowserStreamedRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -14,6 +14,7 @@
 
 library w_transport.src.http.client;
 
+import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/src/http/http_interceptor.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
@@ -26,6 +27,15 @@ import 'package:w_transport/src/platform_adapter.dart';
 /// network connections between requests that share a client.
 abstract class Client {
   factory Client() => PlatformAdapter.retrieve().newClient();
+
+  /// Configuration of automatic request retrying for failed requests. Use this
+  /// object to enable or disable automatic retrying, configure the criteria
+  /// that determines whether or not a request should be retried, as well as the
+  /// number of retries to attempt.
+  ///
+  /// Every request created by this client will inherit this automatic retry
+  /// configuration.
+  AutoRetryConfig autoRetry;
 
   /// A base URI that all requests from this client should inherit.
   Uri baseUri;

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -19,6 +19,7 @@ import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/requests.dart';
@@ -26,7 +27,8 @@ import 'package:w_transport/src/http/utils.dart' as http_utils;
 
 abstract class CommonFormRequest extends CommonRequest implements FormRequest {
   CommonFormRequest() : super();
-  CommonFormRequest.withClient(client) : super.withClient(client);
+  CommonFormRequest.fromClient(Client wTransportClient, client)
+      : super.fromClient(wTransportClient, client);
 
   Map<String, String> _fields = {};
 
@@ -50,6 +52,11 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
 
   Uint8List get _encodedQuery =>
       encoding.encode(http_utils.mapToQuery(fields, encoding: encoding));
+
+  @override
+  FormRequest clone() {
+    return (super.clone() as FormRequest)..fields = fields;
+  }
 
   @override
   Future<HttpBody> finalizeBody([body]) async {

--- a/lib/src/http/common/json_request.dart
+++ b/lib/src/http/common/json_request.dart
@@ -20,13 +20,15 @@ import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/requests.dart';
 
 abstract class CommonJsonRequest extends CommonRequest implements JsonRequest {
   CommonJsonRequest() : super();
-  CommonJsonRequest.withClient(client) : super.withClient(client);
+  CommonJsonRequest.fromClient(Client wTransportClient, client)
+      : super.fromClient(wTransportClient, client);
 
   String _encodedJson;
   dynamic _source;
@@ -56,6 +58,11 @@ abstract class CommonJsonRequest extends CommonRequest implements JsonRequest {
   Uint8List get _bytes => _encodedJson != null
       ? encoding.encode(_encodedJson)
       : new Uint8List.fromList([]);
+
+  @override
+  JsonRequest clone() {
+    return (super.clone() as JsonRequest)..body = _source;
+  }
 
   @override
   Future<HttpBody> finalizeBody([body]) async {

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -20,6 +20,7 @@ import 'dart:math';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/multipart_file.dart';
@@ -71,7 +72,8 @@ abstract class CommonMultipartRequest extends CommonRequest
   Map<String, dynamic> _files = {};
 
   CommonMultipartRequest() : super();
-  CommonMultipartRequest.withClient(client) : super.withClient(client);
+  CommonMultipartRequest.fromClient(Client wTransportClient, client)
+      : super.fromClient(wTransportClient, client);
 
   String get boundary {
     if (_boundary == null) {
@@ -123,8 +125,25 @@ abstract class CommonMultipartRequest extends CommonRequest
   Map<String, String> get fields =>
       isSent ? new Map.unmodifiable(_fields) : _fields;
 
+  set fields(Map<String, String> fields) {
+    verifyUnsent();
+    _fields = new Map.from(fields);
+  }
+
   Map<String, dynamic> get files =>
       isSent ? new Map.unmodifiable(_files) : _files;
+
+  set files(Map<String, dynamic> files) {
+    verifyUnsent();
+    _files = new Map.from(files);
+  }
+
+  @override
+  MultipartRequest clone() {
+    return (super.clone() as MultipartRequest)
+      ..fields = fields
+      ..files = files;
+  }
 
   @override
   Map<String, String> finalizeHeaders() {

--- a/lib/src/http/common/plain_text_request.dart
+++ b/lib/src/http/common/plain_text_request.dart
@@ -19,13 +19,15 @@ import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/requests.dart';
 
 abstract class CommonPlainTextRequest extends CommonRequest implements Request {
   CommonPlainTextRequest() : super();
-  CommonPlainTextRequest.withClient(client) : super.withClient(client);
+  CommonPlainTextRequest.fromClient(Client wTransportClient, client)
+      : super.fromClient(wTransportClient, client);
 
   String _body;
 
@@ -67,6 +69,17 @@ abstract class CommonPlainTextRequest extends CommonRequest implements Request {
   @override
   MediaType get defaultContentType =>
       new MediaType('text', 'plain', {'charset': encoding.name});
+
+  @override
+  Request clone() {
+    Request requestClone = super.clone() as Request;
+    if (_body != null) {
+      requestClone.body = body;
+    } else if (_bodyBytes != null) {
+      requestClone.bodyBytes = bodyBytes;
+    }
+    return requestClone;
+  }
 
   @override
   Future<HttpBody> finalizeBody([body]) async {

--- a/lib/src/http/common/streamed_request.dart
+++ b/lib/src/http/common/streamed_request.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/request.dart';
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/requests.dart';
@@ -25,7 +26,8 @@ import 'package:w_transport/src/http/requests.dart';
 abstract class CommonStreamedRequest extends CommonRequest
     implements StreamedRequest {
   CommonStreamedRequest() : super();
-  CommonStreamedRequest.withClient(client) : super.withClient(client);
+  CommonStreamedRequest.fromClient(Client wTransportClient, client)
+      : super.fromClient(wTransportClient, client);
 
   Stream<List<int>> _body;
 
@@ -55,6 +57,13 @@ abstract class CommonStreamedRequest extends CommonRequest
   @override
   MediaType get defaultContentType =>
       new MediaType('text', 'plain', {'charset': encoding.name});
+
+  @override
+  StreamedRequest clone() {
+    throw new UnsupportedError(
+        'StreamedRequests cannot be cloned because the streamed body can only '
+        'be read once.');
+  }
 
   @override
   Future<StreamedHttpBody> finalizeBody([body]) async {

--- a/lib/src/http/mock/client.dart
+++ b/lib/src/http/mock/client.dart
@@ -29,7 +29,7 @@ class MockClient extends CommonClient implements Client {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new MockFormRequest();
+    FormRequest request = new MockFormRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -39,7 +39,7 @@ class MockClient extends CommonClient implements Client {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new MockJsonRequest();
+    JsonRequest request = new MockJsonRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -49,7 +49,7 @@ class MockClient extends CommonClient implements Client {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new MockMultipartRequest();
+    MultipartRequest request = new MockMultipartRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -59,7 +59,7 @@ class MockClient extends CommonClient implements Client {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new MockPlainTextRequest();
+    Request request = new MockPlainTextRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -69,7 +69,7 @@ class MockClient extends CommonClient implements Client {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new MockStreamedRequest();
+    StreamedRequest request = new MockStreamedRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/mock/requests.dart
+++ b/lib/src/http/mock/requests.dart
@@ -14,6 +14,7 @@
 
 library w_transport.src.http.mock.requests;
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';
 import 'package:w_transport/src/http/common/json_request.dart';
 import 'package:w_transport/src/http/common/multipart_request.dart';
@@ -21,14 +22,34 @@ import 'package:w_transport/src/http/common/plain_text_request.dart';
 import 'package:w_transport/src/http/common/streamed_request.dart';
 import 'package:w_transport/src/http/mock/request_mixin.dart';
 
-class MockFormRequest extends CommonFormRequest with MockRequestMixin {}
+class MockFormRequest extends CommonFormRequest with MockRequestMixin {
+  MockFormRequest() : super();
+  MockFormRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
-class MockJsonRequest extends CommonJsonRequest with MockRequestMixin {}
+class MockJsonRequest extends CommonJsonRequest with MockRequestMixin {
+  MockJsonRequest() : super();
+  MockJsonRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
 class MockMultipartRequest extends CommonMultipartRequest
-    with MockRequestMixin {}
+    with MockRequestMixin {
+  MockMultipartRequest() : super();
+  MockMultipartRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
 class MockPlainTextRequest extends CommonPlainTextRequest
-    with MockRequestMixin {}
+    with MockRequestMixin {
+  MockPlainTextRequest() : super();
+  MockPlainTextRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}
 
-class MockStreamedRequest extends CommonStreamedRequest with MockRequestMixin {}
+class MockStreamedRequest extends CommonStreamedRequest with MockRequestMixin {
+  MockStreamedRequest() : super();
+  MockStreamedRequest.fromClient(Client wTransportClient)
+      : super.fromClient(wTransportClient, null);
+}

--- a/lib/src/http/requests.dart
+++ b/lib/src/http/requests.dart
@@ -55,6 +55,10 @@ abstract class FormRequest extends BaseRequest {
   set fields(Map<String, String> fields);
 
   factory FormRequest() => PlatformAdapter.retrieve().newFormRequest();
+
+  /// Returns an clone of this request.
+  @override
+  FormRequest clone();
 }
 
 /// Representation of an HTTP request where the request body is a json-encodable
@@ -89,6 +93,10 @@ abstract class JsonRequest extends BaseRequest {
   set body(dynamic body);
 
   factory JsonRequest() => PlatformAdapter.retrieve().newJsonRequest();
+
+  /// Returns an clone of this request.
+  @override
+  JsonRequest clone();
 }
 
 /// Representation of an HTTP request where the request body is comprised of
@@ -96,27 +104,32 @@ abstract class JsonRequest extends BaseRequest {
 ///
 /// This request will be sent with content-type: multipart/form-data
 abstract class MultipartRequest extends BaseRequest {
-  /// Get this request's text fields as a Map of field names to their values.
+  /// Get and set this request's text fields as a Map of field names to their
+  /// values.
   ///
   /// The returned `Map` is modifiable. Fields can be set like so:
   ///
   ///     MultipartRequest request = new MultipartRequest()
   ///       ..fields['key1'] = 'value1'
   ///       ..fields['key2'] = 'value2';
-  Map<String, String> get fields;
+  Map<String, String> fields;
 
-  /// Get this request's file fields as a Map of field names to files. The value
-  /// can be a [MultipartFile] or, if in the browser, a [Blob].
+  /// Get and set this request's file fields as a Map of field names to files.
+  /// The value can be a [MultipartFile] or, if in the browser, a [Blob].
   ///
   /// The returned `Map` is modifiable. Files can be set like so:
   ///
   ///     MultipartFile file = new MultipartFile(...);
   ///     MultipartRequest request = new MultipartRequest()
   ///       ..files['file1'] = file;
-  Map<String, dynamic> get files;
+  Map<String, dynamic> files;
 
   factory MultipartRequest() =>
       PlatformAdapter.retrieve().newMultipartRequest();
+
+  /// Returns an clone of this request.
+  @override
+  MultipartRequest clone();
 }
 
 /// Representation of an HTTP request where the request body is plain-text.
@@ -144,6 +157,10 @@ abstract class Request extends BaseRequest {
   set bodyBytes(List<int> bytes);
 
   factory Request() => PlatformAdapter.retrieve().newRequest();
+
+  /// Returns an clone of this request.
+  @override
+  Request clone();
 }
 
 /// Representation of an HTTP request where the request body is sent
@@ -161,4 +178,9 @@ abstract class StreamedRequest extends BaseRequest {
   set body(Stream<List<int>> byteStream);
 
   factory StreamedRequest() => PlatformAdapter.retrieve().newStreamedRequest();
+
+  /// Cloning a StreamedRequest is not supported. This will throw an
+  /// [UnsupportedError].
+  @override
+  StreamedRequest clone();
 }

--- a/lib/src/http/vm/client.dart
+++ b/lib/src/http/vm/client.dart
@@ -41,7 +41,7 @@ class VMClient extends CommonClient implements Client {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new VMFormRequest.withClient(_client);
+    FormRequest request = new VMFormRequest.fromClient(this, _client);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -51,7 +51,7 @@ class VMClient extends CommonClient implements Client {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new VMJsonRequest.withClient(_client);
+    JsonRequest request = new VMJsonRequest.fromClient(this, _client);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -61,7 +61,7 @@ class VMClient extends CommonClient implements Client {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new VMMultipartRequest.withClient(_client);
+    MultipartRequest request = new VMMultipartRequest.fromClient(this, _client);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -71,7 +71,7 @@ class VMClient extends CommonClient implements Client {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new VMPlainTextRequest.withClient(_client);
+    Request request = new VMPlainTextRequest.fromClient(this, _client);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -81,7 +81,7 @@ class VMClient extends CommonClient implements Client {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new VMStreamedRequest.withClient(_client);
+    StreamedRequest request = new VMStreamedRequest.fromClient(this, _client);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/vm/requests.dart
+++ b/lib/src/http/vm/requests.dart
@@ -16,6 +16,7 @@ library w_transport.src.http.vm.requests;
 
 import 'dart:io';
 
+import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';
 import 'package:w_transport/src/http/common/json_request.dart';
 import 'package:w_transport/src/http/common/multipart_request.dart';
@@ -25,25 +26,30 @@ import 'package:w_transport/src/http/vm/request_mixin.dart';
 
 class VMFormRequest extends CommonFormRequest with VMRequestMixin {
   VMFormRequest() : super();
-  VMFormRequest.withClient(HttpClient client) : super.withClient(client);
+  VMFormRequest.fromClient(Client wTransportClient, HttpClient client)
+      : super.fromClient(wTransportClient, client);
 }
 
 class VMJsonRequest extends CommonJsonRequest with VMRequestMixin {
   VMJsonRequest() : super();
-  VMJsonRequest.withClient(HttpClient client) : super.withClient(client);
+  VMJsonRequest.fromClient(Client wTransportClient, HttpClient client)
+      : super.fromClient(wTransportClient, client);
 }
 
 class VMMultipartRequest extends CommonMultipartRequest with VMRequestMixin {
   VMMultipartRequest() : super();
-  VMMultipartRequest.withClient(HttpClient client) : super.withClient(client);
+  VMMultipartRequest.fromClient(Client wTransportClient, HttpClient client)
+      : super.fromClient(wTransportClient, client);
 }
 
 class VMPlainTextRequest extends CommonPlainTextRequest with VMRequestMixin {
   VMPlainTextRequest() : super();
-  VMPlainTextRequest.withClient(HttpClient client) : super.withClient(client);
+  VMPlainTextRequest.fromClient(Client wTransportClient, HttpClient client)
+      : super.fromClient(wTransportClient, client);
 }
 
 class VMStreamedRequest extends CommonStreamedRequest with VMRequestMixin {
   VMStreamedRequest() : super();
-  VMStreamedRequest.withClient(HttpClient client) : super.withClient(client);
+  VMStreamedRequest.fromClient(Client wTransportClient, HttpClient client)
+      : super.fromClient(wTransportClient, client);
 }

--- a/test/integration/http/common_request/mock_test.dart
+++ b/test/integration/http/common_request/mock_test.dart
@@ -21,6 +21,7 @@ import 'package:w_transport/w_transport_mock.dart';
 import '../../../naming.dart';
 import '../../integration_paths.dart';
 import '../mock_endpoints/404.dart';
+import '../mock_endpoints/custom.dart';
 import '../mock_endpoints/download.dart';
 import '../mock_endpoints/reflect.dart';
 import '../mock_endpoints/timeout.dart';
@@ -36,6 +37,7 @@ void main() {
     setUp(() {
       configureWTransportForTest();
       mock404Endpoint(IntegrationPaths.fourOhFourEndpointUri);
+      mockCustomEndpoint(IntegrationPaths.customEndpointUri);
       mockDownloadEndpoint(IntegrationPaths.downloadEndpointUri);
       mockReflectEndpoint(IntegrationPaths.reflectEndpointUri);
       mockTimeoutEndpoint(IntegrationPaths.timeoutEndpointUri);

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -1,0 +1,25 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.test.integration.http.mock_endpoints.custom;
+
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_mock.dart';
+
+void mockCustomEndpoint(Uri uri) {
+  MockTransports.http.when(uri, (FinalizedRequest request) async {
+    var status = int.parse(request.uri.queryParameters['status'] ?? '200');
+    return new MockResponse(status);
+  });
+}

--- a/test/integration/http/multipart_request/browser_test.dart
+++ b/test/integration/http/multipart_request/browser_test.dart
@@ -22,8 +22,6 @@ import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/w_transport_browser.dart';
 
-import 'package:w_transport/src/http/browser/multipart_request.dart';
-
 import '../../../naming.dart';
 import '../../integration_paths.dart';
 import 'suite.dart';
@@ -78,11 +76,6 @@ void main() {
         });
       });
 
-      test('withClient() ctor', () {
-        expect(new BrowserMultipartRequest.withClient(null),
-            new isInstanceOf<MultipartRequest>());
-      });
-
       test('setting content-length is unsupported', () {
         MultipartRequest request = new MultipartRequest();
         expect(() {
@@ -106,6 +99,13 @@ void main() {
 
       test('should support File', () async {
         // TODO: Write a functional test for this - not sure how to mock File/Blob class (or that it's possible)
+      });
+
+      test('clone()', () {
+        MultipartRequest orig = new MultipartRequest()
+          ..fields = {'field1': 'value1'};
+        MultipartRequest clone = orig.clone();
+        expect(clone.fields, equals(orig.fields));
       });
     });
   });

--- a/test/integration/integration_paths.dart
+++ b/test/integration/integration_paths.dart
@@ -20,6 +20,8 @@ class IntegrationPaths {
 
   // HTTP
 
+  static final Uri customEndpointUri =
+      hostUri.replace(path: '/test/http/custom');
   static final Uri downloadEndpointUri =
       hostUri.replace(path: '/test/http/download');
   static final Uri echoEndpointUri = hostUri.replace(path: '/test/http/echo');

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -120,6 +120,13 @@ void main() {
           request.encoding = LATIN1;
         }, throwsStateError);
       });
+
+      test('clone()', () {
+        var fields = {'f1': 'v1', 'f2': 'v2'};
+        FormRequest orig = new FormRequest()..fields = fields;
+        FormRequest clone = orig.clone();
+        expect(clone.fields, equals(fields));
+      });
     });
   });
 }

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -146,6 +146,15 @@ void main() {
           request.encoding = LATIN1;
         }, throwsStateError);
       });
+
+      test('clone()', () {
+        var body = [
+          {'f1': 'v1', 'f2': 'v2'}
+        ];
+        JsonRequest orig = new JsonRequest()..body = body;
+        JsonRequest clone = orig.clone();
+        expect(clone.body, equals(body));
+      });
     });
   });
 }

--- a/test/unit/http/multipart_request_test.dart
+++ b/test/unit/http/multipart_request_test.dart
@@ -57,6 +57,18 @@ void main() {
         expect(request.post(uri: Uri.parse('/test')), throwsUnsupportedError);
       });
 
+      test('body can be set incrementally or all at once', () {
+        MultipartRequest request = new MultipartRequest();
+        request.fields = {'field1': 'v1'};
+        expect(request.fields, containsPair('field1', 'v1'));
+        request.files = {'file1': 'f1'};
+        expect(request.files, containsPair('file1', 'f1'));
+        request.fields['field2'] = 'v2';
+        expect(request.fields, containsPair('field2', 'v2'));
+        request.files['file2'] = 'f2';
+        expect(request.files, containsPair('file2', 'f2'));
+      });
+
       test('body should be unmodifiable once sent', () async {
         Uri uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
@@ -69,6 +81,12 @@ void main() {
         expect(() {
           request.files['too'] = 'late';
         }, throwsUnsupportedError);
+        expect(() {
+          request.fields = {'too': 'late'};
+        }, throwsStateError);
+        expect(() {
+          request.files = {'too': 'late'};
+        }, throwsStateError);
       });
 
       test('setting encoding should be unsupported', () {
@@ -76,6 +94,18 @@ void main() {
         expect(() {
           request.encoding = UTF8;
         }, throwsUnsupportedError);
+      });
+
+      test('clone()', () {
+        var fields = {'f1': 'v1', 'f2': 'v2'};
+        MultipartRequest orig = new MultipartRequest()..fields = fields;
+        MultipartRequest clone = orig.clone();
+        expect(clone.fields, equals(fields));
+      });
+
+      test('autoRetry with files not supported', () {
+        MultipartRequest request = new MultipartRequest()..files['k'] = 'f';
+        expect(request.autoRetry.supported, isFalse);
       });
     });
   });

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -142,6 +142,18 @@ void main() {
           request.encoding = LATIN1;
         }, throwsStateError);
       });
+
+      test('clone()', () {
+        var body = 'body';
+        Request orig = new Request()..body = body;
+        Request clone = orig.clone();
+        expect(clone.body, equals(body));
+
+        var bodyBytes = UTF8.encode('bytes');
+        Request orig2 = new Request()..bodyBytes = bodyBytes;
+        Request clone2 = orig2.clone();
+        expect(clone2.bodyBytes, equals(bodyBytes));
+      });
     });
   });
 }

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -124,6 +124,15 @@ void main() {
           request.encoding = LATIN1;
         }, throwsStateError);
       });
+
+      test('clone()', () {
+        StreamedRequest request = new StreamedRequest();
+        expect(request.clone, throwsUnsupportedError);
+      });
+
+      test('autoRetry not supported', () {
+        expect(new StreamedRequest().autoRetry.supported, isFalse);
+      });
     });
   });
 }

--- a/tool/server/handlers/test/http/custom.dart
+++ b/tool/server/handlers/test/http/custom.dart
@@ -1,0 +1,34 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.tool.server.handlers.test.http.custom;
+
+import 'dart:async';
+import 'dart:io';
+
+import '../../../handler.dart';
+
+/// Return a custom response dictated by the request.
+class CustomHandler extends Handler {
+  CustomHandler() : super() {
+    enableCors();
+  }
+
+  Future get(HttpRequest request) async {
+    request.response.statusCode =
+        request.uri.queryParameters['status'] ?? HttpStatus.OK;
+    request.response.headers.contentType = request.headers.contentType;
+    setCorsHeaders(request);
+  }
+}

--- a/tool/server/handlers/test/http/echo.dart
+++ b/tool/server/handlers/test/http/echo.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.reader;
+library w_transport.tool.server.handlers.test.http.echo;
 
 import 'dart:async';
 import 'dart:io';

--- a/tool/server/handlers/test/http/routes.dart
+++ b/tool/server/handlers/test/http/routes.dart
@@ -16,6 +16,7 @@ library w_transport.tool.server.handlers.test.http.routes;
 
 import '../../../handler.dart';
 import '404_handler.dart';
+import 'custom.dart';
 import 'download.dart';
 import 'ping_handler.dart';
 import 'echo.dart';
@@ -26,6 +27,7 @@ import 'upload.dart';
 String pathPrefix = '/test/http';
 Map<String, Handler> testHttpIntegrationRoutes = {
   '$pathPrefix/404': new FourzerofourHandler(),
+  '$pathPrefix/custom': new CustomHandler(),
   '$pathPrefix/download': new DownloadHandler(),
   '$pathPrefix/echo': new EchoHandler(),
   '$pathPrefix/ping': new PingHandler(),


### PR DESCRIPTION
_Resolves #95_

## Issue
- #95 We should support configurable and transparent request retrying for failed requests

## Changes
**Source:**

### `AutoRetry`
- Add an `AutoRetry` class that encapsulates all configuration and information for a single request
  - Auto retry is opt-in (`enabled` flag must be set to `true`)
  - Max number of retries is configurable
  - Determining whether or not a request is retried is based on 3 factors (each of which has defaults and is configurable) that must each pass for the request to be eligible:
    - HTTP method
    - Response status code
    - Custom test (function that receives the finalized request and the response and returns true/false)
  - Contextual information is available (may be useful for interceptors to determine where in the lifecycle a request is, or for analytics, or for application code after a request finishes, etc)
    - # of attempts
    - list of failures
  - Auto retry is also not supported for certain requests
    - `StreamedRequest`s - can't read the stream body more than once
    - `MultipartRequest`s that contain files in the body - files' byte streams can't be read more than once

### `BaseRequest`
- Add a `clone()` method - necessary for requests
- `BaseRequest` provides a base implementation that constructs the correct request instance (taking into account whether or not it was created from a `Client`)
- Each implementing class of `BaseRequest` overrides this method, calls super to get the base clone, and then adds any request-specific details

### `CommonRequest`
- Support request retrying by testing a failed request for retry eligibility and attempting to retry a clone of the request. If the retry succeeds, that response is returned instead. If the retry eventually fails, that exception is returned.
- Switched to using a `Completer` for some of the async logic so that parts of the stack trace are not lost

### TODO
- [x] Add the `clone()` method to the browser implementation of `MultipartRequest` (currently missing)
- [x] Add a subset of the fields from the `AutoRetry` class to the `Client` class so that retry configuration can be easily applied to all requests
- [x] ~~Add some sort of logging/information when a request that would otherwise be eligible for retry is not retried because it is unsupported (see last bullet of `AutoRetry` above)~~ Deferring until https://github.com/Workiva/w_transport/issues/100
- [x] Update changelog

**Tests:**
- Unit tests added for several different variations of failed/successful requests with different auto-retry configurations.
- TODO:
  - [x] Test that request cancellation during a retry attempt functions correctly
  - [x] Add integration tests for request retrying
  - [x] Test `clone()` (base implementation and request-specific implementations)
  - [x] Test for attempting to retry streamed requests
  - [x] Test for attempting to retry multipart requests with files
  - [x] Test for requests created from a client and then cloned
  - [x] 100% coverage of added lines

## Areas of Regression
- HTTP request dispatch (should be adequately covered by tests)

## Testing
- CI passes
- Examples function as expected
- (Side note: I've created an issue to add an example that demonstrates request retrying https://github.com/Workiva/w_transport/issues/98)

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 