### PR TITLE
CP-1243 Add Response.replace() and StreamedResponse.replace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   retrying via the `autoRetry` field. See ["automatic request retrying"](README.md#automatic-request-retrying)
   in the README.
 
+- Added a `replace` method to `Response` and `StreamedResponse` to allow simple
+  creation of new responses based on another response, while changing only the
+  fields you specify. This is particularly useful during response interception.
+
 ### Bug Fixes
 
 - Headers passed into a request's dispatch method (ex: `.get(headers: {...})`)

--- a/lib/src/http/mock/response.dart
+++ b/lib/src/http/mock/response.dart
@@ -119,6 +119,20 @@ class MockResponse implements Response {
           {body, Map<String, String> headers, String statusText}) =>
       new MockResponse(502,
           body: body, headers: headers, statusText: statusText);
+
+  Response replace(
+      {List<int> bodyBytes,
+      String bodyString,
+      int status,
+      String statusText,
+      Map<String, String> headers}) {
+    return _response.replace(
+        bodyBytes: bodyBytes,
+        bodyString: bodyString,
+        status: status,
+        statusText: statusText,
+        headers: headers);
+  }
 }
 
 class MockStreamedResponse implements StreamedResponse {
@@ -211,6 +225,18 @@ class MockStreamedResponse implements StreamedResponse {
           {byteStream, Map<String, String> headers, String statusText}) =>
       new MockStreamedResponse(502,
           byteStream: byteStream, headers: headers, statusText: statusText);
+
+  StreamedResponse replace(
+      {Stream<List<int>> byteStream,
+      int status,
+      String statusText,
+      Map<String, String> headers}) {
+    return _response.replace(
+        byteStream: byteStream,
+        status: status,
+        statusText: statusText,
+        headers: headers);
+  }
 }
 
 String _mapStatusToText(int status) {

--- a/test/unit/http/response_test.dart
+++ b/test/unit/http/response_test.dart
@@ -38,6 +38,39 @@ void main() {
         Response response = new Response.fromString(200, 'OK', {}, 'body');
         expect(response.body.asString(), equals('body'));
       });
+
+      test('replace', () {
+        Response response = new Response.fromString(200, 'OK', {}, 'body');
+        Response response2 = response.replace(status: 301);
+        expect(response2.status, equals(301));
+        expect(response2.statusText, equals('OK'));
+        expect(response2.headers, equals({}));
+        expect(response2.body.asString(), equals('body'));
+
+        Response response3 = response.replace(statusText: 'Not OK');
+        expect(response3.status, equals(200));
+        expect(response3.statusText, equals('Not OK'));
+        expect(response3.headers, equals({}));
+        expect(response3.body.asString(), equals('body'));
+
+        Response response4 = response.replace(headers: {'origin': 'pluto'});
+        expect(response4.status, equals(200));
+        expect(response4.statusText, equals('OK'));
+        expect(response4.headers, equals({'origin': 'pluto'}));
+        expect(response4.body.asString(), equals('body'));
+
+        Response response5 = response.replace(bodyString: 'phrasing');
+        expect(response5.status, equals(200));
+        expect(response5.statusText, equals('OK'));
+        expect(response5.headers, equals({}));
+        expect(response5.body.asString(), equals('phrasing'));
+
+        Response response6 = response.replace(bodyBytes: [10, 134]);
+        expect(response6.status, equals(200));
+        expect(response6.statusText, equals('OK'));
+        expect(response6.headers, equals({}));
+        expect(response6.body.asBytes(), equals([10, 134]));
+      });
     });
 
     group('StreamedResponse', () {
@@ -54,6 +87,38 @@ void main() {
         StreamedResponse response = new StreamedResponse.fromByteStream(
             200, 'OK', {}, new Stream.fromIterable([bytes]));
         expect(await response.body.byteStream.toList(), equals([bytes]));
+      });
+
+      test('replace', () async {
+        List<int> bytes = [1, 2, 3, 4];
+        StreamedResponse response = new StreamedResponse.fromByteStream(
+            200, 'OK', {}, new Stream.fromIterable([bytes]));
+        StreamedResponse response2 = response.replace(status: 301);
+        expect(response2.status, equals(301));
+        expect(response2.statusText, equals('OK'));
+        expect(response2.headers, equals({}));
+        expect(response2.body, equals(response.body));
+
+        StreamedResponse response3 = response.replace(statusText: 'Not OK');
+        expect(response3.status, equals(200));
+        expect(response3.statusText, equals('Not OK'));
+        expect(response3.headers, equals({}));
+        expect(response3.body, equals(response.body));
+
+        StreamedResponse response4 =
+            response.replace(headers: {'origin': 'pluto'});
+        expect(response4.status, equals(200));
+        expect(response4.statusText, equals('OK'));
+        expect(response4.headers, equals({'origin': 'pluto'}));
+        expect(response4.body, equals(response.body));
+
+        bytes = [5, 6, 7];
+        StreamedResponse response5 =
+            response.replace(byteStream: new Stream.fromIterable([bytes]));
+        expect(response5.status, equals(200));
+        expect(response5.statusText, equals('OK'));
+        expect(response5.headers, equals({}));
+        expect(await response5.body.byteStream.toList(), equals([bytes]));
       });
     });
   });

--- a/test/unit/mocks/mock_response_test.dart
+++ b/test/unit/mocks/mock_response_test.dart
@@ -127,6 +127,12 @@ void main() {
         expect(
             response.contentType.parameters, containsPair('charset', 'utf-8'));
       });
+
+      test('replace', () {
+        Response response = new MockResponse.ok();
+        Response response2 = response.replace(status: 201);
+        expect(response2.status, equals(201));
+      });
     });
 
     group('MockStreamedResponse', () {
@@ -229,6 +235,12 @@ void main() {
         StreamedResponse response =
             new MockStreamedResponse(200, encoding: UTF8);
         expect(response.encoding, equals(UTF8));
+      });
+
+      test('replace', () {
+        StreamedResponse response = new MockStreamedResponse.ok();
+        StreamedResponse response2 = response.replace(status: 201);
+        expect(response2.status, equals(201));
       });
     });
   });


### PR DESCRIPTION
## Issue
Fix #93.

This allows the consumer to create new `Response` and `StreamedResponse` objects from an existing instance when they only want to modify one or a few of its fields.

## Changes
**Source:**
- Add new `replace()` method to `Response` and `StreamedResponse`

**Tests:**
- Add test for new `replace()` method on `Response`
- Add test for new `replace()` method on `StreamedResponse`

## Areas of Regression
- None, new API

## Testing
- New tests sufficiently test new functionality
- CI passes

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf