### PR TITLE
CP-1247 Move sockjs config to be per-socket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 2.1.0
 
+### Deprecation: SockJS global configuration
+
+As of v2.0.0, this library could be configured to use SockJS under the hood when
+the `WSocket` class was used to establish WebSocket connections. This
+configuration occurred on a global basis (meaning it affected every `WSocket`
+instance) which is undesirable for applications with a mixed usage of native
+WebSockets and SockJS. **This global configuration has been deprecated.**
+
+As of v2.1.0, passing `useSockJS: true` to the `configureWTransportForBrowser()`
+method will cause a deprecation warning to be printed to the console.
+
+The SockJS configuration should now occur on a per-socket basis via the
+`WSocket.connect()` method:
+
+```dart
+Uri uri = Uri.parse('ws://echo.websocket.org');
+WSocket webSocket = await WSocket.connect(uri,
+   useSockJS: true, sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
+```
+
 ### Features
 
 - Added a `baseUri` field to `Client` that all requests from the client will

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 - [**Importing**](#importing)
 - [**Platforms**](#platforms)
   - [Browser](#browser)
-  - [Browser (SockJS)](#browser-sockjs)
   - [Dart VM](#dart-vm)
   - [Tests](#tests)
 - [**HTTP**](#http)
@@ -43,6 +42,7 @@
   - [Receiving Data](#receiving-data)
   - [Sending Data](#sending-data)
   - [Listening for Completion](#listening-for-completion)
+  - [Using SockJS](#using-sockjs)
 - [**Testing & Mocks**](#testing--mocks)
   - [Mocking HTTP](#mocking-http)
   - [Mocking WebSockets](#mocking-websockets)
@@ -76,18 +76,6 @@ import 'package:w_transport/w_transport_browser.dart'
 
 void main() {
   configureWTransportForBrowser();
-}
-```
-
-### Browser (SockJS)
-```dart
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
-
-void main() {
-  configureWTransportForBrowser(
-      useSockJS: true,
-      sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
 }
 ```
 
@@ -707,6 +695,16 @@ webSocket.done.then((_) {
 }).catchError((error) {
   // Handle socket error, reopen socket, etc.
 });
+```
+
+### Using SockJS
+Sockets can be configured to use SockJS under the hood instead of native
+WebSockets. This configuration must occur on a per-socket basis.
+
+```dart
+Uri uri = Uri.parse('ws://echo.websocket.org');
+WSocket webSocket = await WSocket.connect(uri,
+   useSockJS: true, sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
 ```
 
 ---

--- a/lib/src/browser_adapter.dart
+++ b/lib/src/browser_adapter.dart
@@ -69,12 +69,23 @@ class BrowserAdapter implements PlatformAdapter {
 
   /// Construct a new [ClientWSocket] instance that implements [WSocket].
   Future<WSocket> newWSocket(Uri uri,
-      {Iterable<String> protocols, Map<String, dynamic> headers}) {
-    if (_useSockJS) {
+      {Map<String, dynamic> headers,
+      Iterable<String> protocols,
+      bool sockJSDebug,
+      bool sockJSNoCredentials,
+      List<String> sockJSProtocolsWhitelist,
+      bool useSockJS}) {
+    sockJSDebug = sockJSDebug ?? _sockJSDebug;
+    sockJSNoCredentials = sockJSNoCredentials ?? _sockJSNoCredentials;
+    sockJSProtocolsWhitelist =
+        sockJSProtocolsWhitelist ?? _sockJSProtocolsWhitelist;
+    useSockJS = useSockJS ?? _useSockJS;
+
+    if (useSockJS) {
       return SockJSSocket.connect(uri,
-          debug: _sockJSDebug,
-          noCredentials: _sockJSNoCredentials,
-          protocolsWhitelist: _sockJSProtocolsWhitelist);
+          debug: sockJSDebug,
+          noCredentials: sockJSNoCredentials,
+          protocolsWhitelist: sockJSProtocolsWhitelist);
     } else {
       return BrowserWSocket.connect(uri,
           protocols: protocols, headers: headers);

--- a/lib/src/mock_adapter.dart
+++ b/lib/src/mock_adapter.dart
@@ -53,6 +53,11 @@ class MockAdapter implements PlatformAdapter {
 
   /// Construct a new [MockWSocket] instance that implements [WSocket].
   Future<WSocket> newWSocket(Uri uri,
-          {Iterable<String> protocols, Map<String, dynamic> headers}) =>
+          {Map<String, dynamic> headers,
+          Iterable<String> protocols,
+          bool sockJSDebug,
+          bool sockJSNoCredentials,
+          List<String> sockJSProtocolsWhitelist,
+          bool useSockJS}) =>
       MockWSocket.connect(uri, protocols: protocols, headers: headers);
 }

--- a/lib/src/platform_adapter.dart
+++ b/lib/src/platform_adapter.dart
@@ -75,5 +75,10 @@ abstract class PlatformAdapter {
 
   /// Constructs a new [WSocket] instance.
   Future<WSocket> newWSocket(Uri uri,
-      {Iterable<String> protocols, Map<String, dynamic> headers});
+      {Map<String, dynamic> headers,
+      Iterable<String> protocols,
+      bool sockJSDebug,
+      bool sockJSNoCredentials,
+      List<String> sockJSProtocolsWhitelist,
+      bool useSockJS});
 }

--- a/lib/src/vm_adapter.dart
+++ b/lib/src/vm_adapter.dart
@@ -49,6 +49,11 @@ class VMAdapter implements PlatformAdapter {
 
   /// Construct a new [ServerWSocket] instance that implements [WSocket].
   Future<WSocket> newWSocket(Uri uri,
-          {Iterable<String> protocols, Map<String, dynamic> headers}) =>
+          {Map<String, dynamic> headers,
+          Iterable<String> protocols,
+          bool sockJSDebug,
+          bool sockJSNoCredentials,
+          List<String> sockJSProtocolsWhitelist,
+          bool useSockJS}) =>
       VMWSocket.connect(uri, protocols: protocols, headers: headers);
 }

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -86,10 +86,19 @@ abstract class WSocket implements Stream, StreamSink {
   /// specified in [headers]. This only applies to server-side usage. See
   /// `dart:io`'s [WebSocket] for more information.
   static Future<WSocket> connect(Uri uri,
-      {Iterable<String> protocols, Map<String, dynamic> headers}) async {
-    return PlatformAdapter
-        .retrieve()
-        .newWSocket(uri, protocols: protocols, headers: headers);
+      {Map<String, dynamic> headers,
+      Iterable<String> protocols,
+      bool sockJSDebug,
+      bool sockJSNoCredentials,
+      List<String> sockJSProtocolsWhitelist,
+      bool useSockJS}) async {
+    return PlatformAdapter.retrieve().newWSocket(uri,
+        headers: headers,
+        protocols: protocols,
+        sockJSDebug: sockJSDebug,
+        sockJSNoCredentials: sockJSNoCredentials,
+        sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+        useSockJS: useSockJS);
   }
 
   /// The close code set when the WebSocket connection is closed. If there is

--- a/lib/w_transport_browser.dart
+++ b/lib/w_transport_browser.dart
@@ -44,6 +44,14 @@ void configureWTransportForBrowser(
     bool sockJSDebug: false,
     bool sockJSNoCredentials: false,
     List<String> sockJSProtocolsWhitelist}) {
+  // Configuring SockJS at this level is deprecated. SockJS configuration should
+  // occur on a per-socket basis.
+  if (useSockJS == true) {
+    print('Deprecation Warning: Configuring all w_transport sockets to use '
+        'SockJS is deprecated. Instead, SockJS usage should be configured on a '
+        'per-socket basis via the optional parameters in WSocket.connect().');
+  }
+
   adapter = new BrowserAdapter(
       useSockJS: useSockJS,
       sockJSDebug: sockJSDebug,

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -18,6 +18,10 @@ library w_transport.test.naming;
 const String platformBrowser = 'browser';
 const String platformBrowserSockjsWS = 'browser (SockJS WS)';
 const String platformBrowserSockjsXhr = 'browser (SockJS XHR)';
+const String platformBrowserSockjsWSDeprecated =
+    'browser (SockJS WS) [DEPRECATED]';
+const String platformBrowserSockjsXhrDeprecated =
+    'browser (SockJS XHR) [DEPRECATED]';
 const String platformMock = 'mock';
 const String platformVM = 'vm';
 


### PR DESCRIPTION
## Issue
- Configuring SockJS usage on a global basis will not work in two scenarios:
  - application with mixed usage of native websockets and SockJS
  - application where `configureWTransportForBrowser()` is called more than once (last config will win, which could break some usages)

## Changes
**Source:**
- Deprecate the method for applying SockJS config on a global basis (via `configureWTransportForBrowser()`)
- Add the SockJS optional params to the `WSocket.connect()` method (will be ignored on the server for now)

**Tests:**
- Current test suite still passes (although the deprecation warnings show)
- **TODO:**
  - [x] Update current test suite to use the new method (per-socket config)
  - [x] Add tests to ensure the deprecated method still works

## Areas of Regression
- WebSocket connection when configured with SockJS

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 