### PR TITLE
CP-1150 Release w_transport 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.0.1
+version: 2.1.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1150

JIRA and PR's included in this release: 


 CP-1156  - Docs updates, w_transport 12.2  - https://github.com/Workiva/w_transport/pull/87
 CP-1154  - HTTP: support timeout threshold.  - https://github.com/Workiva/w_transport/pull/85
 CP-1160  - Remove old mock file.  - https://github.com/Workiva/w_transport/pull/88
 CP-1165  - Dart formatter updates for w_transport, dart_style 0.2.1  - https://github.com/Workiva/w_transport/pull/90
 CP-1179  - Add a `baseUri` field to `Client`  - https://github.com/Workiva/w_transport/pull/94
 CP-1177  - Support request, response interception  - https://github.com/Workiva/w_transport/pull/92
 CP-1202  - Bug fix: dont ignore headers passed to dispatch methods  - https://github.com/Workiva/w_transport/pull/101
 CP-1186  - Automatic retrying for failed requests  - https://github.com/Workiva/w_transport/pull/99
 CP-1247  - Move sockjs config be per-socket.  - https://github.com/Workiva/w_transport/pull/107
 CP-1243  - Add Response.replace and StreamedResponse.replace  - https://github.com/Workiva/w_transport/pull/105
 CP-1249  - Update entry point library names.  - https://github.com/Workiva/w_transport/pull/108

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.0.1...CP-1150_release_2.1.0

