### PR TITLE
CP-1255 FormRequest documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ incrementally set each field.
 ```dart
 FormRequest request = new FormRequest()
   ..uri = Uri.parse('/notes/')
-  ..body['title'] = 'My Note'
-  ..body['contents'] = '...'
-  ..body['date'] = new DateTime.now().toString();
+  ..fields['title'] = 'My Note'
+  ..fields['contents'] = '...'
+  ..fields['date'] = new DateTime.now().toString();
 await request.post();
 ```
 

--- a/lib/src/http/requests.dart
+++ b/lib/src/http/requests.dart
@@ -36,8 +36,8 @@ abstract class FormRequest extends BaseRequest {
   /// like so:
   ///
   ///     FormRequest request = new FormRequest()
-  ///       ..body['foo'] = 'bar'
-  ///       ..body['bar'] = 'baz';
+  ///       ..fields['foo'] = 'bar'
+  ///       ..fields['bar'] = 'baz';
   ///
   /// Prior to sending, this request body will be translated to the equivalent
   /// query string. Depending on the platform, this may then be encoded to


### PR DESCRIPTION
## Issue
- Typo in the readme and in the docstrings for `FormRequest` - `body` should be `fields` (thanks @christopherdaly-wf!)

## Changes
**Source:**
- Update readme and doc string

**Tests:**
- N/a

## Areas of Regression
- N/a

## Testing
- N/a

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 