### PR TITLE
CP-1330 Add option for SockJS timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
       ..timeoutThreshold = new Duration(seconds: 10)
       ..autoRetry.enabled = true
       ..autoRetry.forTimeouts = false;
+
+- Added a `Duration sockJSTimeout` config option to `WSocket.connect()`.
+
+    ```dart
+    // browser only
+    var socket = await WSocket.connect(Uri.parse('...'),
+        useSockJS: true, sockJSTimeout: new Duration(seconds: 5));
     ```
 
 ## 2.1.0

--- a/example/web_socket/echo/index.html
+++ b/example/web_socket/echo/index.html
@@ -29,8 +29,39 @@ limitations under the License.
     <p>Connect to a WebSocket and send messages that will be echoed.</p>
 
     <form id="prompt-form">
+        <label for="sockjs">
+            <input type="checkbox" id="sockjs">
+            Use SockJS
+        </label>
+
+        <br>
+
+        <label for="sockjs-ws">
+            <input type="checkbox" id="sockjs-ws">
+            SockJS websocket
+        </label>
+
+        <br>
+
+        <label for="sockjs-xhr">
+            <input type="checkbox" id="sockjs-xhr">
+            SockJS xhr-streaming
+        </label>
+
+        <br>
+
+        <label for="sockjs-timeout">SockJS Timeout (ms)</label>
+        <input type="number" id="sockjs-timeout">
+
+        <br><br>
+
+        <button type="button" id="connect">Connect</button>
+
+        <br><br>
+
         <label for="prompt">Message</label>
         <input id="prompt" type="text">
+        <button type="submit">Send</button>
     </form>
 
     <pre id="logs"></pre>

--- a/lib/src/browser_adapter.dart
+++ b/lib/src/browser_adapter.dart
@@ -33,16 +33,19 @@ class BrowserAdapter implements PlatformAdapter {
   final bool _sockJSDebug;
   final bool _sockJSNoCredentials;
   final List<String> _sockJSProtocolsWhitelist;
+  final Duration _sockJSTimeout;
 
   BrowserAdapter(
       {bool useSockJS: false,
       bool sockJSNoCredentials: false,
       bool sockJSDebug: false,
-      List<String> sockJSProtocolsWhitelist})
+      List<String> sockJSProtocolsWhitelist,
+      Duration sockJSTimeout})
       : _useSockJS = useSockJS == true,
         _sockJSDebug = sockJSDebug == true,
         _sockJSProtocolsWhitelist = sockJSProtocolsWhitelist,
-        _sockJSNoCredentials = sockJSNoCredentials == true;
+        _sockJSNoCredentials = sockJSNoCredentials == true,
+        _sockJSTimeout = sockJSTimeout;
 
   /// Construct a new [BrowserClient] instance that implements [Client].
   Client newClient() => new BrowserClient();
@@ -74,18 +77,21 @@ class BrowserAdapter implements PlatformAdapter {
       bool sockJSDebug,
       bool sockJSNoCredentials,
       List<String> sockJSProtocolsWhitelist,
+      Duration sockJSTimeout,
       bool useSockJS}) {
     sockJSDebug = sockJSDebug ?? _sockJSDebug;
     sockJSNoCredentials = sockJSNoCredentials ?? _sockJSNoCredentials;
     sockJSProtocolsWhitelist =
         sockJSProtocolsWhitelist ?? _sockJSProtocolsWhitelist;
+    sockJSTimeout = sockJSTimeout ?? _sockJSTimeout;
     useSockJS = useSockJS ?? _useSockJS;
 
     if (useSockJS) {
       return SockJSSocket.connect(uri,
           debug: sockJSDebug,
           noCredentials: sockJSNoCredentials,
-          protocolsWhitelist: sockJSProtocolsWhitelist);
+          protocolsWhitelist: sockJSProtocolsWhitelist,
+          timeout: sockJSTimeout);
     } else {
       return BrowserWSocket.connect(uri,
           protocols: protocols, headers: headers);

--- a/lib/src/mock_adapter.dart
+++ b/lib/src/mock_adapter.dart
@@ -58,6 +58,7 @@ class MockAdapter implements PlatformAdapter {
           bool sockJSDebug,
           bool sockJSNoCredentials,
           List<String> sockJSProtocolsWhitelist,
+          Duration sockJSTimeout,
           bool useSockJS}) =>
       MockWSocket.connect(uri, protocols: protocols, headers: headers);
 }

--- a/lib/src/platform_adapter.dart
+++ b/lib/src/platform_adapter.dart
@@ -80,5 +80,6 @@ abstract class PlatformAdapter {
       bool sockJSDebug,
       bool sockJSNoCredentials,
       List<String> sockJSProtocolsWhitelist,
+      Duration sockJSTimeout,
       bool useSockJS});
 }

--- a/lib/src/vm_adapter.dart
+++ b/lib/src/vm_adapter.dart
@@ -54,6 +54,7 @@ class VMAdapter implements PlatformAdapter {
           bool sockJSDebug,
           bool sockJSNoCredentials,
           List<String> sockJSProtocolsWhitelist,
+          Duration sockJSTimeout,
           bool useSockJS}) =>
       VMWSocket.connect(uri, protocols: protocols, headers: headers);
 }

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -27,7 +27,8 @@ class SockJSSocket extends CommonWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
       {bool debug: false,
       bool noCredentials: false,
-      List<String> protocolsWhitelist}) async {
+      List<String> protocolsWhitelist,
+      Duration timeout}) async {
     if (uri.scheme == 'ws') {
       uri = uri.replace(scheme: 'http');
     } else if (uri.scheme == 'wss') {
@@ -37,7 +38,8 @@ class SockJSSocket extends CommonWSocket implements WSocket {
     sockjs.Client client = new sockjs.Client(uri.toString(),
         debug: debug == true,
         noCredentials: noCredentials == true,
-        protocolsWhitelist: protocolsWhitelist);
+        protocolsWhitelist: protocolsWhitelist,
+        timeout: timeout != null ? timeout.inMilliseconds : null);
 
     // Listen for and store the close event. This will determine whether or
     // not the socket connected successfully, and will also be used later

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -91,6 +91,7 @@ abstract class WSocket implements Stream, StreamSink {
       bool sockJSDebug,
       bool sockJSNoCredentials,
       List<String> sockJSProtocolsWhitelist,
+      Duration sockJSTimeout,
       bool useSockJS}) async {
     return PlatformAdapter.retrieve().newWSocket(uri,
         headers: headers,
@@ -98,6 +99,7 @@ abstract class WSocket implements Stream, StreamSink {
         sockJSDebug: sockJSDebug,
         sockJSNoCredentials: sockJSNoCredentials,
         sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+        sockJSTimeout: sockJSTimeout,
         useSockJS: useSockJS);
   }
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -48,8 +48,8 @@ main(List<String> args) async {
 
   config.examples
     ..port = 9000
-    ..before = [_streamServer]
-    ..after = [_stopServer];
+    ..before = [_streamServer, _streamSockJSServer]
+    ..after = [_stopServer, _stopSockJSServer];
 
   config.format.directories = directories;
 
@@ -109,6 +109,17 @@ Future _streamServer() async {
     reporter.log(reporter.colorBlue('    $line'));
   });
   await _server.start();
+}
+
+Future _streamSockJSServer() async {
+  _sockJSServer = new TaskProcess('node', ['tool/server/sockjs.js']);
+  _sockJSServer.stdout.listen((line) {
+    reporter.log(reporter.colorBlue('    $line'));
+  });
+  _sockJSServer.stderr.listen((line) {
+    reporter.log(reporter.colorBlue('    $line'));
+  });
+  // todo: wait for server to start
 }
 
 /// Stop the server needed for integration tests and examples.

--- a/tool/server/sockjs.js
+++ b/tool/server/sockjs.js
@@ -77,5 +77,6 @@ ping.on('connection', function(conn) {
 var server = http.createServer();
 closeOnRequest.installHandlers(server, {prefix: '/test/ws/close'});
 echo.installHandlers(server, {prefix: '/test/ws/echo'});
+echo.installHandlers(server, {prefix: '/example/ws/echo'});
 ping.installHandlers(server, {prefix: '/test/ws/ping'});
 server.listen(8026, 'localhost');


### PR DESCRIPTION
## Issue
There's currently no way to configure the timeout option for the underlying sockjs-client-dart library. If a socket (using SockJS) takes too long to connect, the connection will be canceled. This is problematic for slower network connections.

## Changes
**Source:**
- Expose the underlying SockJS timeout option via a `sockJSTimeout` optional param.

**Tests:**
- The only way to test this would be an integration test with a custom sockjs server that holds the WS negotiation or maybe the info request until the timeout expires. I'm not sure exactly how to do this, but I can look into if we think it's necessary.

## Areas of Regression
- SockJS socket connection.

## Testing
- CI passes.
- Open the Echo example and check "Use SockJS" along with at least one of "SockJS websocket" and "SockJS xhr-streaming". Should connect and echo as expected.
- Set the SockJS timeout to 1ms - connection should timeout/fail immediately
- Set the SockJS timeout to 1000ms or greater - connection should succeed.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @bryonmarks-wf @markerickson-wf @stevenosborne-wf 