### PR TITLE
CP-1337 Add autoRetry config option for retrying timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.2.0
+
+### Features
+
+- Added an `autoRetry.forTimeouts` flag (defaults to `true`) to the `Client`
+  class and all request classes. This flag determines whether or not requests
+  that are canceled due to exceeding the timeout threshold should be retried.
+
+    ```dart
+    // This request will retry if the timeout is exceeded.
+    var request = new Request()
+      ..timeoutThreshold = new Duration(seconds: 10)
+      ..autoRetry.enabled = true;
+
+    // This request will NOT retry if the timeout is exceeded.
+    var request = new Request()
+      ..timeoutThreshold = new Duration(seconds: 10)
+      ..autoRetry.enabled = true
+      ..autoRetry.forTimeouts = false;
+    ```
+
 ## 2.1.0
 
 ### Deprecation: SockJS global configuration

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -66,6 +66,10 @@ class AutoRetryConfig {
   /// represent server errors that may be transient.
   List<int> forStatusCodes = [500, 502, 503, 504];
 
+  /// When [enabled] is true, this determines whether or not to retry requests
+  /// that fail due to exceeding the timeout threshold.
+  bool forTimeouts = true;
+
   /// Maximum number of retries to attempt. This excludes the original request.
   /// For example, a request with `maxRetries = 2` will produce up to 3 requests
   /// total - the first request and 2 retries.

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -900,6 +900,46 @@ _runAutoRetryTestSuiteFor(
               exception.toString().contains('Request canceled');
         })));
       });
+
+      test('request timeout should be retried by default', () async {
+        // 1st request = hangs until timeout, 2nd request succeeds
+        int c = 0;
+        MockTransports.http.when(requestUri, (request) async {
+          if (++c == 1) {
+            await new Future.delayed(new Duration(seconds: 1));
+          } else {
+            return new MockResponse.ok();
+          }
+        }, method: 'GET');
+
+        BaseRequest request = requestFactory();
+        request.timeoutThreshold = new Duration(milliseconds: 250);
+        request.autoRetry
+          ..enabled = true
+          ..maxRetries = 2;
+
+        await request.get(uri: requestUri);
+        expect(request.autoRetry.numAttempts, equals(2));
+      });
+
+      test('request timeout should not be retried if disabled', () async {
+        // 1st request = hangs until timeout
+        MockTransports.http.when(requestUri, (request) async {
+          await new Future.delayed(new Duration(seconds: 1));
+        }, method: 'GET');
+
+        BaseRequest request = requestFactory();
+        request.timeoutThreshold = new Duration(milliseconds: 250);
+        request.autoRetry
+          ..enabled = true
+          ..forTimeouts = false
+          ..maxRetries = 2;
+
+        var future = request.get(uri: requestUri);
+        expect(future, throwsA(new isInstanceOf<RequestException>()));
+        await future.catchError((_) {});
+        expect(request.autoRetry.numAttempts, equals(1));
+      });
     });
   });
 }

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -471,6 +471,20 @@ void _runCommonRequestSuiteFor(
       }, throwsStateError);
     });
 
+    test(
+        'should not double-wrap exception when applying responseInterceptor after failure',
+        () async {
+      var error = new Error();
+      MockTransports.http.expect('GET', requestUri, failWith: error);
+      BaseRequest request = requestFactory();
+      request.responseInterceptor =
+          (request, response, [exception]) async => response;
+      expect(request.get(uri: requestUri), throwsA(predicate((exception) {
+        return exception is RequestException &&
+            identical(exception.error, error);
+      })));
+    });
+
     test('timeoutThreshold is not enforced if not set', () async {
       BaseRequest request = requestFactory();
       Future future = request.get(uri: requestUri);


### PR DESCRIPTION
## Issue
- Currently there's no way for requests that fail due to exceeding the timeout threshold to be retried.

## Changes
**Source:**
- Add an `autoRetry.forTimeouts` flag that defaults to `true` and determines whether or not a timed out request will be retried.

**Tests:**
- 2 unit tests added

## Areas of Regression
- Request sending and retry logic.

## Testing
- CI Passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @trentonsmith-wf @richklein-wf (this will be used in w_session to fix the session context retry issue)