### PR TITLE
CP-1356 Improve error messaging around failed requests, w_transport.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
       ..backOff = new RetryBackOff.exponential(new Duration(milliseconds: 125));
   ```
 
+- Improved error messaging around failed requests. If automatic retrying is
+  enabled, the error message for a failed request will include each individual
+  attempt and why it failed.
+
 ## [2.2.0](https://github.com/Workiva/w_transport/compare/2.1.0...2.2.0)
 _February 8, 2016_
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -283,14 +283,16 @@ abstract class CommonRequest extends Object
   /// Check if this request has been canceled.
   void checkForCancellation({BaseResponse response}) {
     if (isCanceled) {
-      throw new RequestException(
+      var error = new RequestException(
           method,
           this.uri,
           this,
           response,
           _cancellationError != null
               ? _cancellationError
-              : new Exception('Request canceled.'));
+              : new Exception('Request canceled'));
+      autoRetry.failures.add(error);
+      throw error;
     }
   }
 
@@ -650,7 +652,6 @@ abstract class CommonRequest extends Object
           if (!retryCompleter.isCompleted) {
             requestException = retryError;
             // TODO: Combine stack trace from above with the retry stack trace?
-            // TODO: Or is replacing with the retry stack trace enough?
             retryCompleter.complete();
           }
         });

--- a/lib/src/http/request_exception.dart
+++ b/lib/src/http/request_exception.dart
@@ -42,13 +42,30 @@ class RequestException implements Exception {
 
   /// Descriptive error message that includes the request method & URL and the response status.
   String get message {
-    String msg = '$method';
-    if (response != null) {
-      msg += ' ${response.status} ${response.statusText}';
-    }
-    msg += ' $uri';
-    if (error != null) {
-      msg += '\n\t$error';
+    String msg;
+    if (request != null && request.autoRetry.numAttempts > 1) {
+      msg = '$method $uri';
+      for (var i = 0; i < request.autoRetry.failures.length; i++) {
+        var failure = request.autoRetry.failures[i];
+        var attempt = '\n\tAttempt #${i+1}:';
+        if (failure.response != null) {
+          attempt +=
+              ' ${failure.response.status} ${failure.response.statusText}';
+        }
+        if (failure.error != null) {
+          attempt += ' (${failure.error})';
+        }
+        msg += attempt;
+      }
+    } else {
+      msg = '$method';
+      if (response != null) {
+        msg += ' ${response.status} ${response.statusText}';
+      }
+      msg += ' $uri';
+      if (error != null) {
+        msg += '\n\t$error';
+      }
     }
     return msg;
   }

--- a/test/unit/http/request_exception_test.dart
+++ b/test/unit/http/request_exception_test.dart
@@ -28,7 +28,7 @@ void main() {
 
   group(naming.toString(), () {
     group('RequestException', () {
-      test('should include the method and URi if given', () {
+      test('should include the method and URI if given', () {
         RequestException exception =
             new RequestException('POST', Uri.parse('/path'), null, null);
         expect(exception.toString(), contains('POST'));


### PR DESCRIPTION
Fix #100.

## Issue
- Error messaging around request failures could be improved, especially when retries are involved.

## Changes
**Source:**
- More robust `toString()` implementation for `RequestException` that takes into account retries
- Before:
    ```
    RequestException: GET 400 BAD REQUEST https://example.com/
    ```

- After:
    ```
    RequestException: GET https://example.com/
        Attempt #1: 400 BAD REQUEST
        Attempt #2: 403 FORBIDDEN
        Attempt #3: 500 INTERNAL SERVER ERROR
        Attempt #4: (TimeoutException after 0:00:00.100000: Request took too long to complete.)
        Attempt #5: (Exception: Unexpected failure.)
    ```

**Tests:**
- Tests added.

## Areas of Regression
- n/a

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 