### PR TITLE
CP-1359 Manual request retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@
       ..backOff = new RetryBackOff.exponential(new Duration(milliseconds: 125));
   ```
 
+- Added methods to all request classes for manually retrying failures. This is
+  mainly useful for corner cases where the request's success is dependent on
+  something else and where automatic retrying won't help.
+
+    ```dart
+    var request = new Request();
+    // send request, catch failure
+
+    var response = await request.retry(); // normal
+    var response = await request.streamRetry(); // streamed
+    ```
+
 - Improved error messaging around failed requests. If automatic retrying is
   enabled, the error message for a failed request will include each individual
   attempt and why it failed.

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -132,4 +132,12 @@ abstract class BaseRequest implements FluriMixin, RequestDispatchers {
   /// [configure] returns a `Future`, the request will not be sent until the
   /// returned `Future` completes.
   void configure(configure(request));
+
+  /// Retry this request. Throws a `StateError` if this request did not or has
+  /// yet to fail.
+  Future<Response> retry();
+
+  /// Retry this request and stream the response. Throws a `StateError` if this
+  /// request did not or has yet to fail.
+  Future<StreamedResponse> streamRetry();
 }


### PR DESCRIPTION
Fix #104.

## Issue
- There are corner cases where being able to manually retry a request after a failure would be useful (in particular, w_session membership preferences request)

## Changes
**Source:**
- Add a `.retry()` and `.streamRetry()` methods to `BaseRequest` that allow manual retrying of requests that have already been attempted and have failed. They will throw a `StateError` if the request has not yet been sent, if it is still in progress, or if it completed successfully.

**Tests:**
- Unit tests added.

## Areas of Regression
- n/a

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 