### PR TITLE
CP-1344 Release w_transport 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.2.0
+version: 2.3.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1344

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1350  - Retry back-off, w_transport.  - https://github.com/Workiva/w_transport/pull/115

 CP-1356  - Improve error messaging around failed requests, w_transport.  - https://github.com/Workiva/w_transport/pull/117

 CP-1359  - Manual request retrying  - https://github.com/Workiva/w_transport/pull/118

 CP-1363  - 2.3.0 release date, w_transport  - https://github.com/Workiva/w_transport/pull/119

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.2.0...CP-1344_release_2.3.0

