### PR TITLE
CP-1382 Workaround for dart2js bug when request is canceled.

### DIFF
--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -592,6 +592,7 @@ abstract class CommonRequest extends Object
       // response fetching early if it occurs before the request has finished.
       void breakOutOfResponseFetching(_) {
         if (!responseCompleter.isCompleted) {
+          response = null;
           responseCompleter.complete();
         }
       }


### PR DESCRIPTION
## Issue
- In non-dartium browsers (where dart is compiled to JS), a very weird situation can occur that results in `response` being assigned a completely incorrect value. I'm assuming this is a dart2js bug and will try to get a reduced test case created later.

## Changes
**Source:**
- Through debugging, I discovered that adding a print statement at a certain line that referenced the `response` variable that was being assigned an incorrect value actually fixed the issue.
- Instead of a logging statement, inserting a no-op assignment of the `response` variable to null accomplishes the same thing.

**Tests:**
- No idea how to test this.

## Areas of Regression
- n/a

## Testing
- Open the w_session example *in Chrome*
- Log in once to establish a session
- Reload
- Using the Network Link Conditioner, turn on a 10 second downlink delay
- Try to initialize session
- Note that the first session context request is canceled and an error shows up in the console referencing "get$header"
- Turn off the Network Link Conditioner
- Install this version of w_transport to w_session
- Restart pub serve
- Reload the example
- Turn the Network Link Conditioner back on
- Try to initialize session
- Note that the first request is canceled again, but now the retries successfully occur
-  (╯°□°）╯︵ ┻━┻

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: This should fix (for the third time) the session context request issues
@michaelcarter-wf @bradybecker-wf @trentonsmith-wf 