### PR TITLE
CP-1364 Release w_transport 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.3.0
+version: 2.3.1
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1364

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1382  - Workaround for dart2js bug when request is canceled.  - https://github.com/Workiva/w_transport/pull/122

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.3.0...CP-1364_release_2.3.1

