### PR TITLE
CP-1425 Fix inheritance of autoRetry settings for requests created by Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.3.2](https://github.com/Workiva/w_transport/compare/2.3.0...2.3.2)
+_March 2, 2016_
+
+- **Bug Fix:** requests created from a `Client` now properly inherit all of the
+  `autoRetry` configuration. Previously the `backOff`, `forTimeouts`, and
+  `maxRetries` settings were missing.
+
 ## [2.3.0](https://github.com/Workiva/w_transport/compare/2.2.0...2.3.0)
 _February 11, 2016_
 

--- a/lib/src/http/common/client.dart
+++ b/lib/src/http/common/client.dart
@@ -105,9 +105,12 @@ abstract class CommonClient implements Client {
       request.withCredentials = true;
     }
     request.autoRetry
+      ..backOff = autoRetry.backOff
       ..enabled = autoRetry.enabled
       ..forHttpMethods = autoRetry.forHttpMethods
       ..forStatusCodes = autoRetry.forStatusCodes
+      ..forTimeouts = autoRetry.forTimeouts
+      ..maxRetries = autoRetry.maxRetries
       ..test = autoRetry.test;
     if (_requestPathway.hasInterceptors) {
       request.requestInterceptor = (request) async {

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -212,6 +212,35 @@ void main() {
         }
       });
 
+      test('autoRetry should be inherited by all requests', () async {
+        Client client = new Client();
+        client.autoRetry
+          ..backOff = const RetryBackOff.fixed(const Duration(seconds: 2))
+          ..enabled = true
+          ..forHttpMethods = ['GET']
+          ..forStatusCodes = [404]
+          ..forTimeouts = false
+          ..maxRetries = 4
+          ..test = (request, response, willRetry) async => true;
+
+        for (var request in createAllRequestTypes(client)) {
+          expect(request.autoRetry.backOff.duration,
+              equals(client.autoRetry.backOff.duration));
+          expect(request.autoRetry.backOff.method,
+              equals(client.autoRetry.backOff.method));
+          expect(request.autoRetry.enabled, equals(client.autoRetry.enabled));
+          expect(request.autoRetry.forHttpMethods,
+              equals(client.autoRetry.forHttpMethods));
+          expect(request.autoRetry.forStatusCodes,
+              equals(client.autoRetry.forStatusCodes));
+          expect(request.autoRetry.forTimeouts,
+              equals(client.autoRetry.forTimeouts));
+          expect(request.autoRetry.maxRetries,
+              equals(client.autoRetry.maxRetries));
+          expect(request.autoRetry.test, equals(client.autoRetry.test));
+        }
+      });
+
       test('addInterceptor() single interceptor (request only)', () async {
         Client client = new Client()..addInterceptor(new ReqInt());
         for (BaseRequest request in createAllRequestTypes(client)) {


### PR DESCRIPTION
Fix #126.

## Issue
There are three `autoRetry` settings that do not get properly passed down to requests created by a `Client` instance.

## Changes
**Source:**
- Copy `autoRetry.backOff`, `autoRetry.forTimeouts`, and `autoRetry.maxRetries` to requests created by a `Client`

**Tests:**
- Unit test added.

## Areas of Regression
- n/a

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @jeroencranendonk-wf 