### PR TITLE
CP-1462 Remove usage of new Chain.current() (caused RTE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.3.3](https://github.com/Workiva/w_transport/compare/2.3.4...2.3.3)
+_March 15, 2016_
+
+- **Bug Fix:** remove incorrect usage of `new Chain.current()` that was
+  resulting in uncaught exceptions when requests would time out.
+
 ## [2.3.2](https://github.com/Workiva/w_transport/compare/2.3.0...2.3.2)
 _March 2, 2016_
 

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -17,8 +17,6 @@ library w_transport.src.http.browser.request_mixin;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:stack_trace/stack_trace.dart';
-
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/browser/form_data_body.dart';
 import 'package:w_transport/src/http/browser/utils.dart' as browser_utils;
@@ -85,7 +83,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         BaseResponse response =
             await _createResponse(streamResponse: streamResponse);
         error = new RequestException(method, uri, this, response, error);
-        c.completeError(error, new Chain.current());
+        c.completeError(error);
       }
     }
     _request.onError.listen(onError);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.0
-  stack_trace: "^1.4.0"
 dev_dependencies:
   ansicolor: "^0.0.9"
   args: "^0.13.0"


### PR DESCRIPTION
## Issue
`new Chain.current()` was being used outside of a call to `Chain.capture()` which was resulting in a run-time exception. See http://news.dartlang.org/2016/01/unboxing-packages-stacktrace.html for more information on how the stack_trace package should be used.

## Changes
- Remove the usage of `new Chain.current()` - it will be up to the consumer to use the `stack_trace` package to appropriately catch async stack traces.

## Testing
- Run truss examples locally and go to any shell that starts auth status polling (I used session UI)
- Turn on at least a 10 second downlink delay via Network Link Conditioner
- Verify that when the /authentication/status request times out and is canceled, an uncaught exception related to `new Chain.current()` is seen in the console
- Turn off Network Link Conditioner
- Pull this branch into truss via `dependency_overrides` and run `pub get`
- Restart examples and refresh the example you had open earlier
- Turn Network Link Conditioner back on
- Verify that the /authentication/status request times out and fails silently, and that polling continues without any uncaught exceptions being logged to the console

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
