### PR TITLE
CP-1705 Hide dart:html.Client to avoid conflict with w_transport.Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [HEAD](https://github.com/Workiva/w_transport/compare/2.3.2...master)
+_Not yet released._
+
+- **SDK Compatibility:** Dart 1.16 exposed a new `Client` class from the
+  `dart:html` library that conflicted with the `Client` class in this library.
+  This has been fixed by adjusting our imports internally, but it may still
+  affect consumers of this library.
+
+- **Documentation:** fixed inaccurate documentation around mocking & testing
+  with WebSockets.
+
 ## [2.3.2](https://github.com/Workiva/w_transport/compare/2.3.0...2.3.2)
 _March 2, 2016_
 

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -16,7 +16,7 @@ library w_transport.src.http.browser.multipart_request;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html';
+import 'dart:html' hide Client;
 
 import 'package:http_parser/http_parser.dart'
     show CaseInsensitiveMap, MediaType;


### PR DESCRIPTION
## Issue
Dart 1.16 exposes a new `Client` class in the `dart:html` library. This conflicts with the `Client` class in w_transport. Thanks for pointing this out @theisensanders-wf.

## Solution
To avoid this, I'm hiding the `Client` class form the `dart:html` import in the one file that this conflict occurs. **This will work for now, but we should probably consider renaming our class since consumers will likely hit this conflict with their own imports.**

## Testing
- [ ] `ddev analyze` runs successfully on Dart 1.16

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 