### PR TITLE
CP-1709 FormRequest: support fields with multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [HEAD](https://github.com/Workiva/w_transport/compare/2.3.2...master)
+_Not yet released._
+
+- **SDK Compatibility:** Dart 1.16 exposed a new `Client` class from the
+  `dart:html` library that conflicted with the `Client` class in this library.
+  This has been fixed by adjusting our imports internally, but it may still
+  affect consumers of this library.
+
+- **Documentation:** fixed inaccurate documentation around mocking & testing
+  with WebSockets.
+
 ## [2.3.2](https://github.com/Workiva/w_transport/compare/2.3.0...2.3.2)
 _March 2, 2016_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [HEAD](https://github.com/Workiva/w_transport/compare/2.3.2...master)
 _Not yet released._
 
+- **Improvement:** `FormRequest` now supports fields with multiple values.
+
+    ```dart
+    var request = new FormRequest()
+      ..fields['multi'] = ['one', 'two'];
+    ```
+
 - **SDK Compatibility:** Dart 1.16 exposed a new `Client` class from the
   `dart:html` library that conflicted with the `Client` class in this library.
   This has been fixed by adjusting our imports internally, but it may still

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -16,7 +16,7 @@ library w_transport.src.http.browser.multipart_request;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html';
+import 'dart:html' hide Client;
 
 import 'package:http_parser/http_parser.dart'
     show CaseInsensitiveMap, MediaType;

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -30,7 +30,7 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
   CommonFormRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 
-  Map<String, String> _fields = {};
+  Map<String, dynamic> _fields = {};
 
   @override
   int get contentLength => _encodedQuery.length;
@@ -39,10 +39,10 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
   MediaType get defaultContentType => new MediaType(
       'application', 'x-www-form-urlencoded', {'charset': encoding.name});
 
-  Map<String, String> get fields =>
+  Map<String, dynamic> get fields =>
       isSent ? new Map.unmodifiable(_fields) : _fields;
 
-  set fields(Map<String, String> fields) {
+  set fields(Map<String, dynamic> fields) {
     verifyUnsent();
     if (fields == null) {
       fields = {};
@@ -50,8 +50,15 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
     _fields = fields;
   }
 
-  Uint8List get _encodedQuery =>
-      encoding.encode(http_utils.mapToQuery(fields, encoding: encoding));
+  Uint8List get _encodedQuery {
+    fields.forEach((key, value) {
+      if (value is! String && value is! Iterable<String>) {
+        throw new ArgumentError('FormRequest: value of "$key" field must be of '
+            'type `String` or `Iterable<String>`');
+      }
+    });
+    return encoding.encode(http_utils.mapToQuery(fields, encoding: encoding));
+  }
 
   @override
   FormRequest clone() {

--- a/lib/src/http/requests.dart
+++ b/lib/src/http/requests.dart
@@ -30,7 +30,7 @@ abstract class FormRequest extends BaseRequest {
   /// Gets this request's body as a `Map` where each key-value pair is a form
   /// field's name and value.
   ///
-  /// By default, the body of this [FormRequest] will is an empty `Map`.
+  /// By default, the body of this [FormRequest] is an empty `Map`.
   ///
   /// The returned `Map` is modifiable, allowing incremental field assignment
   /// like so:
@@ -39,11 +39,16 @@ abstract class FormRequest extends BaseRequest {
   ///       ..fields['foo'] = 'bar'
   ///       ..fields['bar'] = 'baz';
   ///
+  /// To set multiple values for a single key, use a `Iterable<String>`:
+  ///
+  ///     FormRequest request = new FormRequest()
+  ///       ..fields['names'] = ['foo', 'bar'];
+  ///
   /// Prior to sending, this request body will be translated to the equivalent
   /// query string. Depending on the platform, this may then be encoded to
   /// bytes. Be sure to set [encoding] if this request body should be encoded
   /// with something other than the default UTF8.
-  Map<String, String> get fields;
+  Map<String, dynamic> get fields;
 
   /// Sets this request's form fields. The given `Map` should represent the form
   /// fields where each key-value pair is a field's name and value.
@@ -52,7 +57,7 @@ abstract class FormRequest extends BaseRequest {
   /// query string. Depending on the platform, this may then be encoded to
   /// bytes. Be sure to set [encoding] if this request body should be encoded
   /// with something other than the default UTF8.
-  set fields(Map<String, String> fields);
+  set fields(Map<String, dynamic> fields);
 
   factory FormRequest() => PlatformAdapter.retrieve().newFormRequest();
 

--- a/test/integration/http/form_request/suite.dart
+++ b/test/integration/http/form_request/suite.dart
@@ -100,5 +100,24 @@ void runFormRequestSuite() {
       expect(echo, containsPair('field1', 'value1'));
       expect(echo, containsPair('field2', 'value2'));
     });
+
+    test('should support multiple values for a single field', () async {
+      FormRequest request = new FormRequest()
+        ..uri = IntegrationPaths.echoEndpointUri
+        ..fields['items'] = ['one', 'two'];
+      Response response = await request.post();
+      Map echo = http_utils.queryToMap(response.body.asString());
+      expect(echo['items'], equals(['one', 'two']));
+    });
+
+    test(
+        'should prevent unsupported value types (anything other than String and List<String>)',
+        () {
+      FormRequest request = new FormRequest()
+        ..uri = IntegrationPaths.echoEndpointUri
+        ..fields['invalid'] = 10;
+
+      expect(request.post(), throwsArgumentError);
+    });
   });
 }


### PR DESCRIPTION
_Dependent on #136._

## Improvement
Most servers support form requests with multiple-value fields. For example:

```
?foo=bar&foo=baz
```

The above query string would produce this form payload:

```
{ foo: ['bar', 'baz'] }
```

Currently, we don't support this because the `fields` map is of type `Map<String, String>`.

## Changes
- Change the signatures of the `FormRequest.fields` getters and setters to `Map<String, dynamic>`
- Update the utilities for converting from map to query string and vice versa to support fields with multiple values
- Add type checks to verify that each field's value is either `String` or `Iterable<String>`
- Add test to exercise sending a field with multiple values
- Add test to verify that invalid field value type causes an `ArgumentError` to be thrown

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 

fyi: @brianneal-wf 