### PR TITLE
CP-1880 Refactor WSocket to fulfill Stream and StreamSink contracts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2.4.1](https://github.com/Workiva/w_transport/compare/2.4.0...2.4.1)
+_TBD_
+
+- **Bug Fix:** `WSocket` extends `Stream` and `StreamSink`, but was not
+  fulfilling those contracts in all scenarios. In particular:
+
+  - After obtaining a `StreamSubscription` instance from a call to
+    `WSocket.listen()`, reassigning the `onData()`, `onError()`, and `onDone()`
+    handlers had no effect.
+
+      ```dart
+      var webSocket = await WSocket.connect(...);
+      var subscription = webSocket.listen((data) { ... });
+
+      // This does nothing:
+      subscription.onData((data) { ... });
+      // Same goes for onError() and onDone()
+      ```
+
+  - A subscription to a `WSocket` instance did not properly respect pause and
+    resume signals. This could produce a memory leak by buffering WebSocket
+    events indefinitely.
+
+  - A `WSocket` instance was immediately listening to the underlying WebSocket
+    and buffering events from the underlying WebSocket until a listener was
+    registered. This is not how a standard Dart `Stream` works.
+
+  - The SockJS configuration was not properly handling the fact that the SockJS
+    `Client` produces WebSocket events with a broadcast stream.
+
+  - **All of these issues have been addressed, and every `WSocket` instance
+    should now behave exactly as a standard `Stream` and `StreamSink` would,
+    regardless of the platform (VM, browser, SockJS, or mock).**
+
 ## [2.4.0](https://github.com/Workiva/w_transport/compare/2.3.2...2.4.0)
 _May 4, 2016_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ _TBD_
     should now behave exactly as a standard `Stream` and `StreamSink` would,
     regardless of the platform (VM, browser, SockJS, or mock).**
 
+> The `WSocketCloseEvent` class has been deprecated. This class was only used
+> internally and should not have been exported as a part of the public API.
+
 ## [2.4.0](https://github.com/Workiva/w_transport/compare/2.3.2...2.4.0)
 _May 4, 2016_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ _TBD_
 > The `WSocketCloseEvent` class has been deprecated. This class was only used
 > internally and should not have been exported as a part of the public API.
 
+> The WSocket implementations are no longer registering an `onError` handler for
+> the underlying WebSocket stream. If an error occurs on the server, it will not
+> add the error to the stream, it will just close the connection. As a result,
+> the `MockWSocket.triggerServerError()` method has been deprecated - use
+> `MockWSocket.triggerServerClose()` instead.
+
+
 ## [2.4.0](https://github.com/Workiva/w_transport/compare/2.3.2...2.4.0)
 _May 4, 2016_
 

--- a/lib/src/mocks/http.dart
+++ b/lib/src/mocks/http.dart
@@ -44,8 +44,6 @@ handleMockRequest(MockBaseRequest request) {
     if (e.headers == null) {
       // Ignore headers check if expectation didn't specify.
       headersMatch = true;
-    } else if (e.headers.isEmpty) {
-      headersMatch = request.headers.isEmpty;
     } else {
       headersMatch = true;
       e.headers.forEach((header, value) {

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -20,7 +20,6 @@ import 'package:sockjs_client/sockjs_client.dart' as sockjs;
 
 import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
-import 'package:w_transport/src/web_socket/w_socket_close_event.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
 class SockJSSocket extends CommonWSocket implements WSocket {
@@ -61,46 +60,76 @@ class SockJSSocket extends CommonWSocket implements WSocket {
     return new SockJSSocket._(client, closed);
   }
 
-  /// The underlying SockJS Client instance.
-  sockjs.Client _socket;
+  sockjs.Client _webSocket;
 
-  /// The close event Future from the SockJS Client onClose stream.
-  var _socketClosed;
-
-  SockJSSocket._(sockjs.Client this._socket, this._socketClosed) : super() {
-    // The outgoing communication will be handled by this stream controller.
-    // The sink from this controller will be used by [add] and [addStream].
-    outgoing = new StreamController();
-    outgoing.stream.listen((message) {
-      // Pipe messages through to the underlying socket.
-      _socket.send(message);
-    }, onError: handleOutgoingError, onDone: handleOutgoingDone);
-
-    // Map events from the underlying socket to the incoming controller.
-    incoming = new StreamController();
-    _socket.onMessage.listen((messageEvent) {
-      // Pipe messages from the socket through to the stream.
-      incoming.add(messageEvent.data);
+  SockJSSocket._(this._webSocket, Future webSocketClosed) : super() {
+    webSocketClosed.then((closeEvent) {
+      closeCode = closeEvent.code;
+      closeReason = closeEvent.reason;
+      onIncomingDone();
     });
-    _socketClosed.then((closeEvent) {
-      // Now that the socket has closed, capture the close code and reason.
-      var wCloseEvent =
-          new WSocketCloseEvent(closeEvent.code, closeEvent.reason);
-      handleSocketDone(wCloseEvent);
+
+    // Note: We don't listen to the SockJS client for messages immediately like
+    // we do with the native WebSockets. This is because the event streams from
+    // the SockJS client are all drawn from a single broadcast stream. To make
+    // it act like a single subscription stream (and thus make it fit the
+    // interface of a standard Stream), we create a subscription when a consumer
+    // listens to this WSocket instance, cancel that subscription when the
+    // consumer's subscription is paused, and re-listen when the consumer
+    // resumes listening. See [onIncomingListen], [onIncomingPause], and
+    // [onIncomingResume].
+
+    // Additional note: the SockJS Client has no error stream, so no need to
+    // listen to for errors.
+  }
+
+  @override
+  void closeWebSocket(int code, String reason) {
+    _webSocket.close(code, reason);
+  }
+
+  @override
+  void onIncomingError(error, [StackTrace stackTrace]) {
+    shutDown(error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void onIncomingListen() {
+    // When this [WSocket] instance is listened to, start listening to the
+    // SockJS client's broadcast stream.
+    webSocketSubscription = _webSocket.onMessage.listen((messageEvent) {
+      onIncomingData(messageEvent.data);
     });
   }
 
   @override
-  void closeSocket(int code, String reason) {
-    _socket.close(code, reason);
+  void onIncomingPause() {
+    // When this [WSocket]'s subscription is paused, cancel the subscription to
+    // the SockJS client's broadcast stream. This is the recommended behavior
+    // when proxying a subscription to a broadcast stream. This effectively
+    // prevents buffering events indefinitely (a possible memory leak) by
+    // canceling the subscription altogether. When the subscription to this
+    // [WSocket] instance is resumed, we will re-subscribe.
+    webSocketSubscription.cancel();
   }
 
-  /// Validate the WebSocket message data type. When using SockJS, only [String]
-  /// messages are valid.
-  ///
-  /// Throws an [ArgumentError] if [data] is invalid.
   @override
-  void validateDataType(Object data) {
+  void onIncomingResume() {
+    // Resubscribe to the SockJS client's broadcast stream to effectively resume
+    // the consumer's subscription to this [WSocket] instance.
+    webSocketSubscription = _webSocket.onMessage.listen((messageEvent) {
+      onIncomingData(messageEvent.data);
+    });
+  }
+
+  @override
+  void onOutgoingData(data) {
+    // Pipe messages through to the underlying socket.
+    _webSocket.send(data);
+  }
+
+  @override
+  void validateOutgoingData(Object data) {
     if (data is! String) {
       throw new ArgumentError(
           'WSocket data type must be a String when using SockJS.');

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -96,11 +96,6 @@ class SockJSSocket extends CommonWSocket implements WSocket {
   }
 
   @override
-  void onIncomingError(error, [StackTrace stackTrace]) {
-    shutDown(error: error, stackTrace: stackTrace);
-  }
-
-  @override
   void onIncomingListen() {
     // When this [WSocket] instance is listened to, start listening to the
     // SockJS client's broadcast stream.

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -22,6 +22,10 @@ import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
+/// Implementation of the platform-dependent pieces of the [WSocket] class for
+/// the SockJS browser configuration. This class uses the SockJS library to
+/// establish a WebSocket-like connection (could be a native WebSocket, could
+/// be XHR-streaming).
 class SockJSSocket extends CommonWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
       {bool debug: false,
@@ -60,6 +64,9 @@ class SockJSSocket extends CommonWSocket implements WSocket {
     return new SockJSSocket._(client, closed);
   }
 
+  /// The "WebSocket" - in this case, it's a SockJS Client that has an API
+  /// similar to that of a WebSocket, regardless of what protocol is actually
+  /// used.
   sockjs.Client _webSocket;
 
   SockJSSocket._(this._webSocket, Future webSocketClosed) : super() {
@@ -80,7 +87,7 @@ class SockJSSocket extends CommonWSocket implements WSocket {
     // [onIncomingResume].
 
     // Additional note: the SockJS Client has no error stream, so no need to
-    // listen to for errors.
+    // listen for errors.
   }
 
   @override

--- a/lib/src/web_socket/browser/w_socket.dart
+++ b/lib/src/web_socket/browser/w_socket.dart
@@ -22,6 +22,8 @@ import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
+/// Implementation of the platform-dependent pieces of the [WSocket] class for
+/// the browser. This class uses native WebSockets.
 class BrowserWSocket extends CommonWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
       {Iterable<String> protocols, Map<String, dynamic> headers}) async {
@@ -51,6 +53,7 @@ class BrowserWSocket extends CommonWSocket implements WSocket {
     return new BrowserWSocket._(socket, closed);
   }
 
+  /// The underlying native WebSocket.
   WebSocket _webSocket;
 
   BrowserWSocket._(this._webSocket, Future<CloseEvent> webSocketClosed)

--- a/lib/src/web_socket/browser/w_socket.dart
+++ b/lib/src/web_socket/browser/w_socket.dart
@@ -61,7 +61,6 @@ class BrowserWSocket extends CommonWSocket implements WSocket {
     webSocketSubscription = _webSocket.onMessage.listen((messageEvent) {
       onIncomingData(messageEvent.data);
     });
-    _webSocket.onError.listen(onIncomingError);
     webSocketClosed.then((closeEvent) {
       closeCode = closeEvent.code;
       closeReason = closeEvent.reason;
@@ -72,11 +71,6 @@ class BrowserWSocket extends CommonWSocket implements WSocket {
   @override
   void closeWebSocket(int code, String reason) {
     _webSocket.close(code, reason);
-  }
-
-  @override
-  void onIncomingError(error, [StackTrace stackTrace]) {
-    shutDown(error: error, stackTrace: stackTrace);
   }
 
   @override

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -232,10 +232,6 @@ abstract class CommonWSocket extends Stream implements WSocket {
   /// [reason].
   void closeWebSocket(int code, String reason);
 
-  /// Called when the incoming `StreamController` receives an [error]. This
-  /// should trigger the shut down of this [WSocket] instance.
-  void onIncomingError(error, [StackTrace stackTrace]);
-
   /// Called when the incoming `StreamController` receives a listener. This
   /// should effectively trigger a subscription to the WebSocket's events. Up
   /// until this point, events from the WebSocket should have been discarded.

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -35,7 +35,7 @@ abstract class CommonWSocket extends Stream implements WSocket {
   bool isClosed = false;
 
   /// The subscription to the underlying WebSocket (either a browser WebSocket,
-  /// VM WebSocket, SockJS Client, or a mock WebSocket.
+  /// VM WebSocket, SockJS Client, or a mock WebSocket).
   StreamSubscription webSocketSubscription;
 
   /// A completer that completes when both the outgoing stream sink and the

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -17,7 +17,7 @@ library w_transport.src.web_socket.common.w_socket;
 import 'dart:async';
 
 import 'package:w_transport/src/web_socket/w_socket.dart';
-import 'package:w_transport/src/web_socket/w_socket_close_event.dart';
+import 'package:w_transport/src/web_socket/w_socket_subscription.dart';
 
 abstract class CommonWSocket extends Stream implements WSocket {
   /// The close code set when the WebSocket connection is closed. If there is
@@ -28,73 +28,50 @@ abstract class CommonWSocket extends Stream implements WSocket {
   /// no close reason available this property will be `null`.
   String closeReason;
 
-  /// Incoming communication. Data from the web socket will be piped
-  /// to this controller's sink. The stream will be exposed, allowing
-  /// users to listen to the incoming data.
-  StreamController incoming;
+  bool isClosed = false;
 
-  /// Outgoing communication. Sink will be exposed, allowing users to
-  /// add items to the outgoing stream.
-  StreamController outgoing;
+  StreamSubscription webSocketSubscription;
 
-  /// Completer that will complete when the outgoing sink has finished closing
-  /// and the socket connection has finished closing.
   Completer<Null> _allClosed = new Completer();
-
-  /// The close event with close code and reason from the socket connection.
-  /// Will only be populated once the socket has actually closed.
-  WSocketCloseEvent _closeEvent;
-
-  /// Completer that will complete when [_allClosed] has completed and the close
-  /// code and reason have been set. If the socket closed due to an error, this
-  /// will complete with an error. Otherwise, it will complete normally.
   Completer<Null> _done = new Completer();
-
-  /// The error that was either added to the socket sink or received from the
-  /// socket stream. This will only be populated if an error occurs.
   var _error;
-
-  /// Whether or not the web socket is in the process of closing (or already has
-  /// closed). This prevents duplicate behavior if [close] is called multiple
-  /// times.
-  bool _isClosed = false;
-
-  /// Whether or not the outgoing sink has been closed.
-  bool _isSinkClosed = false;
-
-  /// Whether or not the incoming socket stream connection has been closed.
-  bool _isSocketClosed = false;
-
-  /// The stack trace from the error that was either added to the socket sink or
-  /// received from the socket stream. This will only be populated if an error
-  /// occurs.
+  StreamController _incoming;
+  bool _isIncomingClosed = false;
+  bool _isOutgoingClosed = false;
+  StreamController _outgoing;
   StackTrace _stackTrace;
+  WSocketSubscription _incomingSubscription;
 
   CommonWSocket() {
-    // Wait for both the sink and the socket to finish closing before exposing
-    // the close code, close reason, and completing the [_done] completer.
-    // If the socket closed due to an error, the [_done] completer will be
-    // completed with that error.
     _allClosed.future.then((_) {
-      closeCode = _closeEvent.code;
-      closeReason = _closeEvent.reason;
-      _isClosed = true;
+      if (_incomingSubscription?.doneHandler != null) {
+        _incomingSubscription.doneHandler();
+      }
+
       if (_error != null) {
         _done.completeError(_error, _stackTrace);
       } else {
         _done.complete();
       }
     });
+
+    // Outgoing communication will be handled by this stream controller.
+    _outgoing = new StreamController();
+    _outgoing.stream.listen(onOutgoingData,
+        onError: onOutgoingError, onDone: onOutgoingDone);
+
+    // Map events from the underlying socket to the incoming controller.
+    // It is important to have handlers for start/stop/pause/resume so that the
+    // controller properly respects the StreamSubscription API.
+    _incoming = new StreamController(
+        onListen: onIncomingListen,
+        onPause: onIncomingPause,
+        onResume: onIncomingResume,
+        onCancel: onIncomingCancel);
   }
 
   /// Future that resolves when this WebSocket connection has completely closed.
   Future get done => _done.future;
-
-  /// The stream sink for outgoing messages.
-  StreamSink get sink => outgoing.sink;
-
-  /// The stream for incoming messages.
-  Stream get stream => incoming.stream;
 
   /// Sends a message over the WebSocket connection.
   ///
@@ -107,14 +84,14 @@ abstract class CommonWSocket extends Stream implements WSocket {
   /// On the server:
   ///   - String
   ///   - List<int>
-  void add(message) {
-    validateDataType(message);
-    sink.add(message);
+  void add(data) {
+    validateOutgoingData(data);
+    _outgoing.add(data);
   }
 
   /// Add an error to the sink. This will cause the WebSocket connection to close.
   void addError(errorEvent, [StackTrace stackTrace]) {
-    shutDown(error: errorEvent, stackTrace: stackTrace);
+    _outgoing.addError(errorEvent, stackTrace);
   }
 
   /// Adds a stream of data to send over the WebSocket connection.
@@ -126,31 +103,58 @@ abstract class CommonWSocket extends Stream implements WSocket {
   /// Sending additional data before this stream has completed may
   /// result in a [StateError].
   Future addStream(Stream stream) async {
-    await sink.addStream(stream);
+    return _outgoing.addStream(stream);
   }
 
   /// Closes the WebSocket connection. Optionally set [code] and [reason]
   /// to send close information to the remote peer.
   Future close([int code, String reason]) {
-    if (_isClosed) return done;
-    _isClosed = true;
     shutDown(code: code, reason: reason);
     return done;
   }
 
-  void closeSocket(int code, String reason);
-
-  void handleOutgoingError(error, [StackTrace stackTrace]) {
-    // Don't pass the error on to the socket. It will cause the socket to
-    // close anyway, so we will preempt this and handle the shut down
-    // by ourselves. This allows us to prevent the error from propagating to
-    // the root zone where it cannot be caught.
-    shutDown(error: error, stackTrace: stackTrace);
+  StreamSubscription listen(void onData(event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    var sub = _incoming.stream
+        .listen(onData, onError: onError, cancelOnError: cancelOnError);
+    _incomingSubscription = new WSocketSubscription(sub, onDone, onCancel: () {
+      _incomingSubscription = null;
+      return done;
+    });
+    return _incomingSubscription;
   }
 
-  void handleOutgoingDone() {
-    _isSinkClosed = true;
-    if (_isSocketClosed) {
+  Future onIncomingCancel() async {
+    webSocketSubscription.cancel();
+    return _incoming.close();
+  }
+
+  void onIncomingData(data) {
+    // Pipe messages from the socket through to the stream, but only if a
+    // listener has been registered and is not paused. Otherwise we risk leaking
+    // resources by adding events to the controller that may be buffered
+    // indefinitely.
+    if (!_incoming.isPaused && !_incoming.isClosed) {
+      _incoming.add(data);
+    }
+  }
+
+  void onIncomingDone() {
+    isClosed = true;
+
+    // Now that the socket has closed, capture the close code and reason.
+    _isIncomingClosed = true;
+
+    if (_isOutgoingClosed) {
+      _allClosed.complete();
+    } else {
+      _outgoing.close().catchError((_) {});
+    }
+  }
+
+  void onOutgoingDone() {
+    _isOutgoingClosed = true;
+    if (_isIncomingClosed) {
       _allClosed.complete();
     }
 
@@ -162,43 +166,39 @@ abstract class CommonWSocket extends Stream implements WSocket {
     // - the sink receives an error during a call to [addStream]
   }
 
-  void handleSocketError(error, [StackTrace stackTrace]) {
+  void onOutgoingError(error, [StackTrace stackTrace]) {
+    // Don't pass the error on to the socket. It will cause the socket to close
+    // anyway, so we will preempt this and handle the shut down by ourselves.
+    // This allows us to prevent the error from propagating to the root zone
+    // where it cannot be caught.
     shutDown(error: error, stackTrace: stackTrace);
   }
 
-  void handleSocketDone(WSocketCloseEvent closeEvent) {
-    _closeEvent = closeEvent;
-
-    _isSocketClosed = true;
-    if (_isSinkClosed) {
-      _allClosed.complete();
-    } else {
-      outgoing.close().catchError((_) {});
-    }
-  }
-
-  StreamSubscription listen(void onData(event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    if (onDone != null) {
-      done.then((_) => onDone());
-    }
-    return stream.listen(onData,
-        onError: onError, cancelOnError: cancelOnError);
-  }
-
-  /// Close the WebSocket connection if one has been established.
   void shutDown({int code, error, String reason, StackTrace stackTrace}) {
+    if (isClosed) return;
+    isClosed = true;
+
     // Store the error and stack trace. When everything has finished closing,
     // they will be indicators that the socket connection closed with an error.
     _error = error;
     _stackTrace = stackTrace;
 
     // Close both incoming and outgoing communication.
-    closeSocket(code, reason);
-    sink.close();
+    _outgoing.close();
+    closeWebSocket(code, reason);
   }
 
-  /// Validate the data type of the message being sent. Throws an ArgumentError
-  /// if [message] is of invalid type.
-  void validateDataType(message);
+  void closeWebSocket(int code, String reason);
+
+  void onIncomingError(error, [StackTrace stackTrace]);
+
+  void onIncomingListen();
+
+  void onIncomingPause();
+
+  void onIncomingResume();
+
+  void onOutgoingData(data);
+
+  void validateOutgoingData(Object data);
 }

--- a/lib/src/web_socket/mock/w_socket.dart
+++ b/lib/src/web_socket/mock/w_socket.dart
@@ -44,6 +44,12 @@ abstract class MockWSocket implements WSocket {
   void triggerServerClose([int code, String reason]);
 
   /// Cause the "server" to add an error to the stream.
+  ///
+  /// In practice, this cannot happen. If an error is added to the stream on the
+  /// server side, it will cause the connection to close, but it will not send
+  /// the error and thus an error will not be received by the client. For this
+  /// reason, this method has been deprecated. Use [triggerServerClose] instead.
+  @Deprecated('in 3.0.0. Use triggerServerClose() instead.')
   void triggerServerError(error, [StackTrace stackTrace]);
 }
 
@@ -58,8 +64,8 @@ class _MockWSocket extends CommonWSocket implements MockWSocket, WSocket {
   StreamController _mocket = new StreamController();
 
   _MockWSocket() : super() {
-    webSocketSubscription = _mocket.stream.listen(onIncomingData,
-        onError: onIncomingError, onDone: onIncomingDone);
+    webSocketSubscription =
+        _mocket.stream.listen(onIncomingData, onDone: onIncomingDone);
   }
 
   @override
@@ -77,9 +83,8 @@ class _MockWSocket extends CommonWSocket implements MockWSocket, WSocket {
     close(code, reason);
   }
 
-  @override
   void triggerServerError(error, [StackTrace stackTrace]) {
-    _mocket.addError(error, stackTrace);
+    close();
   }
 
   @override
@@ -87,11 +92,6 @@ class _MockWSocket extends CommonWSocket implements MockWSocket, WSocket {
     closeCode = code;
     closeReason = reason;
     _mocket.close();
-  }
-
-  @override
-  void onIncomingError(error, [StackTrace stackTrace]) {
-    shutDown(error: error, stackTrace: stackTrace);
   }
 
   @override

--- a/lib/src/web_socket/mock/w_socket.dart
+++ b/lib/src/web_socket/mock/w_socket.dart
@@ -28,14 +28,33 @@ abstract class MockWSocket implements WSocket {
 
   factory MockWSocket() => new _MockWSocket();
 
+  /// Simulate an incoming message that the owner of this [WSocket] instance
+  /// will receive if listening.
   void addIncoming(data);
+
+  /// Register a callback that will be called for every outgoing data event that
+  /// the owner of this [WSocket] instance adds.
+  ///
+  /// [data] will either be the single data item or the stream, depending on
+  /// whether `add()` or `addStream()` was called.
   void onOutgoing(callback(data));
+
+  /// Cause the "server" to close, effectively severing the connection between
+  /// the server and client.
   void triggerServerClose([int code, String reason]);
+
+  /// Cause the "server" to add an error to the stream.
   void triggerServerError(error, [StackTrace stackTrace]);
 }
 
 class _MockWSocket extends CommonWSocket implements MockWSocket, WSocket {
+  /// List of "onOutgoing" callbacks that have been registered. Any time a piece
+  /// of data is added to the mock [WSocket], all callbacks in this list will be
+  /// called with said data, allowing them to react and mock out the server.
   List<Function> _callbacks = [];
+
+  /// The mock underlying WebSocket. Events are added manually via the
+  /// [MockWSocket] api.
   StreamController _mocket = new StreamController();
 
   _MockWSocket() : super() {
@@ -43,25 +62,22 @@ class _MockWSocket extends CommonWSocket implements MockWSocket, WSocket {
         onError: onIncomingError, onDone: onIncomingDone);
   }
 
-  /// Simulate an incoming message that the owner of this [WSocket] instance
-  /// will receive if listening.
+  @override
   void addIncoming(data) {
     _mocket.add(data);
   }
 
-  /// Register a callback that will be called for every outgoing data event that
-  /// the owner of this [WSocket] instance adds.
-  ///
-  /// [data] will either be the single data item or the stream, depending on
-  /// whether `add()` or `addStream()` was called.
+  @override
   void onOutgoing(callback(data)) {
     _callbacks.add(callback);
   }
 
+  @override
   void triggerServerClose([int code, String reason]) {
     close(code, reason);
   }
 
+  @override
   void triggerServerError(error, [StackTrace stackTrace]) {
     _mocket.addError(error, stackTrace);
   }

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -41,8 +41,7 @@ class VMWSocket extends CommonWSocket implements WSocket {
   WebSocket _webSocket;
 
   VMWSocket._(this._webSocket) : super() {
-    webSocketSubscription =
-        _webSocket.listen(onIncomingData, onError: onIncomingError, onDone: () {
+    webSocketSubscription = _webSocket.listen(onIncomingData, onDone: () {
       closeCode = _webSocket.closeCode;
       closeReason = _webSocket.closeReason;
       onIncomingDone();
@@ -52,11 +51,6 @@ class VMWSocket extends CommonWSocket implements WSocket {
   @override
   void closeWebSocket(int code, String reason) {
     _webSocket.close(code, reason);
-  }
-
-  @override
-  void onIncomingError(error, [StackTrace stackTrace]) {
-    shutDown(error: error, stackTrace: stackTrace);
   }
 
   @override

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -19,72 +19,73 @@ import 'dart:io';
 
 import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
-import 'package:w_transport/src/web_socket/w_socket_close_event.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
 class VMWSocket extends CommonWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
       {Iterable<String> protocols, Map<String, dynamic> headers}) async {
-    WebSocket socket;
+    WebSocket webSocket;
     try {
-      socket = await WebSocket.connect(uri.toString(),
+      webSocket = await WebSocket.connect(uri.toString(),
           protocols: protocols, headers: headers);
     } on SocketException catch (e) {
       throw new WSocketException(e.toString());
     }
 
-    return new VMWSocket._(socket);
+    return new VMWSocket._(webSocket);
   }
 
-  /// The underlying [WebSocket] instance.
-  WebSocket _socket;
+  WebSocket _webSocket;
 
-  /// Subscription to the incoming web socket data. Will be mapped to
-  /// the incoming stream controller.
-  StreamSubscription _socketSubscription;
-
-  VMWSocket._(WebSocket this._socket) : super() {
-    // The outgoing communication will be handled by this stream controller.
-    // The sink from this controller will be used by [add] and [addStream].
-    outgoing = new StreamController();
-    outgoing.stream.listen((message) {
-      // Pipe messages through to the underlying socket.
-      _socket.add(message);
-    }, onError: handleOutgoingError, onDone: handleOutgoingDone);
-
-    // The incoming communication will be handled by mapping a stream
-    // controller to a subscription to the underlying socket.
-    _socketSubscription = _socket.listen(
-        (data) {
-          // Pipe messages from the socket through to the stream.
-          incoming.add(data);
-        },
-        onError: handleSocketError,
-        onDone: () {
-          // Now that the socket has closed, capture the close code and reason.
-          var closeEvent =
-              new WSocketCloseEvent(_socket.closeCode, _socket.closeReason);
-          handleSocketDone(closeEvent);
-        });
-
-    // Map the incoming controller to this subscription to the web socket.
-    incoming = new StreamController(
-        onListen: _socketSubscription.resume,
-        onPause: _socketSubscription.pause,
-        onResume: _socketSubscription.resume);
+  VMWSocket._(this._webSocket) : super() {
+    webSocketSubscription =
+        _webSocket.listen(onIncomingData, onError: onIncomingError, onDone: () {
+      closeCode = _webSocket.closeCode;
+      closeReason = _webSocket.closeReason;
+      onIncomingDone();
+    });
   }
 
   @override
-  void closeSocket(int code, String reason) {
-    _socket.close(code, reason);
+  void closeWebSocket(int code, String reason) {
+    _webSocket.close(code, reason);
   }
 
-  /// Validate the WebSocket message data type. For server-side messages,
-  /// [String] and [List<int>] are valid types.
-  ///
-  /// Throws an [ArgumentError] if [data] is invalid.
   @override
-  void validateDataType(Object data) {
+  void onIncomingError(error, [StackTrace stackTrace]) {
+    shutDown(error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void onIncomingListen() {
+    // On the VM, we listen to the WebSocket immediately, so there's nothing to
+    // do here.
+  }
+
+  @override
+  void onIncomingPause() {
+    // On the VM, we are always listening to the WebSocket. Traditionally when
+    // a stream subscription is paused, the producer of events should stop
+    // producing events to avoid buffering that could lead to a memory leak.
+    // Instead of doing that, we check the status of the subscription to this
+    // [WSocket] instance whenever an event is dispatched and discard said event
+    // if it's paused. This is effectively the same.
+  }
+
+  @override
+  void onIncomingResume() {
+    // See the note in [onIncomingPause]. We don't actually pause the
+    // subscription to the WebSocket, so there's no need to resume it here.
+  }
+
+  @override
+  void onOutgoingData(data) {
+    // Pipe messages through to the underlying socket.
+    _webSocket.add(data);
+  }
+
+  @override
+  void validateOutgoingData(Object data) {
     if (data is! String && data is! List<int>) {
       throw new ArgumentError(
           'WSocket data type must be a String or a List<int>.');

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -21,6 +21,8 @@ import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
+/// Implementation of the platform-dependent pieces of the [WSocket] class for
+/// the Dart VM. This class uses native Dart WebSockets.
 class VMWSocket extends CommonWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
       {Iterable<String> protocols, Map<String, dynamic> headers}) async {
@@ -35,6 +37,7 @@ class VMWSocket extends CommonWSocket implements WSocket {
     return new VMWSocket._(webSocket);
   }
 
+  /// The underlying native WebSocket.
   WebSocket _webSocket;
 
   VMWSocket._(this._webSocket) : super() {

--- a/lib/src/web_socket/w_socket_close_event.dart
+++ b/lib/src/web_socket/w_socket_close_event.dart
@@ -15,6 +15,10 @@
 library w_transport.src.web_socket.w_socket_close_event;
 
 /// Represents the close event from a WebSocket.
+///
+/// This was previously only used internally, but was erroneously exported as a
+/// part of the public API. It is no longer used at all, and has thus been
+/// deprecated and will be removed in 3.0.0.
 @Deprecated('in 3.0.0')
 class WSocketCloseEvent {
   final int code;

--- a/lib/src/web_socket/w_socket_close_event.dart
+++ b/lib/src/web_socket/w_socket_close_event.dart
@@ -15,6 +15,7 @@
 library w_transport.src.web_socket.w_socket_close_event;
 
 /// Represents the close event from a WebSocket.
+@Deprecated('in 3.0.0')
 class WSocketCloseEvent {
   final int code;
   final String reason;

--- a/lib/src/web_socket/w_socket_subscription.dart
+++ b/lib/src/web_socket/w_socket_subscription.dart
@@ -40,7 +40,9 @@ class WSocketSubscription<T> implements StreamSubscription<T> {
   @override
   Future cancel() async {
     await _sub.cancel();
-    return _onCancel();
+    if (_onCancel != null) {
+      await _onCancel();
+    }
   }
 
   @override

--- a/lib/src/web_socket/w_socket_subscription.dart
+++ b/lib/src/web_socket/w_socket_subscription.dart
@@ -1,9 +1,36 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
+/// A representation of a `StreamSubscription` specific to the [WSocket] class.
+/// This subscription proxies the underlying subscription to the WebSocket while
+/// taking into account both the outgoing and incoming streams. In other words,
+/// this subscription is exactly the same, except that it isn't considered
+/// "done" until both the incoming and the outgoing subscriptions are closed.
 class WSocketSubscription<T> implements StreamSubscription<T> {
+  /// The callback given by the listener to be called when this subscription
+  /// is completely done.
   Function get doneHandler => _doneHandler;
   Function _doneHandler;
+
+  /// The callback given by the [WSocket] implementation to be called when this
+  /// subscription is canceled. This allows the [WSocket] instance to perform
+  /// necessary cleanup.
   Function _onCancel;
+
+  /// The `StreamSubscription` being proxied.
   StreamSubscription<T> _sub;
 
   WSocketSubscription(StreamSubscription this._sub, this._doneHandler,
@@ -20,7 +47,7 @@ class WSocketSubscription<T> implements StreamSubscription<T> {
   Future asFuture([var futureValue]) {
     var c = new Completer();
     _doneHandler = () {
-      c.complete();
+      c.complete(futureValue);
     };
     return c.future;
   }
@@ -36,6 +63,17 @@ class WSocketSubscription<T> implements StreamSubscription<T> {
   @override
   void pause([Future resumeSignal]) {
     _sub.pause();
+    if (resumeSignal != null) {
+      () async {
+        try {
+          await resumeSignal;
+        } catch (e) {
+          rethrow;
+        } finally {
+          resume();
+        }
+      }();
+    }
   }
 
   @override

--- a/lib/src/web_socket/w_socket_subscription.dart
+++ b/lib/src/web_socket/w_socket_subscription.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+class WSocketSubscription<T> implements StreamSubscription<T> {
+  Function get doneHandler => _doneHandler;
+  Function _doneHandler;
+  Function _onCancel;
+  StreamSubscription<T> _sub;
+
+  WSocketSubscription(StreamSubscription this._sub, this._doneHandler,
+      {Function onCancel})
+      : _onCancel = onCancel;
+
+  @override
+  Future cancel() async {
+    await _sub.cancel();
+    return _onCancel();
+  }
+
+  @override
+  Future asFuture([var futureValue]) {
+    var c = new Completer();
+    _doneHandler = () {
+      c.complete();
+    };
+    return c.future;
+  }
+
+  @override
+  bool get isPaused => _sub.isPaused;
+
+  @override
+  void resume() {
+    _sub.resume();
+  }
+
+  @override
+  void pause([Future resumeSignal]) {
+    _sub.pause();
+  }
+
+  @override
+  void onDone(void handleDone()) {
+    _doneHandler = handleDone;
+  }
+
+  @override
+  void onError(Function handleError) {
+    _sub.onError(handleError);
+  }
+
+  @override
+  void onData(void handleData(T data)) {
+    _sub.onData(handleData);
+  }
+}

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -21,7 +21,8 @@ import 'package:w_transport/w_transport.dart' show WSocket, WSocketException;
 
 import '../integration_paths.dart';
 
-void runCommonWebSocketIntegrationTests({connect(Uri uri), int port}) {
+void runCommonWebSocketIntegrationTests(
+    {Future<WSocket> connect(Uri uri), int port}) {
   if (connect == null) {
     connect = (uri) => WSocket.connect(uri);
   }
@@ -41,43 +42,44 @@ void runCommonWebSocketIntegrationTests({connect(Uri uri), int port}) {
   });
 
   test('add() should send a message', () async {
-    WSocket socket = await connect(echoUri);
-    WSHelper helper = new WSHelper(socket);
+    var webSocket = await connect(echoUri);
+    var helper = new WSHelper(webSocket);
 
-    socket.add('message');
+    webSocket.add('message');
     await helper.messagesReceived(1);
-    expect(await helper.messages.single, equals('message'));
-    await socket.close();
+    expect(helper.messages.single, equals('message'));
+    await webSocket.close();
   });
 
   test('add() should support sending multiple messages', () async {
-    WSocket socket = await connect(echoUri);
-    WSHelper helper = new WSHelper(socket);
+    var webSocket = await connect(echoUri);
+    var helper = new WSHelper(webSocket);
 
-    socket.add('message1');
-    socket.add('message2');
+    webSocket.add('message1');
+    webSocket.add('message2');
     await helper.messagesReceived(2);
-    expect(await helper.messages, unorderedEquals(['message1', 'message2']));
-    await socket.close();
+    expect(helper.messages, unorderedEquals(['message1', 'message2']));
+    await webSocket.close();
   });
 
   test('add() should throw after sink has been closed', () async {
-    WSocket socket = await connect(echoUri);
-    await socket.close();
+    var webSocket = await connect(echoUri);
+    await webSocket.close();
+    print('closed');
     expect(() {
-      socket.add('too late');
+      webSocket.add('too late');
     }, throwsStateError);
   });
 
   test('addError() should close the socket with an error that can be caught',
       () async {
-    WSocket socket = await connect(echoUri);
-    socket.addError(
+    var webSocket = await connect(echoUri);
+    webSocket.addError(
         new Exception('Exception should close the socket with an error.'));
 
     var error;
     try {
-      await socket.done;
+      await webSocket.done;
     } catch (e) {
       error = e;
     }
@@ -87,133 +89,133 @@ void runCommonWebSocketIntegrationTests({connect(Uri uri), int port}) {
   });
 
   test('addStream() should send a Stream of data', () async {
-    WSocket socket = await connect(echoUri);
-    WSHelper helper = new WSHelper(socket);
+    var webSocket = await connect(echoUri);
+    var helper = new WSHelper(webSocket);
 
     var stream = new Stream.fromIterable(['message1', 'message2']);
-    socket.addStream(stream);
+    webSocket.addStream(stream);
     await helper.messagesReceived(2);
-    expect(await helper.messages, unorderedEquals(['message1', 'message2']));
-    await socket.close();
+    expect(helper.messages, unorderedEquals(['message1', 'message2']));
+    await webSocket.close();
   });
 
   test('addStream() should support sending multiple Streams serially',
       () async {
-    WSocket socket = await connect(echoUri);
-    WSHelper helper = new WSHelper(socket);
+    var webSocket = await connect(echoUri);
+    var helper = new WSHelper(webSocket);
 
     var stream1 = new Stream.fromIterable(['message1a', 'message2a']);
     var stream2 = new Stream.fromIterable(['message1b', 'message2b']);
-    await socket.addStream(stream1);
-    await socket.addStream(stream2);
+    await webSocket.addStream(stream1);
+    await webSocket.addStream(stream2);
     await helper.messagesReceived(4);
-    expect(await helper.messages,
+    expect(helper.messages,
         unorderedEquals(['message1a', 'message1b', 'message2a', 'message2b']));
-    await socket.close();
+    await webSocket.close();
   });
 
   test('addStream() should throw if multiple Streams added concurrently',
       () async {
-    WSocket socket = await connect(echoUri);
+    var webSocket = await connect(echoUri);
 
     var stream = new Stream.fromIterable(['message1', 'message2']);
-    var firstFuture = socket.addStream(stream);
-    var lateFuture = socket.addStream(stream);
+    var firstFuture = webSocket.addStream(stream);
+    var lateFuture = webSocket.addStream(stream);
     expect(lateFuture, throwsStateError);
     await firstFuture;
     try {
       await lateFuture;
     } catch (e) {}
     try {
-      await socket.close();
+      await webSocket.close();
     } catch (e) {}
   });
 
   test('addStream() should throw after sink has been closed', () async {
-    WSocket socket = await connect(echoUri);
-    await socket.close();
-    expect(socket.addStream(new Stream.fromIterable(['too late'])),
+    var webSocket = await connect(echoUri);
+    await webSocket.close();
+    expect(webSocket.addStream(new Stream.fromIterable(['too late'])),
         throwsStateError);
   });
 
   test('addStream() should cause socket to close if error is added', () async {
-    WSocket socket = await connect(echoUri);
+    var webSocket = await connect(echoUri);
     var controller = new StreamController();
     controller.add('message1');
     controller.addError(new Exception('addStream error, should close socket'));
     controller.close();
-    await socket.addStream(controller.stream);
-    expect(socket.done, throwsException);
+    await webSocket.addStream(controller.stream);
+    expect(webSocket.done, throwsException);
   });
 
   test('should support listening to incoming messages', () async {
-    WSocket socket = await connect(pingUri);
-    WSHelper helper = new WSHelper(socket);
+    var webSocket = await connect(pingUri);
+    var helper = new WSHelper(webSocket);
 
-    socket.add('ping2');
+    webSocket.add('ping2');
     await helper.messagesReceived(2);
 
-    expect(await helper.messages, unorderedEquals(['pong', 'pong']));
-    await socket.close();
+    expect(helper.messages, unorderedEquals(['pong', 'pong']));
+    await webSocket.close();
   });
 
   test('should not allow multiple listeners by default', () async {
-    WSocket socket = await connect(echoUri);
-    socket.listen((_) {});
+    var webSocket = await connect(echoUri);
+    webSocket.listen((_) {});
     expect(() {
-      socket.listen((_) {});
+      webSocket.listen((_) {});
     }, throwsStateError);
-    await socket.close();
+    await webSocket.close();
   });
 
   test('should not lose messages if a listener is registered late', () async {
-    WSocket socket = await connect(pingUri);
-    socket.add('ping3');
+    var webSocket = await connect(pingUri);
+    webSocket.add('ping3');
 
-    await new Future.delayed(new Duration(seconds: 1));
-    WSHelper helper = new WSHelper(socket);
+    await new Future.delayed(new Duration(milliseconds: 500));
+    var helper = new WSHelper(webSocket);
     await helper.messagesReceived(3);
 
-    expect(await helper.messages, unorderedEquals(['pong', 'pong', 'pong']));
-    await socket.close();
-  });
+    expect(helper.messages, unorderedEquals(['pong', 'pong', 'pong']));
+    await webSocket.close();
+  }, skip: 'AC changed');
 
   test('should call onDone() when socket closes', () async {
-    WSocket socket = await connect(echoUri);
+    var webSocket = await connect(echoUri);
 
     Completer c = new Completer();
-    socket.listen((_) {}, onDone: () {
+    webSocket.listen((_) {}, onDone: () {
       c.complete();
     });
 
-    socket.close();
+    webSocket.close();
     await c.future;
   });
 
   test('should have the close code and reason available in onDone() callback',
       () async {
-    WSocket socket = await connect(echoUri);
+    var webSocket = await connect(echoUri);
 
     Completer c = new Completer();
-    socket.listen((_) {}, onDone: () {
-      expect(socket.closeCode, equals(4001));
-      expect(socket.closeReason, equals('Closed.'));
+    webSocket.listen((_) {}, onDone: () {
+      expect(webSocket.closeCode, equals(4001));
+      expect(webSocket.closeReason, equals('Closed.'));
 
       c.complete();
     });
 
-    socket.add('echo');
+    webSocket.add('echo');
 
-    new Timer(new Duration(seconds: 1), () {
-      socket.close(4001, 'Closed.');
+    new Timer(new Duration(milliseconds: 500), () {
+      webSocket.close(4001, 'Closed.');
     });
 
     await c.future;
   });
 
   test('should work as a broadcast stream', () async {
-    WSocket socket = await connect(pingUri);
-    Stream stream = socket.asBroadcastStream();
+    var webSocket = await connect(pingUri);
+    Stream stream = webSocket.asBroadcastStream();
 
     Completer c1 = new Completer();
     Completer c2 = new Completer();
@@ -225,60 +227,168 @@ void runCommonWebSocketIntegrationTests({connect(Uri uri), int port}) {
       c2.complete();
     });
 
-    socket.add('ping');
+    webSocket.add('ping');
 
     await Future.wait([c1.future, c2.future]);
-    await socket.close();
+    await webSocket.close();
   });
 
   test('should have the close code and reason available after closing',
       () async {
-    WSocket socket = await connect(echoUri);
-    await socket.close(4001, 'Closed.');
-    expect(socket.closeCode, equals(4001));
-    expect(socket.closeReason, equals('Closed.'));
+    var webSocket = await connect(echoUri);
+    await webSocket.close(4001, 'Closed.');
+    expect(webSocket.closeCode, equals(4001));
+    expect(webSocket.closeReason, equals('Closed.'));
   });
 
   test(
       'should close and properly drain stream even if no listeners were registered',
       () async {
-    WSocket socket = await connect(echoUri);
-    await socket.close();
+    var webSocket = await connect(echoUri);
+    await webSocket.close();
   });
 
   test('should handle the server closing the connection', () async {
-    WSocket socket = await connect(closeUri);
-    socket.add(_closeRequest());
-    await socket.done;
+    var webSocket = await connect(closeUri);
+    webSocket.add(_closeRequest());
+    await webSocket.done;
   });
 
   test(
       'should ignore close() being called after the server closes the connection',
       () async {
-    WSocket socket = await connect(closeUri);
-    socket.add(_closeRequest(4001, 'Closed by server.'));
-    await socket.done;
-    await socket.close(4002, 'Late close.');
-    expect(socket.closeCode, equals(4001));
-    expect(socket.closeReason, equals('Closed by server.'));
+    var webSocket = await connect(closeUri);
+    webSocket.add(_closeRequest(4001, 'Closed by server.'));
+    await webSocket.done;
+    await webSocket.close(4002, 'Late close.');
+    expect(webSocket.closeCode, equals(4001));
+    expect(webSocket.closeReason, equals('Closed by server.'));
   });
 
   test('should ignore close() calls after the first', () async {
-    WSocket socket = await connect(echoUri);
-    await socket.close(4001, 'Custom close.');
-    await socket.close(4002, 'Late close.');
-    expect(socket.closeCode, equals(4001));
-    expect(socket.closeReason, equals('Custom close.'));
+    var webSocket = await connect(echoUri);
+    await webSocket.close(4001, 'Custom close.');
+    await webSocket.close(4002, 'Late close.');
+    expect(webSocket.closeCode, equals(4001));
+    expect(webSocket.closeReason, equals('Custom close.'));
   });
 
   test(
       'should report the close code and reason that the server used when closing the connection',
       () async {
-    WSocket socket = await connect(closeUri);
+    var socket = await connect(closeUri);
     socket.add(_closeRequest(4001, 'Closed by server.'));
     await socket.done;
     expect(socket.closeCode, equals(4001));
     expect(socket.closeReason, equals('Closed by server.'));
+  });
+
+  test('message events should be discarded prior to a subscription', () async {
+    var webSocket = await connect(echoUri);
+
+    webSocket.add('1');
+    webSocket.add('2');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    var messages = [];
+    webSocket.listen((data) {
+      messages.add(data);
+    });
+
+    webSocket.add('3');
+    webSocket.add('4');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    await webSocket.close();
+    expect(messages, orderedEquals(['3', '4']));
+  });
+
+  test(
+      'the first event should be received if a subscription is made immediately',
+      () async {
+    var webSocket = await connect(echoUri);
+
+    var c = new Completer();
+    webSocket.listen((data) {
+      c.complete(data);
+    });
+    webSocket.add('first');
+
+    expect(await c.future, equals('first'));
+    await webSocket.close();
+  });
+
+  test('all event streams should respect pause() and resume() signals',
+      () async {
+    var webSocket = await connect(echoUri);
+    var messages = [];
+
+    // no subscription yet, messages should be discarded
+    webSocket.add('1');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    // setup a subscription, messages should be recorded
+    var sub = webSocket.listen((data) {
+      messages.add(data);
+    });
+    webSocket.add('2');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    // pause the subscription, messages should be discarded
+    sub.pause();
+    await new Future.delayed(new Duration(milliseconds: 500));
+    webSocket.add('3');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    // resume the subscription, messages should be recorded again
+    sub.resume();
+    await new Future.delayed(new Duration(milliseconds: 500));
+    webSocket.add('4');
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    expect(messages, orderedEquals(['2', '4']));
+    await webSocket.close();
+  });
+
+  test('should support reassigning the onData() handler', () async {
+    var webSocket = await connect(echoUri);
+
+    var origMessages = [];
+    var origOnData = (data) {
+      origMessages.add(data);
+    };
+
+    var newMessages = [];
+    var newOnData = (data) {
+      newMessages.add(data);
+    };
+
+    var subscription = webSocket.listen(origOnData);
+    webSocket.add('1');
+    webSocket.add('2');
+    // SockJS requires a delay longer than 1 tick for the echos to be received.
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    subscription.onData(newOnData);
+    webSocket.add('3');
+    webSocket.add('4');
+    // SockJS requires a delay longer than 1 tick for the echos to be received.
+    await new Future.delayed(new Duration(milliseconds: 500));
+
+    expect(origMessages, orderedEquals(['1', '2']));
+    expect(newMessages, orderedEquals(['3', '4']));
+    await webSocket.close();
+  });
+
+  test('should support reassigning the onDone() handler', () async {
+    var webSocket = await connect(closeUri);
+    var c = new Completer();
+    var subscription = webSocket.listen((_) {}, onDone: () {});
+    subscription.onDone(() {
+      c.complete();
+    });
+    webSocket.add(_closeRequest());
+    await c.future;
   });
 }
 

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -79,7 +79,7 @@ void main() {
             numPongs = int.parse(data);
           } catch (e) {}
           for (int i = 0; i < numPongs; i++) {
-            await new Future.delayed(new Duration(milliseconds: 50));
+            await new Future.delayed(new Duration(milliseconds: 5));
             webSocket.addIncoming('pong');
           }
         });

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -38,6 +38,7 @@ import 'mocks/mock_response_test.dart' as mock_response_test;
 import 'mocks/mock_web_socket_test.dart' as mock_web_socket_test;
 
 import 'ws/w_socket_exception_test.dart' as ws_w_socket_exception_test;
+import 'ws/w_socket_subscription_test.dart' as ws_w_socket_subscription_test;
 import 'ws/w_socket_test.dart' as ws_w_socket_test;
 
 void main() {
@@ -62,5 +63,6 @@ void main() {
   mock_web_socket_test.main();
 
   ws_w_socket_exception_test.main();
+  ws_w_socket_subscription_test.main();
   ws_w_socket_test.main();
 }

--- a/test/unit/ws/w_socket_subscription_test.dart
+++ b/test/unit/ws/w_socket_subscription_test.dart
@@ -1,0 +1,93 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm || browser')
+library w_transport.test.unit.ws.w_socket_subscription_test;
+
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:w_transport/src/web_socket/w_socket_subscription.dart';
+
+import '../../naming.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..testType = testTypeUnit
+    ..topic = topicWebSocket;
+
+  group(naming.toString(), () {
+    group('WSocketSubscription', () {
+      test('cancel() should cancel underlying subscription and call callback',
+          () async {
+        var subCanceled = new Completer();
+        var onCancelCalled = new Completer();
+
+        var sc = new StreamController(onCancel: subCanceled.complete);
+        var sub = sc.stream.listen((_) {});
+        var wsub = new WSocketSubscription(sub, () {},
+            onCancel: onCancelCalled.complete);
+
+        await Future
+            .wait([wsub.cancel(), subCanceled.future, onCancelCalled.future,]);
+      });
+
+      test('isPaused should return the status of the underlying subscription',
+          () {
+        var sc = new StreamController();
+        var sub = sc.stream.listen((_) {});
+        var wsub = new WSocketSubscription(sub, () {});
+
+        expect(sub.isPaused, isFalse);
+        expect(wsub.isPaused, isFalse);
+
+        sub.pause();
+        expect(sub.isPaused, isTrue);
+        expect(wsub.isPaused, isTrue);
+      });
+
+      test('onDone() should update the done handler', () {
+        var sub = new MockStreamSubscription();
+        var wsub = new WSocketSubscription(sub, () {});
+        var doneHandler = () {};
+
+        wsub.onDone(doneHandler);
+        expect(wsub.doneHandler, equals(doneHandler));
+      });
+
+      test('onError() should call onError() on the underlying subscription',
+          () {
+        var sub = new MockStreamSubscription();
+        var wsub = new WSocketSubscription(sub, () {});
+        var errorHandler = (_) {};
+
+        wsub.onError(errorHandler);
+        verify(sub.onError(errorHandler));
+      });
+
+      test('onData() should call onData() on the underlying subscription', () {
+        var sub = new MockStreamSubscription();
+        var wsub = new WSocketSubscription(sub, () {});
+        var dataHandler = (_) {};
+
+        wsub.onData(dataHandler);
+        verify(sub.onData(dataHandler));
+      });
+    });
+  });
+}
+
+class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}

--- a/test/unit/ws/w_socket_test.dart
+++ b/test/unit/ws/w_socket_test.dart
@@ -206,14 +206,14 @@ void main() {
         webSocket.addError(new Exception('web socket consumer error'));
       });
 
-      test('error from the socket should be stored and close the socket',
-          () async {
+      // TODO: remove this test once triggerServerError has been removed
+      test('DEPRECATED: error should close the socket', () async {
         var mockWebSocket = new MockWSocket();
         MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
         var webSocket = await WSocket.connect(webSocketUri);
 
-        expect(webSocket.done, throwsException);
         mockWebSocket.triggerServerError(new Exception('Server Exception'));
+        await webSocket.done;
       });
 
       test('server closing the connection should close the socket', () async {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -14,9 +14,6 @@
 
 import 'dart:async';
 
-Future nextTick([int numTicks = 1]) async {
-  int i = 0;
-  while (i++ < numTicks) {
-    return new Future.delayed(new Duration(milliseconds: 1));
-  }
+Future nextTick() {
+  return new Future.delayed(new Duration(milliseconds: 1));
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,5 +1,22 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
-Future nextTick() {
-  return new Future.delayed(new Duration(milliseconds: 1));
+Future nextTick([int numTicks = 1]) async {
+  int i = 0;
+  while (i++ < numTicks) {
+    return new Future.delayed(new Duration(milliseconds: 1));
+  }
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,5 @@
+import 'dart:async';
+
+Future nextTick() {
+  return new Future.delayed(new Duration(milliseconds: 1));
+}

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -43,7 +43,7 @@ main(List<String> args) async {
 
   config.coverage
     ..reportOn = ['lib/']
-    ..before = [_startServer, _startSockJSServer]
+    ..before = [_streamServer, _streamSockJSServer]
     ..after = [_stopServer, _stopSockJSServer];
 
   config.examples
@@ -64,7 +64,7 @@ main(List<String> args) async {
       'test/integration/vm_integration_test.dart'
     ]
     ..platforms = ['vm', 'content-shell']
-    ..before = [_startServer, _startSockJSServer]
+    ..before = [_streamServer, _streamSockJSServer]
     ..after = [_stopServer, _stopSockJSServer];
 
   await dev(args);
@@ -81,24 +81,6 @@ List<String> _serverOutput;
 
 /// Output from the SockJS server.
 List<String> _sockJSServerOutput;
-
-/// Start the server needed for integration tests and examples and cache the
-/// server output until the task requiring the server has finished. Then, the
-/// server output will be dumped all at once.
-Future _startServer() async {
-  _serverOutput = [];
-  _server = new Server();
-  _server.output.listen(_serverOutput.add);
-  await _server.start();
-}
-
-Future _startSockJSServer() async {
-  _sockJSServerOutput = [];
-  _sockJSServer = new TaskProcess('node', ['tool/server/sockjs.js']);
-  _sockJSServer.stdout.listen(_sockJSServerOutput.add);
-  _sockJSServer.stderr.listen(_sockJSServerOutput.add);
-  // todo: wait for server to start
-}
 
 /// Start the server needed for integration tests and examples and stream the
 /// server output as it arrives. The output will be mixed in with output from


### PR DESCRIPTION
_Fixes #134._

## Issue
- `WSocket` extends `Stream` and `StreamSink`, but was not fulfilling those contracts in all scenarios. In particular:
  - After obtaining a `StreamSubscription` instance from a call to `WSocket.listen()`, reassigning the `onData()`, `onError()`, and `onDone()` handlers had no effect.

      ```dart
      var webSocket = await WSocket.connect(...);
      var subscription = webSocket.listen((data) { ... });

      // This does nothing:
      subscription.onData((data) { ... });
      // Same goes for onError() and onDone()
      ```

  - A subscription to a `WSocket` instance did not properly respect pause and resume signals. This could produce a memory leak by buffering WebSocket events indefinitely.

  - A `WSocket` instance was immediately listening to the underlying WebSocket and buffering events from the underlying WebSocket until a listener was registered. This is not how a standard Dart `Stream` works.

  - The SockJS configuration was not properly handling the fact that the SockJS `Client` produces WebSocket events with a broadcast stream.

## Solution

- The `WSocket` implementation has been refactored such that it behaves exactly like a standard Dart `Stream` and `StreamSink`. This involved several things:

  - Proxying the subscription to the underlying WebSocket so that the `onDone()`, `onData()`, and `onError()` handlers could be properly reassigned via the `StreamSubscription` api. This was necessary because the `WSocket` instance is not considered "done" until both the outgoing and the incoming streams are finished closing. Just relying on the "done" event from the subscription to the incoming stream would be inadequate and may fire earlier than desired.

  - Respecting the state of the subscription to the `WSocket` instance. If it is paused, events from the underlying WebSocket are discarded to prevent buffering of events indefinitely which would cause a memory leak. This is in line with how standard Dart streams work - if the subscription is paused, no events should be added to the stream.

  - Handling the fact that the SockJS `Client` produces events from a single broadcast stream. This is different than the native `WebSocket` instances because they are single-subscription streams by default. To account for this, the `WSocket` instance waits to subscribe to the broadcast stream until the `onListen` event. Then if the subscription to the `WSocket` instance is paused, the subscription to the underlying SockJS stream is canceled. Finally, if a paused subscription to the `WSocket` instance is resumed, we re-subscribe to the SockJS stream. This is the recommended solution for dealing with subscriptions to broadcast streams.

- **All of the issues mentioned in the "Issues" section have been addressed, and every `WSocket` instance should now behave exactly as a standard `Stream` and `StreamSink` would, regardless of the platform (VM, browser, SockJS, or mock).**

## Testing
- [ ] CI passes.
- [ ] WebSocket examples still work as expected.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@sebastianmalysa-wf 
@jayudey-wf 

fyi: @stevenosborne-wf @tayloranderson-wf 