### PR TITLE
CP-1862 Upgrade to sockjs-dart-client 0.3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
-      ref: 0.3.0
+      ref: 0.3.1
   stack_trace: "^1.4.0"
 dev_dependencies:
   ansicolor: "^0.0.9"


### PR DESCRIPTION
## Issue
sockjs-dart-client version 0.3.1 was released with a bug fix, but we haven't yet updated our dependency to point to that version.

## Solution
Point to sockjs-dart-client 0.3.1

## Testing
- [ ] CI Passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@sebastianmalysa-wf 
@jayudey-wf 

fyi: @dominicfrost-wf 