### PR TITLE
CP-1884 Fix Coverage, w_transport

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment:
+  layout: header
+coverage:
+  status:
+    patch:
+      default:
+        target: '100'
+    project:
+      default:
+        target: '98'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   ansicolor: "^0.0.9"
   args: "^0.13.0"
   browser: "^0.10.0+2"
-  coverage: "^0.7.2"
+  coverage: "^0.7.4"
   dart_dev: "^1.0.0"
   dart_style: "^0.2.1"
   dartdoc: ">=0.4.0 <0.7.0"


### PR DESCRIPTION
## Issue
Coverage should be working with the latest Dart SDK release (1.17.0) and at least `coverage` 0.7.4. Additionally, codecov.io made a change that now requires configuration to be set in a `codecov.yml` file instead of through their UI. This is why code coverage comments and the CI status check have not been appearing on recent PRs.

## Solution
Upgrade to `coverage ^0.7.4` and add a `codecov.yml`.

## Testing
- [ ] CI passes (in particular, the coverage step)
- [ ] Coverage is reported to codecov.io
- [ ] Coverage comment is added to this PR
- [ ] Coverage CI check shows up and passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 