### PR TITLE
CP-1725 Release w_transport 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.4.0
+version: 2.5.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1725

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



======= w_transport 2.5.0 items =======

 CP-1918  - Update changelog for 2.5.0  - https://github.com/Workiva/w_transport/pull/149

 CP-1880  - WSocket: StreamSubscription onError, onDone aren't honored  - https://github.com/Workiva/w_transport/pull/142

 CP-1884  - Fix Coverage, w_transport  - https://github.com/Workiva/w_transport/pull/146

 CP-1862  - Upgrade to sockjs-dart-client 0.3.1  - https://github.com/Workiva/w_transport/pull/145
======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.4.0...CP-1725_release_2.5.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.4.0...2.5.0

