### PR TITLE
CP-1939 Allow content-type to be set manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## [2.6.0](https://github.com/Workiva/w_transport/compare/2.5.1...2.6.0)
-_TBD_
+## [2.6.0](https://github.com/Workvia/w_transport/compare/2.5.1...2.6.0)
+_June 20, 2016_
 
 - **Improvement:** The `MockTransport` utilities now support expecting
   and registering handlers for HTTP requests and WS connections that
@@ -37,6 +37,28 @@ _TBD_
       return webSocket;
     });
     ```
+
+- **Improvement:** the content-type for HTTP requests can now be set manually.
+
+    ```dart
+    var request = new Request()
+      ..uri = Uri.parse('/example')
+      ..contentType =
+          new MediaType('application', 'x-custom', {'charset': UTF8.name});
+    ```
+
+  - The content-type still has a default value based on the type of request
+    (`Request` - text/plain, `JsonRequest` - application/json, etc.).
+
+  - The content-type's charset parameter will still be updated automatically
+    when you set the `encoding`, **but once you manually set `contentType`, this
+    behavior will stop.** In other words, we are assuming that if you set
+    `contentType` manually, you are intentionally overriding the defaults and
+    are taking responsibility of setting the `charset` parameter appropriately.
+
+- **Bug Fix:** the `StreamedRequest` now properly verifies that the request has
+  not been sent when setting `contentType`. It will now throw a `StateError`
+  like the rest of the request types.
 
 ## [2.5.1](https://github.com/Workiva/w_transport/compare/2.5.0...2.5.1)
 _June 16, 2016_

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -113,13 +113,20 @@ abstract class CommonMultipartRequest extends CommonRequest
   }
 
   @override
+  set contentType(MediaType contentType) {
+    throw new UnsupportedError(
+        'The content-type of a multipart request cannot be set manually.');
+  }
+
+  @override
   MediaType get defaultContentType =>
       new MediaType('multipart', 'form-data', {'boundary': boundary});
 
   @override
   set encoding(Encoding encoding) {
     throw new UnsupportedError(
-        'A multipart request has many individually-encoded parts. An encoding cannot be set for the entire request.');
+        'A multipart request has many individually-encoded parts. An encoding '
+        'cannot be set for the entire request.');
   }
 
   Map<String, String> get fields =>

--- a/lib/src/http/common/streamed_request.dart
+++ b/lib/src/http/common/streamed_request.dart
@@ -50,11 +50,6 @@ abstract class CommonStreamedRequest extends CommonRequest
   }
 
   @override
-  set contentType(MediaType contentType) {
-    updateContentType(contentType);
-  }
-
-  @override
   MediaType get defaultContentType =>
       new MediaType('text', 'plain', {'charset': encoding.name});
 

--- a/test/integration/http/form_request/suite.dart
+++ b/test/integration/http/form_request/suite.dart
@@ -59,6 +59,18 @@ void runFormRequestSuite() {
       expect(contentType.mimeType, equals('application/x-www-form-urlencoded'));
     });
 
+    test('content-type should be overridable', () async {
+      var contentType = new MediaType('application', 'x-custom');
+      FormRequest request = new FormRequest()
+        ..uri = IntegrationPaths.reflectEndpointUri
+        ..fields['field'] = 'value'
+        ..contentType = contentType;
+      Response response = await request.post();
+      var reflectedContentType = new MediaType.parse(
+          response.body.asJson()['headers']['content-type']);
+      expect(reflectedContentType.mimeType, equals(contentType.mimeType));
+    });
+
     test('UTF8', () async {
       FormRequest request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri

--- a/test/integration/http/json_request/suite.dart
+++ b/test/integration/http/json_request/suite.dart
@@ -54,6 +54,18 @@ void runJsonRequestSuite() {
       expect(contentType.mimeType, equals('application/json'));
     });
 
+    test('content-type should be overridable', () async {
+      var contentType = new MediaType('application', 'x-custom');
+      JsonRequest request = new JsonRequest()
+        ..uri = IntegrationPaths.reflectEndpointUri
+        ..body = {'field1': 'value1', 'field2': 'value2'}
+        ..contentType = contentType;
+      Response response = await request.post();
+      var reflectedContentType = new MediaType.parse(
+          response.body.asJson()['headers']['content-type']);
+      expect(reflectedContentType.mimeType, equals(contentType.mimeType));
+    });
+
     test('UTF8', () async {
       JsonRequest request = new JsonRequest()
         ..uri = IntegrationPaths.echoEndpointUri

--- a/test/integration/http/plain_text_request/suite.dart
+++ b/test/integration/http/plain_text_request/suite.dart
@@ -54,6 +54,18 @@ void runPlainTextRequestSuite() {
       expect(contentType.mimeType, equals('text/plain'));
     });
 
+    test('content-type should be overridable', () async {
+      var contentType = new MediaType('application', 'x-custom');
+      Request request = new Request()
+        ..uri = IntegrationPaths.reflectEndpointUri
+        ..body = 'data'
+        ..contentType = contentType;
+      Response response = await request.post();
+      var reflectedContentType = new MediaType.parse(
+          response.body.asJson()['headers']['content-type']);
+      expect(reflectedContentType.mimeType, equals(contentType.mimeType));
+    });
+
     test('UTF8', () async {
       Request request = new Request()
         ..uri = IntegrationPaths.echoEndpointUri

--- a/test/integration/http/streamed_request/suite.dart
+++ b/test/integration/http/streamed_request/suite.dart
@@ -69,6 +69,19 @@ void runStreamedRequestSuite() {
       expect(contentType.mimeType, equals('text/plain'));
     });
 
+    test('content-type should be overridable', () async {
+      var contentType = new MediaType('application', 'x-custom');
+      StreamedRequest request = new StreamedRequest()
+        ..uri = IntegrationPaths.reflectEndpointUri
+        ..body = new Stream.fromIterable([])
+        ..contentLength = 0
+        ..contentType = contentType;
+      Response response = await request.post();
+      var reflectedContentType = new MediaType.parse(
+          response.body.asJson()['headers']['content-type']);
+      expect(reflectedContentType.mimeType, equals(contentType.mimeType));
+    });
+
     test('UTF8', () async {
       StreamedRequest request = new StreamedRequest()
         ..uri = IntegrationPaths.echoEndpointUri

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -35,11 +35,6 @@ void main() {
         configureWTransportForTest();
       });
 
-      test('content-type cannot be set manually', () {
-        JsonRequest request = new JsonRequest();
-        expect(() => request.contentType = null, throwsUnsupportedError);
-      });
-
       test('setting entire body (Map)', () {
         Map json = {'field': 'value'};
         JsonRequest request = new JsonRequest()..body = json;
@@ -135,6 +130,33 @@ void main() {
 
         request.encoding = ASCII;
         expect(request.contentType.parameters['charset'], equals(ASCII.name));
+      });
+
+      test(
+          'setting encoding should not update content-type if content-type has been set manually',
+          () {
+        JsonRequest request = new JsonRequest();
+        expect(request.contentType.parameters['charset'], equals(UTF8.name));
+
+        // Manually override content-type.
+        request.contentType =
+            new MediaType('application', 'x-custom', {'charset': LATIN1.name});
+        expect(request.contentType.mimeType, equals('application/x-custom'));
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+
+        // Changes to encoding should no longer update the content-type.
+        request.encoding = ASCII;
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+      });
+
+      test('setting content-type should not be allowed once sent', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('GET', uri);
+        JsonRequest request = new JsonRequest();
+        await request.get(uri: uri);
+        expect(() {
+          request.contentType = new MediaType('application', 'x-custom');
+        }, throwsStateError);
       });
 
       test('setting encoding should not be allowed once sent', () async {

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -35,11 +35,6 @@ void main() {
         configureWTransportForTest();
       });
 
-      test('content-type cannot be set manually', () {
-        Request request = new Request();
-        expect(() => request.contentType = null, throwsUnsupportedError);
-      });
-
       test('setting body (string)', () {
         Request request = new Request();
 
@@ -131,6 +126,33 @@ void main() {
 
         request.encoding = ASCII;
         expect(request.contentType.parameters['charset'], equals(ASCII.name));
+      });
+
+      test(
+          'setting encoding should not update content-type if content-type has been set manually',
+          () {
+        Request request = new Request();
+        expect(request.contentType.parameters['charset'], equals(UTF8.name));
+
+        // Manually override content-type.
+        request.contentType =
+            new MediaType('application', 'x-custom', {'charset': LATIN1.name});
+        expect(request.contentType.mimeType, equals('application/x-custom'));
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+
+        // Changes to encoding should no longer update the content-type.
+        request.encoding = ASCII;
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+      });
+
+      test('setting content-type should not be allowed once sent', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('GET', uri);
+        Request request = new Request();
+        await request.get(uri: uri);
+        expect(() {
+          request.contentType = new MediaType('application', 'x-custom');
+        }, throwsStateError);
       });
 
       test('setting encoding should not be allowed once sent', () async {

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -115,6 +115,33 @@ void main() {
         expect(request.contentType.parameters['charset'], equals(ASCII.name));
       });
 
+      test(
+          'setting encoding should not update content-type if content-type has been set manually',
+          () {
+        StreamedRequest request = new StreamedRequest();
+        expect(request.contentType.parameters['charset'], equals(UTF8.name));
+
+        // Manually override content-type.
+        request.contentType =
+            new MediaType('application', 'x-custom', {'charset': LATIN1.name});
+        expect(request.contentType.mimeType, equals('application/x-custom'));
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+
+        // Changes to encoding should no longer update the content-type.
+        request.encoding = ASCII;
+        expect(request.contentType.parameters['charset'], equals(LATIN1.name));
+      });
+
+      test('setting content-type should not be allowed once sent', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('GET', uri);
+        StreamedRequest request = new StreamedRequest();
+        await request.get(uri: uri);
+        expect(() {
+          request.contentType = new MediaType('application', 'x-custom');
+        }, throwsStateError);
+      });
+
       test('setting encoding should not be allowed once sent', () async {
         Uri uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);


### PR DESCRIPTION
## Improvement
Currently every request's content-type is set automatically (with the exception of `StreamedRequest`) based on the request type and the encoding. This is too inflexible as there are valid use cases for wanting to override the content-type like integration with a server that expects a certain content-type.

It was requested by @stevenosborne-wf that we add support for manually setting the content-type.

## Changes
- `FormRequest.contentType`, `JsonRequest.contentType`, and `Request.contentType` can now be set manually.

- `MultipartRequest.contentType` **still cannot** be set manually because a multipart request requires a specific content-type with a boundary string parameter.

- `StreamedRequest.contentType` was already overridable by consumers since the content is not known prior to opening the request. This is still the case, but I fixed a bug where we weren't verifying that the request had not yet been sent when setting the content-type.

- Previously, the content-type would be automatically updated when the encoding was changed. This is still the default behavior, but **once a user manually sets the content-type, this will stop**. In other words, we are assuming that a consumer who sets the content-type manually is intentionally overriding the defaults and is taking responsibility of setting the charset parameter appropriately.

- Technically, since the `StreamedRequest` already allowed consumers to manually set the content-type but did not enforce the behavior described in the previous point, the expected behavior of existing code could change in only this exact scenario:

    ```dart
    var streamedRequest = new StreamedRequest()
      ..uri = Uri.parse('/example')
      ..contentLength = 100
      ..contentType = new MediaType('application', 'octet-stream')
      ..encoding = UTF8;
    ```

  Previously, setting `encoding` after `contentType` would have triggered an update to the content-type to include a `charset: utf-8` parameter, but after this change, this will no longer happen.

## Testing

- [ ] CI passes (tests updated and new tests added, should be 100% patch coverage)
- [ ] Examples still work as expected

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 

fyi: @stevenosborne-wf 