### PR TITLE
CP-1940 Release w_transport 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.5.1
+version: 2.6.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1940

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.6.0 items =======

 CP-1939  - Allow content-type to be set manually  - https://github.com/Workiva/w_transport/pull/153

 CP-1885  - Pattern matching for mock HTTP/WS urls  - https://github.com/Workiva/w_transport/pull/148

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.5.1...CP-1940_release_2.6.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.5.1...2.6.0

