### PR TITLE
cp-1605 : added jitter and maxDuration between retries

### DIFF
--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -157,31 +157,48 @@ class RequestAutoRetry extends AutoRetryConfig {
 }
 
 /// Representation of the back-off method to use when retrying requests. A fixed
-/// back-off will space retries out by [duration]. An exponential back-off will
-/// delay retries by `d*2^n` where `d` is [duration] and `n` is the number of
+/// back-off will space retries out by [interval]. An exponential back-off will
+/// delay retries by `d*2^n` where `d` is [interval] and `n` is the number of
 /// attempts so far.
 class RetryBackOff {
   /// The base duration from which the delay between retries will be calculated.
   /// For fixed back-off, the delay will always be this value. For exponential
   /// back-off, the delay will be this value multiplied by 2^n where `n` is the
   /// number of attempts so far.
-  final Duration duration;
+  final Duration interval;
 
   /// The back-off method to use. One of none, fixed, or exponential.
   final RetryBackOffMethod method;
 
-  /// Construct a new exponential back-off representation where [duration] is
-  /// the base duration from which each delay will be calculated.
-  const RetryBackOff.exponential(this.duration)
-      : method = RetryBackOffMethod.exponential;
+  /// Whether to enable jitter or not.
+  final bool withJitter;
 
-  /// Construct a new fixed back-off representation where [duration] is the
+  /// The maximum duration between retries.
+  final Duration maxInterval;
+
+  /// The default maximum duration between retries. (5 minutes)
+  static const Duration defaultMaxInterval = const Duration(minutes: 5);
+
+  /// Construct a new exponential back-off representation where [interval] is
+  /// the base duration from which each delay will be calculated.
+  const RetryBackOff.exponential(this.interval,
+      {bool withJitter: true, Duration maxInterval})
+      : method = RetryBackOffMethod.exponential,
+        withJitter = withJitter,
+        maxInterval = maxInterval != null ? maxInterval : defaultMaxInterval;
+
+  /// Construct a new fixed back-off representation where [interval] is the
   /// delay between each retry.
-  const RetryBackOff.fixed(this.duration) : method = RetryBackOffMethod.fixed;
+  const RetryBackOff.fixed(this.interval, {bool withJitter: true})
+      : method = RetryBackOffMethod.fixed,
+        withJitter = withJitter,
+        maxInterval = null;
 
   /// Construct a null back-off representation, meaning no delay between retry
   /// attempts.
   const RetryBackOff.none()
-      : duration = null,
-        method = RetryBackOffMethod.none;
+      : interval = null,
+        method = RetryBackOffMethod.none,
+        withJitter = false,
+        maxInterval = null;
 }

--- a/lib/src/http/common/backoff.dart
+++ b/lib/src/http/common/backoff.dart
@@ -1,0 +1,68 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:math';
+import 'package:w_transport/src/http/auto_retry.dart';
+
+class Backoff {
+  static const int base = 2;
+
+  static Duration _createExponentialBackOff(RequestAutoRetry autoRetry) {
+    int backOffInMs = autoRetry.backOff.interval.inMilliseconds *
+        pow(base, autoRetry.numAttempts);
+    backOffInMs =
+        min(autoRetry.backOff.maxInterval.inMilliseconds, backOffInMs);
+
+    if (autoRetry.backOff.withJitter == true) {
+      Random random = new Random();
+      backOffInMs = random.nextInt(backOffInMs);
+    }
+    return new Duration(milliseconds: backOffInMs);
+  }
+
+  static Duration _createFixedBackOff(RequestAutoRetry autoRetry) {
+    Duration backOff;
+
+    if (autoRetry.backOff.withJitter == true) {
+      Random random = new Random();
+      backOff = new Duration(
+          milliseconds: autoRetry.backOff.interval.inMilliseconds ~/ 2 +
+              random
+                  .nextInt(autoRetry.backOff.interval.inMilliseconds)
+                  .toInt());
+    } else {
+      backOff = autoRetry.backOff.interval;
+    }
+
+    return backOff;
+  }
+
+  /// Calculate the backoff duration based on [RequestAutoRetry] configuration.
+  /// Returns [null] if backoff is not applicable.
+  static Duration calculateBackOff(RequestAutoRetry autoRetry) {
+    Duration backOff;
+    switch (autoRetry.backOff.method) {
+      case RetryBackOffMethod.exponential:
+        backOff = _createExponentialBackOff(autoRetry);
+        break;
+      case RetryBackOffMethod.fixed:
+        backOff = _createFixedBackOff(autoRetry);
+        break;
+      case RetryBackOffMethod.none:
+      default:
+        break;
+    }
+    return backOff;
+  }
+}

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -16,7 +16,6 @@ library w_transport.src.http.common.request;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math' show pow;
 
 import 'package:fluri/fluri.dart';
 import 'package:http_parser/http_parser.dart';
@@ -31,6 +30,7 @@ import 'package:w_transport/src/http/request_exception.dart';
 import 'package:w_transport/src/http/request_progress.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/http/response.dart';
+import 'package:w_transport/src/http/common/backoff.dart';
 
 abstract class CommonRequest extends Object
     with FluriMixin
@@ -666,14 +666,8 @@ abstract class CommonRequest extends Object
         Completer<BaseResponse> retryCompleter = new Completer();
 
         // If retry back-off is configured, wait as necessary.
-        var backOff;
-        if (autoRetry.backOff.method == RetryBackOffMethod.exponential) {
-          var base = autoRetry.backOff.duration.inMilliseconds;
-          var exponent = autoRetry.numAttempts;
-          backOff = new Duration(milliseconds: base * pow(2, exponent));
-        } else if (autoRetry.backOff.method == RetryBackOffMethod.fixed) {
-          backOff = autoRetry.backOff.duration;
-        }
+        Duration backOff = Backoff.calculateBackOff(autoRetry);
+
         if (backOff != null) {
           await new Future.delayed(backOff);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   args: "^0.13.0"
   browser: "^0.10.0+2"
   coverage: "^0.7.4"
-  dart_dev: "^1.0.0"
+  dart_dev: "^1.1.2"
   dart_style: "^0.2.4"
   http_server: "^0.9.5+1"
   mockito: "^0.9.0"

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -30,6 +30,7 @@ const String testTypeIntegration = 'integration';
 const String testTypeUnit = 'unit';
 
 /// Topics
+const String topicBackoff = 'Backoff';
 const String topicHttp = 'HTTP';
 const String topicMocks = 'Mocks';
 const String topicPlatformAdapter = 'Platform Adapter';

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -224,8 +224,8 @@ void main() {
           ..test = (request, response, willRetry) async => true;
 
         for (var request in createAllRequestTypes(client)) {
-          expect(request.autoRetry.backOff.duration,
-              equals(client.autoRetry.backOff.duration));
+          expect(request.autoRetry.backOff.interval,
+              equals(client.autoRetry.backOff.interval));
           expect(request.autoRetry.backOff.method,
               equals(client.autoRetry.backOff.method));
           expect(request.autoRetry.enabled, equals(client.autoRetry.enabled));

--- a/test/unit/http/common/backoff_test.dart
+++ b/test/unit/http/common/backoff_test.dart
@@ -1,0 +1,170 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm || browser')
+import 'dart:math';
+
+import 'package:test/test.dart';
+
+import 'package:w_transport/src/http/auto_retry.dart';
+import 'package:w_transport/src/http/requests.dart';
+import 'package:w_transport/src/http/common/backoff.dart';
+import 'package:w_transport/w_transport_mock.dart';
+
+import '../../../naming.dart';
+
+void main() {
+  configureWTransportForTest();
+
+  Naming naming = new Naming()
+    ..platform = platformBrowser
+    ..testType = testTypeUnit
+    ..topic = topicBackoff;
+
+  group(naming.toString(), () {
+    group('ExponentialBackOff : ', () {
+      test('no jitter, maxInterval not exceeded', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        Duration maxInterval = new Duration(milliseconds: 400);
+        bool withJitter = false;
+        request.autoRetry.backOff = new RetryBackOff.exponential(interval,
+            withJitter: withJitter, maxInterval: maxInterval);
+
+        for (var i = 0; i < 5; i++) {
+          request.autoRetry.numAttempts = i;
+
+          if (i == 0) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(interval.inMilliseconds));
+          } else {
+            expect(
+                Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(interval.inMilliseconds *
+                    pow(Backoff.base, request.autoRetry.numAttempts)));
+          }
+        }
+      });
+
+      test('with jitter, maxInterval not exceeded', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        Duration maxInterval = new Duration(milliseconds: 400);
+        bool withJitter = true;
+        request.autoRetry.backOff = new RetryBackOff.exponential(interval,
+            withJitter: withJitter, maxInterval: maxInterval);
+
+        for (var i = 0; i < 5; i++) {
+          request.autoRetry.numAttempts = i;
+
+          if (i == 0) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                lessThanOrEqualTo(interval.inMilliseconds));
+          } else {
+            expect(
+                Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                lessThanOrEqualTo(interval.inMilliseconds *
+                    pow(Backoff.base, request.autoRetry.numAttempts)));
+          }
+        }
+      });
+
+      test('no jitter, maxInterval is exceeded', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        Duration maxInterval = new Duration(milliseconds: 20);
+        bool withJitter = false;
+        request.autoRetry.backOff = new RetryBackOff.exponential(interval,
+            withJitter: withJitter, maxInterval: maxInterval);
+
+        for (var i = 0; i < 5; i++) {
+          request.autoRetry.numAttempts = i;
+
+          if (i == 0) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(interval.inMilliseconds));
+          } else if (i == 1) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(10));
+          } else {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(request.autoRetry.backOff.maxInterval.inMilliseconds));
+          }
+        }
+      });
+
+      test('with jitter, maxInterval is exceeded', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        Duration maxInterval = new Duration(milliseconds: 20);
+        bool withJitter = true;
+        request.autoRetry.backOff = new RetryBackOff.exponential(interval,
+            withJitter: withJitter, maxInterval: maxInterval);
+
+        for (var i = 0; i < 50; i++) {
+          request.autoRetry.numAttempts = i;
+
+          if (i == 0) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                lessThanOrEqualTo(interval.inMilliseconds));
+          } else if (i == 1) {
+            expect(
+                Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                lessThanOrEqualTo(
+                    request.autoRetry.backOff.maxInterval.inMilliseconds));
+          } else {
+            expect(
+                Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                lessThanOrEqualTo(
+                    request.autoRetry.backOff.maxInterval.inMilliseconds));
+          }
+        }
+      });
+    });
+
+    group('FixedBackOff : ', () {
+      test('no jitter', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        bool withJitter = false;
+        request.autoRetry.backOff =
+            new RetryBackOff.fixed(interval, withJitter: withJitter);
+
+        for (var i = 0; i < 5; i++) {
+          request.autoRetry.numAttempts = i;
+
+          if (i == 0) {
+            expect(Backoff.calculateBackOff(request.autoRetry).inMilliseconds,
+                equals(interval.inMilliseconds));
+          }
+        }
+      });
+
+      test('with jitter', () async {
+        var request = new Request();
+        Duration interval = new Duration(milliseconds: 5);
+        bool withJitter = true;
+        request.autoRetry.backOff =
+            new RetryBackOff.fixed(interval, withJitter: withJitter);
+
+        for (var i = 0; i < 5; i++) {
+          int backoff =
+              Backoff.calculateBackOff(request.autoRetry).inMilliseconds;
+          expect(backoff, lessThanOrEqualTo(interval.inMilliseconds * 1.5));
+          expect(backoff, greaterThanOrEqualTo(interval.inMilliseconds ~/ 2));
+        }
+      });
+    });
+  });
+}

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -18,6 +18,7 @@ library w_transport.test.unit.unit_test_suite;
 import 'package:test/test.dart';
 
 import 'http/client_test.dart' as http_client_test;
+import 'http/common/backoff_test.dart' as backoff_test;
 import 'http/form_request_test.dart' as http_form_request_test;
 import 'http/http_body_test.dart' as http_body_test;
 import 'http/http_interceptor_test.dart' as http_interceptor_test;
@@ -42,6 +43,7 @@ import 'ws/w_socket_subscription_test.dart' as ws_w_socket_subscription_test;
 import 'ws/w_socket_test.dart' as ws_w_socket_test;
 
 void main() {
+  backoff_test.main();
   http_client_test.main();
   http_body_test.main();
   http_interceptor_test.main();


### PR DESCRIPTION
### CODE REVIEW

This is a rebase of https://github.com/Workiva/w_transport/pull/155
For consideration:

#### PROBLEM
We don't currently allow jitter with our exponential backoff strategy.

#### SOLUTION
We now allow the optional inclusion of jitter and a maximum retry duration + default maximum retry duration.

Inspired by https://www.awsarchitectureblog.com/2015/03/backoff.html

**Testing Suggestions:**
run unit-tests
run integration tests

**Required:**
@evanweible-wf @maxwellpeterson-wf @trentgrover-wf @sebastianmalysa-wf 

**FYI:**
@jayudey-wf