### PR TITLE
CP-1966 Handle request with no encoding and no charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.6.1](https://github.com/Workvia/w_transport/compare/2.6.0...2.6.1)
+_TBD_
+
+- **Bug Fix:** A request's `encoding` property can no longer be set to null.
+  This would have most likely caused an RTE when the request was sent, so now an
+  `ArgumentError` will be thrown immediately.
+
+- **Bug Fix:** As of 2.6.0, if you were to set a request's content-type manually
+  without a charset or with an unknown charset, it was possible to hit an RTE
+  due to a null `encoding`. The `HttpBody` class has been updated to be more
+  resilient to a missing encoding or charset. Additionally, all request classes
+  will now pass in the value of its `encoding` property, which should now always
+  be non-null.
+
 ## [2.6.0](https://github.com/Workvia/w_transport/compare/2.5.1...2.6.0)
 _June 20, 2016_
 

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -70,6 +70,7 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
     if (body != null) {
       this.fields = body;
     }
-    return new HttpBody.fromBytes(contentType, _encodedQuery);
+    return new HttpBody.fromBytes(contentType, _encodedQuery,
+        fallbackEncoding: encoding);
   }
 }

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -197,6 +197,7 @@ abstract class CommonRequest extends Object
   /// will update the [contentType] `charset` parameter.
   set encoding(Encoding encoding) {
     verifyUnsent();
+    if (encoding == null) throw new ArgumentError.notNull('encoding');
     _encoding = encoding;
     if (!_contentTypeSetManually) {
       updateContentType(

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -56,10 +56,31 @@ class HttpBody extends BaseHttpBody {
   Encoding _encoding;
 
   /// Construct the body to an HTTP request or an HTTP response from bytes.
+  ///
+  /// If [encoding] is given, it will be used to encode/decode the body.
+  ///
+  /// Otherwise, the `charset` parameter from [contentType] will be mapped to an
+  /// Encoding supported by Dart.
+  ///
+  /// If a `charset` parameter is not available or the value is unrecognized,
+  /// [fallbackEncoding] will be used.
+  ///
+  /// If [fallbackEncoding] is `null`, UTF8 will be the default encoding.
+  ///
+  /// If an encoding cannot be parsed from the content-type header (via the
+  /// `charset` param), then [fallbackEncoding] will be used (UTF8 by default).
   HttpBody.fromBytes(MediaType this.contentType, List<int> bytes,
-      {Encoding fallbackEncoding}) {
-    _encoding = http_utils.parseEncodingFromContentType(contentType,
-        fallback: fallbackEncoding);
+      {Encoding encoding, Encoding fallbackEncoding}) {
+    if (fallbackEncoding == null) {
+      fallbackEncoding = UTF8;
+    }
+    if (encoding != null) {
+      _encoding = encoding;
+    } else {
+      _encoding = http_utils.parseEncodingFromContentType(contentType,
+          fallback: fallbackEncoding);
+    }
+
     if (bytes == null) {
       bytes = [];
     }
@@ -67,10 +88,31 @@ class HttpBody extends BaseHttpBody {
   }
 
   /// Construct the body to an HTTP request or an HTTP response from text.
+  ///
+  /// If [encoding] is given, it will be used to encode/decode the body.
+  ///
+  /// Otherwise, the `charset` parameter from [contentType] will be mapped to an
+  /// Encoding supported by Dart.
+  ///
+  /// If a `charset` parameter is not available or the value is unrecognized,
+  /// [fallbackEncoding] will be used.
+  ///
+  /// If [fallbackEncoding] is `null`, UTF8 will be the default encoding.
+  ///
+  /// If an encoding cannot be parsed from the content-type header (via the
+  /// `charset` param), then [fallbackEncoding] will be used (UTF8 by default).
   HttpBody.fromString(MediaType this.contentType, String body,
-      {Encoding fallbackEncoding}) {
-    _encoding = http_utils.parseEncodingFromContentType(contentType,
-        fallback: fallbackEncoding);
+      {Encoding encoding, Encoding fallbackEncoding}) {
+    if (fallbackEncoding == null) {
+      fallbackEncoding = UTF8;
+    }
+    if (encoding != null) {
+      _encoding = encoding;
+    } else {
+      _encoding = http_utils.parseEncodingFromContentType(contentType,
+          fallback: fallbackEncoding);
+    }
+
     if (body == null) {
       body = '';
     }
@@ -86,7 +128,7 @@ class HttpBody extends BaseHttpBody {
       var encoded;
       try {
         encoded = encoding.encode(_body);
-      } catch (e) {
+      } on ArgumentError {
         throw new ResponseFormatException(contentType, encoding, body: _body);
       }
       _bytes = new Uint8List.fromList(encoded);
@@ -99,7 +141,7 @@ class HttpBody extends BaseHttpBody {
     if (_body == null) {
       try {
         _body = encoding.decode(_bytes);
-      } catch (e) {
+      } on FormatException {
         throw new ResponseFormatException(contentType, encoding, bytes: _bytes);
       }
     }

--- a/lib/src/http/response_format_exception.dart
+++ b/lib/src/http/response_format_exception.dart
@@ -50,9 +50,10 @@ class ResponseFormatException implements Exception {
       bodyLine = 'Bytes: $bytes';
     }
 
-    String msg = description;
+    var msg = description;
+    var encodingName = encoding != null ? encoding.name : 'null';
     msg += '\n\tContent-Type: $contentType';
-    msg += '\n\tEncoding: ${encoding.name}';
+    msg += '\n\tEncoding: $encodingName';
     msg += '\n\t$bodyLine';
 
     return msg;

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -95,6 +95,13 @@ void main() {
         }, throwsUnsupportedError);
       });
 
+      test('setting encoding to null should throw', () {
+        var request = new FormRequest();
+        expect(() {
+          request.encoding = null;
+        }, throwsArgumentError);
+      });
+
       test('setting encoding should update content-type', () {
         FormRequest request = new FormRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
@@ -141,6 +148,15 @@ void main() {
         expect(() {
           request.encoding = LATIN1;
         }, throwsStateError);
+      });
+
+      test('custom content-type without inferrable encoding', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('POST', uri);
+        var request = new FormRequest()
+          ..contentType = new MediaType('application', 'x-custom')
+          ..fields['foo'] = 'bar';
+        await request.post(uri: uri);
       });
 
       test('clone()', () {

--- a/test/unit/http/http_body_test.dart
+++ b/test/unit/http/http_body_test.dart
@@ -36,18 +36,51 @@ void main() {
         expect(body.asBytes(), isEmpty);
       });
 
+      test('should use encoding if one is explicitly given', () {
+        var contentType = new MediaType('text', 'plain');
+
+        var stringBody =
+            new HttpBody.fromString(contentType, 'body', encoding: ASCII);
+        expect(stringBody.encoding, equals(ASCII));
+
+        var bytesBody = new HttpBody.fromBytes(contentType, UTF8.encode('body'),
+            encoding: ASCII);
+        expect(bytesBody.encoding, equals(ASCII));
+      });
+
       test('should parse encoding from content-type', () {
-        MediaType contentType =
+        var contentType =
             new MediaType('text', 'plain', {'charset': ASCII.name});
-        HttpBody body = new HttpBody.fromString(contentType, 'body');
-        expect(body.encoding.name, equals(ASCII.name));
+
+        var stringBody = new HttpBody.fromString(contentType, 'body');
+        expect(stringBody.encoding, equals(ASCII));
+
+        var bytesBody =
+            new HttpBody.fromBytes(contentType, UTF8.encode('body'));
+        expect(bytesBody.encoding, equals(ASCII));
       });
 
       test('should allow a fallback encoding', () {
-        MediaType contentType = new MediaType('text', 'plain');
-        HttpBody body = new HttpBody.fromString(contentType, 'body',
-            fallbackEncoding: LATIN1);
-        expect(body.encoding.name, equals(LATIN1.name));
+        var contentType = new MediaType('text', 'plain');
+
+        var stringBody = new HttpBody.fromString(contentType, 'body',
+            fallbackEncoding: ASCII);
+        expect(stringBody.encoding, equals(ASCII));
+
+        var bytesBody = new HttpBody.fromBytes(contentType, UTF8.encode('body'),
+            fallbackEncoding: ASCII);
+        expect(bytesBody.encoding, equals(ASCII));
+      });
+
+      test('should use UTF8 by default', () {
+        var contentType = new MediaType('text', 'plain');
+
+        var stringBody = new HttpBody.fromString(contentType, 'body');
+        expect(stringBody.encoding, equals(UTF8));
+
+        var bytesBody =
+            new HttpBody.fromBytes(contentType, UTF8.encode('body'));
+        expect(bytesBody.encoding, equals(UTF8));
       });
 
       test('content-length should be calculated automaticlaly', () {

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -121,6 +121,13 @@ void main() {
         }, throwsUnsupportedError);
       });
 
+      test('setting encoding to null should throw', () {
+        var request = new JsonRequest();
+        expect(() {
+          request.encoding = null;
+        }, throwsArgumentError);
+      });
+
       test('setting encoding should update content-type', () {
         JsonRequest request = new JsonRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
@@ -167,6 +174,15 @@ void main() {
         expect(() {
           request.encoding = LATIN1;
         }, throwsStateError);
+      });
+
+      test('custom content-type without inferrable encoding', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('POST', uri);
+        var request = new JsonRequest()
+          ..contentType = new MediaType('application', 'x-custom')
+          ..body = {'foo': 'bar'};
+        await request.post(uri: uri);
       });
 
       test('clone()', () {

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -117,6 +117,13 @@ void main() {
         }, throwsUnsupportedError);
       });
 
+      test('setting encoding to null should throw', () {
+        var request = new Request();
+        expect(() {
+          request.encoding = null;
+        }, throwsArgumentError);
+      });
+
       test('setting encoding should update content-type', () {
         Request request = new Request();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
@@ -163,6 +170,15 @@ void main() {
         expect(() {
           request.encoding = LATIN1;
         }, throwsStateError);
+      });
+
+      test('custom content-type without inferrable encoding', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('POST', uri);
+        var request = new Request()
+          ..contentType = new MediaType('application', 'x-custom')
+          ..body = 'body';
+        await request.post(uri: uri);
       });
 
       test('clone()', () {

--- a/test/unit/http/response_format_exception_test.dart
+++ b/test/unit/http/response_format_exception_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.test.unit.http.response_format_exception_test;
+
+import 'dart:convert';
+
+import 'package:http_parser/http_parser.dart' show MediaType;
+import 'package:test/test.dart';
+
+import 'package:w_transport/src/http/response_format_exception.dart';
+
+import '../../naming.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..testType = testTypeUnit
+    ..topic = topicHttp;
+
+  group(naming.toString(), () {
+    group('ResponseFormatException', () {
+      test('should detail why bytes could not be decoded', () {
+        var bytes = UTF8.encode('bodyçå®');
+        var contentType =
+            new MediaType('application', 'json', {'charset': ASCII.name});
+        var exception =
+            new ResponseFormatException(contentType, ASCII, bytes: bytes);
+        expect(exception.toString(), contains('Bytes could not be decoded'));
+        expect(exception.toString(), contains('Content-Type: $contentType'));
+        expect(exception.toString(), contains('Encoding: ${ASCII.name}'));
+        expect(
+            exception.toString(), contains(UTF8.encode('bodyçå®').toString()));
+      });
+
+      test('should detail why string could not be encoded', () {
+        var body = 'bodyçå®';
+        var contentType =
+            new MediaType('application', 'json', {'charset': ASCII.name});
+        var exception =
+            new ResponseFormatException(contentType, ASCII, body: body);
+        expect(exception.toString(), contains('Body could not be encoded'));
+        expect(exception.toString(), contains('Content-Type: $contentType'));
+        expect(exception.toString(), contains('Encoding: ${ASCII.name}'));
+        expect(exception.toString(), contains('bodyçå®'));
+      });
+
+      test('should warn if encoding is null', () {
+        var body = 'bodyçå®';
+        var contentType =
+            new MediaType('application', 'json', {'charset': ASCII.name});
+        var exception =
+            new ResponseFormatException(contentType, null, body: body);
+        expect(exception.toString(), contains('Body could not be encoded'));
+        expect(exception.toString(), contains('Content-Type: $contentType'));
+        expect(exception.toString(), contains('Encoding: null'));
+        expect(exception.toString(), contains('bodyçå®'));
+      });
+    });
+  });
+}

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -104,6 +104,13 @@ void main() {
         }, throwsStateError);
       });
 
+      test('setting encoding to null should throw', () {
+        var request = new StreamedRequest();
+        expect(() {
+          request.encoding = null;
+        }, throwsArgumentError);
+      });
+
       test('setting encoding should update content-type', () {
         StreamedRequest request = new StreamedRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
@@ -150,6 +157,17 @@ void main() {
         expect(() {
           request.encoding = LATIN1;
         }, throwsStateError);
+      });
+
+      test('custom content-type without inferrable encoding', () async {
+        Uri uri = Uri.parse('/test');
+        MockTransports.http.expect('POST', uri);
+        var request = new StreamedRequest()
+          ..contentType = new MediaType('application', 'x-custom')
+          ..body = new Stream.fromIterable([
+            [1, 2]
+          ]);
+        await request.post(uri: uri);
       });
 
       test('clone()', () {

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -29,6 +29,8 @@ import 'http/plain_text_request_test.dart' as http_plain_text_request_test;
 import 'http/request_exception_test.dart' as http_request_exception_test;
 import 'http/request_progress_test.dart' as http_request_progress_test;
 import 'http/request_test.dart' as http_request_test;
+import 'http/response_format_exception_test.dart'
+    as http_response_format_exception_test;
 import 'http/response_test.dart' as http_response_test;
 import 'http/streamed_request_test.dart' as http_streamed_request_test;
 import 'http/utils_test.dart' as http_utils_test;
@@ -54,6 +56,7 @@ void main() {
   http_request_exception_test.main();
   http_request_progress_test.main();
   http_request_test.main();
+  http_response_format_exception_test.main();
   http_response_test.main();
   http_streamed_request_test.main();
   http_utils_test.main();


### PR DESCRIPTION
_Fixes #159._

## Issue
#159 reported an issue when setting a request's content-type manually. If that content-type has no `charset` parameter, and the request's encoding was not set, you will hit an RTE in `HttpBody` when trying to read the body and a conversion is required (bytes->string or vice versa). This is because the `HttpBody` constructors have an optional `fallbackEncoding` parameter that has no default value. For responses, we pass in a fallback encoding of `LATIN1` per RFC 2616, but we aren't passing in a fallback encoding at all for request bodies.

This issue hadn't manifested itself before because most requests set the content-type automatically, including the charset, but #153 introduced the ability to manually set the content-type.

## Solution
- Update `HttpBody.fromString()` and `HttpBody.fromBytes()` to give the optional `fallbackEncoding` parameter a default value of `UTF8`.
- Add a null check that will throw an `ArgumentError` if `fallbackEncoding` happens to be null
- Additionally, a null check for encoding was added before trying to read the name in `ResponseFormatException`.
- Bonus: When attempting to decode/encode a request/response body, we now only catch the expected error instead of any exception (ArgumentError for encode, FormatException for decode). This will prevent us from swallowing unexpected exceptions erroneously wrapping them in a `ResponseFormatException`, which is what happened in the stack trace from #159.

## Testing
- [ ] CI passes
- [ ] HTTP examples work as expected
- [ ] @stevenosborne-wf's tests are fixed

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 

fyi: @stevenosborne-wf 