### PR TITLE
CP-1974 Restore & deprecate autoRetry.backOff.duration for backwards compatibility

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,2 @@
+// TODO: Add link to upgrade guide.
+const String v3Deprecation = 'in 4.0.0.';

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -16,6 +16,8 @@ library w_transport.src.http.auto_retry;
 
 import 'dart:async';
 
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
+
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/finalized_request.dart';
 import 'package:w_transport/src/http/request_exception.dart';
@@ -161,23 +163,23 @@ class RequestAutoRetry extends AutoRetryConfig {
 /// delay retries by `d*2^n` where `d` is [interval] and `n` is the number of
 /// attempts so far.
 class RetryBackOff {
+  /// The default maximum duration between retries. (5 minutes)
+  static const Duration defaultMaxInterval = const Duration(minutes: 5);
+
   /// The base duration from which the delay between retries will be calculated.
   /// For fixed back-off, the delay will always be this value. For exponential
   /// back-off, the delay will be this value multiplied by 2^n where `n` is the
   /// number of attempts so far.
   final Duration interval;
 
+  /// The maximum duration between retries.
+  final Duration maxInterval;
+
   /// The back-off method to use. One of none, fixed, or exponential.
   final RetryBackOffMethod method;
 
   /// Whether to enable jitter or not.
   final bool withJitter;
-
-  /// The maximum duration between retries.
-  final Duration maxInterval;
-
-  /// The default maximum duration between retries. (5 minutes)
-  static const Duration defaultMaxInterval = const Duration(minutes: 5);
 
   /// Construct a new exponential back-off representation where [interval] is
   /// the base duration from which each delay will be calculated.
@@ -201,4 +203,8 @@ class RetryBackOff {
         method = RetryBackOffMethod.none,
         withJitter = false,
         maxInterval = null;
+
+  /// Use [interval] instead.
+  @Deprecated(v3Deprecation)
+  Duration get duration => interval;
 }

--- a/test/unit/http/backoff_test.dart
+++ b/test/unit/http/backoff_test.dart
@@ -22,7 +22,7 @@ import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/http/common/backoff.dart';
 import 'package:w_transport/w_transport_mock.dart';
 
-import '../../../naming.dart';
+import '../../naming.dart';
 
 void main() {
   configureWTransportForTest();
@@ -34,6 +34,13 @@ void main() {
 
   group(naming.toString(), () {
     group('ExponentialBackOff : ', () {
+      test('deprecated `duration` should be forwarded to `interval`', () {
+        var interval = new Duration(seconds: 10);
+        var backOff = new RetryBackOff.exponential(interval);
+        expect(backOff.duration, equals(interval));
+        expect(backOff.duration, equals(backOff.interval));
+      });
+
       test('no jitter, maxInterval not exceeded', () async {
         var request = new Request();
         Duration interval = new Duration(milliseconds: 5);
@@ -134,6 +141,13 @@ void main() {
     });
 
     group('FixedBackOff : ', () {
+      test('deprecated `duration` should be forwarded to `interval`', () {
+        var interval = new Duration(seconds: 10);
+        var backOff = new RetryBackOff.fixed(interval);
+        expect(backOff.duration, equals(interval));
+        expect(backOff.duration, equals(backOff.interval));
+      });
+
       test('no jitter', () async {
         var request = new Request();
         Duration interval = new Duration(milliseconds: 5);
@@ -164,6 +178,14 @@ void main() {
           expect(backoff, lessThanOrEqualTo(interval.inMilliseconds * 1.5));
           expect(backoff, greaterThanOrEqualTo(interval.inMilliseconds ~/ 2));
         }
+      });
+    });
+
+    group('No Backoff', () {
+      test('deprecated `duration` should be forwarded to `interval`', () {
+        var backOff = new RetryBackOff.none();
+        expect(backOff.duration, isNull);
+        expect(backOff.duration, equals(backOff.interval));
       });
     });
   });

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -18,7 +18,7 @@ library w_transport.test.unit.unit_test_suite;
 import 'package:test/test.dart';
 
 import 'http/client_test.dart' as http_client_test;
-import 'http/common/backoff_test.dart' as backoff_test;
+import 'http/backoff_test.dart' as http_backoff_test;
 import 'http/form_request_test.dart' as http_form_request_test;
 import 'http/http_body_test.dart' as http_body_test;
 import 'http/http_interceptor_test.dart' as http_interceptor_test;
@@ -45,7 +45,7 @@ import 'ws/w_socket_subscription_test.dart' as ws_w_socket_subscription_test;
 import 'ws/w_socket_test.dart' as ws_w_socket_test;
 
 void main() {
-  backoff_test.main();
+  http_backoff_test.main();
   http_client_test.main();
   http_body_test.main();
   http_interceptor_test.main();


### PR DESCRIPTION
## Issue
#158 changed `RetryBackOff.duration` to `RetryBackOff.interval` to better describe its purpose, but this is a breaking change.

## Solution
- Restore the `RetryBackOff.duration` property with a getter that simply returns the value of `RetryBackOff.interval`
- Deprecate `RetryBackOff.duration`
- Add tests to ensure the original behavior works as expected

> A PR to update the changelog will be following shortly and will include a note about this deprecation.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 