### PR TITLE
CP-1954 Release w_transport 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.6.0
+version: 2.7.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1954

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.7.0 items =======

 CP-1974  - Restore & deprecate autoRetry.backOff.duration for backwards compatibility  - https://github.com/Workiva/w_transport/pull/163

 CP-1975  - Update changelog for 2.7.0  - https://github.com/Workiva/w_transport/pull/164

 CP-1966  - Handle request with no encoding and no charset  - https://github.com/Workiva/w_transport/pull/161

 CP-1605  - Introduce jitter to exponential backoff  - https://github.com/Workiva/w_transport/pull/158

 CP-1963  - Upgrade to dart_style 0.2.4  - https://github.com/Workiva/w_transport/pull/160

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.6.0...CP-1954_release_2.7.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.6.0...2.7.0

