### PR TITLE
CP-2064 Add support for canceling mock handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
-## [2.7.1](https://github.com/Workvia/w_transport/compare/2.6.0...2.7.0)
+## [2.8.0](https://github.com/Workvia/w_transport/compare/2.7.1...2.8.0)
+_TBD_
+
+- **Improvement:** Mock transport handlers can now be canceled. This will allow
+  consumers to remove HTTP or WebSocket mock handlers without having to call
+  `MockTransports.reset()` or `MockTransports.uninstall`.
+
+    ```dart
+    var uri = Uri.parse('/example');
+
+    var myHttpHandler = MockTransports.http.when(uri, (request) { ... });
+    myHttpHandler.cancel();
+
+    var myWebSocketHandler = MockTransports.webSocket.when(uri,
+        handler: (protocols, headers) { ... });
+    myWebSocketHandler.cancel();
+
+    /// The same works for the `whenPattern()` methods, as well.
+    ```
+
+## [2.7.1](https://github.com/Workvia/w_transport/compare/2.7.0...2.7.1)
 _July 20, 2016_
 
 - **Bug Fix:** previously, you could not retry a request that failed with a

--- a/lib/src/http/mock/request_mixin.dart
+++ b/lib/src/http/mock/request_mixin.dart
@@ -24,7 +24,7 @@ import 'package:w_transport/src/http/request_exception.dart';
 import 'package:w_transport/src/http/request_progress.dart';
 import 'package:w_transport/src/http/response.dart';
 import 'package:w_transport/src/http/utils.dart' as http_utils;
-import 'package:w_transport/src/mocks/http.dart';
+import 'package:w_transport/src/mocks/http.dart' show MockHttpInternal;
 
 abstract class MockRequestMixin implements MockBaseRequest, CommonRequest {
   Completer _canceled = new Completer();
@@ -137,10 +137,10 @@ abstract class MockRequestMixin implements MockBaseRequest, CommonRequest {
     if (_mockHandlersRegistered) return;
     _mockHandlersRegistered = true;
     onCanceled.then((_) {
-      cancelMockRequest(this);
+      MockHttpInternal.cancelMockRequest(this);
     });
     onSent.then((_) {
-      handleMockRequest(this);
+      MockHttpInternal.handleMockRequest(this);
     });
   }
 }

--- a/lib/src/mocks/http.dart
+++ b/lib/src/mocks/http.dart
@@ -28,138 +28,27 @@ typedef Future<BaseResponse> RequestHandler(FinalizedRequest request);
 typedef Future<BaseResponse> PatternRequestHandler(
     FinalizedRequest request, Match match);
 
-List<_RequestExpectation> _expectations = [];
-Map<String, Map<String, RequestHandler>> _requestHandlers = {};
-Map<Pattern, Map<String, PatternRequestHandler>> _patternRequestHandlers = {};
-List<MockBaseRequest> _pending = [];
-
-void cancelMockRequest(MockBaseRequest request) {
-  if (_pending.contains(request)) {
-    _pending.remove(request);
-  }
-}
-
-handleMockRequest(MockBaseRequest request) {
-  var matchingExpectations = _expectations.where((e) {
-    bool methodMatches = e.method == request.method;
-    bool uriMatches = false;
-    if (e.uri is Uri) {
-      uriMatches = e.uri == request.uri;
-    } else if (e.uri is Pattern) {
-      uriMatches =
-          (e.uri as Pattern).allMatches(request.uri.toString()).isNotEmpty;
-    }
-    bool headersMatch;
-    if (e.headers == null) {
-      // Ignore headers check if expectation didn't specify.
-      headersMatch = true;
-    } else {
-      headersMatch = true;
-      e.headers.forEach((header, value) {
-        if (!request.headers.containsKey(header) ||
-            request.headers[header] != value) {
-          headersMatch = false;
-        }
-      });
-    }
-    return methodMatches && uriMatches && headersMatch;
-  });
-
-  if (matchingExpectations.isNotEmpty) {
-    /// If this request was expected, resolve it as planned.
-    _RequestExpectation expectation = matchingExpectations.first;
-    if (expectation.failWith != null) {
-      request.completeError(error: expectation.failWith);
-    } else if (expectation.respondWith != null) {
-      request.complete(response: expectation.respondWith);
-    }
-    _expectations.remove(expectation);
-    return;
-  }
-
-  var matchingRequestHandlerKey = _requestHandlers.keys.firstWhere((key) {
-    return key == _getUriKey(request.uri);
-  }, orElse: () => null);
-
-  Match match;
-  var matchingPatternRequestHandlerKey =
-      _patternRequestHandlers.keys.firstWhere((pattern) {
-    var matches = pattern.allMatches(request.uri.toString());
-    if (matches.isNotEmpty) {
-      match = matches.first;
-      return true;
-    }
-    return false;
-  }, orElse: () => null);
-
-  var handlersByMethod = [];
-  if (matchingRequestHandlerKey != null) {
-    handlersByMethod = _requestHandlers[matchingRequestHandlerKey];
-  } else if (matchingPatternRequestHandlerKey != null) {
-    handlersByMethod =
-        _patternRequestHandlers[matchingPatternRequestHandlerKey];
-  }
-
-  if (handlersByMethod.isNotEmpty) {
-    /// Try to find an applicable handler.
-    var handler;
-    if (handlersByMethod.containsKey(request.method)) {
-      handler = handlersByMethod[request.method];
-    } else if (handlersByMethod.containsKey('*')) {
-      handler = handlersByMethod['*'];
-    }
-
-    /// If a handler was set up for this type of request, call the handler.
-    if (handler != null) {
-      if (handler is RequestHandler) {
-        request.onSent.then((FinalizedRequest finalizedRequest) {
-          handler(finalizedRequest).then((response) {
-            request.complete(response: response);
-          }, onError: (error) {
-            request.completeError(error: error);
-          });
-        });
-        return;
-      } else if (handler is PatternRequestHandler) {
-        request.onSent.then((FinalizedRequest finalizedRequest) {
-          handler(finalizedRequest, match).then((response) {
-            request.complete(response: response);
-          }, onError: (error) {
-            request.completeError(error: error);
-          });
-        });
-        return;
-      }
-    }
-  }
-
-  /// Otherwise, store this request as pending.
-  _pending.add(request);
-}
-
-String _getUriKey(Uri uri) => uri.replace(query: '', fragment: '').toString();
-
 class MockHttp {
   const MockHttp();
 
-  int get numPendingRequests => _pending.length;
+  int get numPendingRequests => MockHttpInternal._pending.length;
 
   void causeFailureOnOpen(BaseRequest request) {
-    _verifyRequestIsMock(request);
+    MockHttpInternal._verifyRequestIsMock(request);
     (request as MockBaseRequest).causeFailureOnOpen();
   }
 
   void completeRequest(BaseRequest request, {BaseResponse response}) {
-    _verifyRequestIsMock(request);
+    MockHttpInternal._verifyRequestIsMock(request);
     (request as MockBaseRequest).complete(response: response);
-    _pending.remove(request);
+    MockHttpInternal._pending.remove(request);
   }
 
   void expect(String method, Uri uri,
       {Object failWith,
       Map<String, String> headers,
       BaseResponse respondWith}) {
-    _expect(method, uri,
+    MockHttpInternal._expect(method, uri,
         failWith: failWith, headers: headers, respondWith: respondWith);
   }
 
@@ -167,71 +56,204 @@ class MockHttp {
       {Object failWith,
       Map<String, String> headers,
       BaseResponse respondWith}) {
-    _expect(method, uriPattern,
+    MockHttpInternal._expect(method, uriPattern,
         failWith: failWith, headers: headers, respondWith: respondWith);
   }
 
   void failRequest(BaseRequest request, {Object error, BaseResponse response}) {
-    _verifyRequestIsMock(request);
+    MockHttpInternal._verifyRequestIsMock(request);
     (request as MockBaseRequest)
         .completeError(error: error, response: response);
-    _pending.remove(request);
+    MockHttpInternal._pending.remove(request);
   }
 
   void reset() {
-    _expectations = [];
-    _requestHandlers = {};
-    _patternRequestHandlers = {};
-    _pending = [];
+    MockHttpInternal._expectations = [];
+    MockHttpInternal._patternRequestHandlers = {};
+    MockHttpInternal._pending = [];
+    MockHttpInternal._requestHandlers = {};
   }
 
   void verifyNoOutstandingExceptions() {
     String errorMsg = '';
-    if (_pending.isNotEmpty) {
+    if (MockHttpInternal._pending.isNotEmpty) {
       errorMsg += 'Unresolved mock requests:\n';
-      var requestLines = _pending.map((e) => '\t${e.method} ${e.uri}');
+      var requestLines =
+          MockHttpInternal._pending.map((e) => '\t${e.method} ${e.uri}');
       errorMsg += requestLines.join('\n');
       errorMsg += '\n';
     }
-    if (_expectations.isNotEmpty) {
+    if (MockHttpInternal._expectations.isNotEmpty) {
       errorMsg += 'Unsatisfied requests:\n';
-      var requestLines = _expectations.map((e) => '\t${e.method} ${e.uri}');
+      var requestLines =
+          MockHttpInternal._expectations.map((e) => '\t${e.method} ${e.uri}');
       errorMsg += requestLines.join('\n');
       errorMsg += '\n';
     }
     if (errorMsg.isNotEmpty) throw new StateError(errorMsg);
   }
 
-  void when(Uri uri, RequestHandler handler, {String method}) {
+  MockHttpHandler when(Uri uri, RequestHandler handler, {String method}) {
     // Note: there's really no reason to use `_getUriKey()` here - it strips the
     // fragment and query from the uri, but neither of those pieces of info are
     // used anywhere else. The consumer should just be expected to pass in an
     // exact match here. At the next breaking release, this method and related
     // ones should be cleaned up & clarified.
-    String uriKey = _getUriKey(uri);
-    if (!_requestHandlers.containsKey(uriKey)) {
-      _requestHandlers[uriKey] = {};
+    String uriKey = MockHttpInternal._getUriKey(uri);
+    if (!MockHttpInternal._requestHandlers.containsKey(uriKey)) {
+      MockHttpInternal._requestHandlers[uriKey] = {};
     }
-    if (method == null) {
-      _requestHandlers[uriKey]['*'] = handler;
-    } else {
-      _requestHandlers[uriKey][method.toUpperCase()] = handler;
-    }
+    var methodKey = method == null ? '*' : method.toUpperCase();
+    MockHttpInternal._requestHandlers[uriKey][methodKey] = handler;
+    return new MockHttpHandler._(() {
+      var handlers = MockHttpInternal._requestHandlers[uriKey];
+      if (handlers != null &&
+          handlers[methodKey] != null &&
+          handlers[methodKey] == handler) {
+        MockHttpInternal._requestHandlers[uriKey].remove(methodKey);
+      }
+    });
   }
 
-  void whenPattern(Pattern uriPattern, PatternRequestHandler handler,
+  MockHttpHandler whenPattern(Pattern uriPattern, PatternRequestHandler handler,
       {String method}) {
-    if (!_patternRequestHandlers.containsKey(uriPattern)) {
-      _patternRequestHandlers[uriPattern] = {};
+    if (!MockHttpInternal._patternRequestHandlers.containsKey(uriPattern)) {
+      MockHttpInternal._patternRequestHandlers[uriPattern] = {};
     }
-    if (method == null) {
-      _patternRequestHandlers[uriPattern]['*'] = handler;
-    } else {
-      _patternRequestHandlers[uriPattern][method.toUpperCase()] = handler;
+    var methodKey = method == null ? '*' : method.toUpperCase();
+    MockHttpInternal._patternRequestHandlers[uriPattern][methodKey] = handler;
+    return new MockHttpHandler._(() {
+      var handlers = MockHttpInternal._patternRequestHandlers[uriPattern];
+      if (handlers != null &&
+          handlers[methodKey] != null &&
+          handlers[methodKey] == handler) {
+        MockHttpInternal._patternRequestHandlers[uriPattern].remove(methodKey);
+      }
+    });
+  }
+}
+
+class MockHttpHandler {
+  Function _cancel;
+  MockHttpHandler._(this._cancel);
+
+  void cancel() {
+    _cancel();
+  }
+}
+
+class MockHttpInternal {
+  static List<_RequestExpectation> _expectations = [];
+  static Map<String, Map<String, RequestHandler>> _requestHandlers = {};
+  static Map<Pattern, Map<String, PatternRequestHandler>>
+      _patternRequestHandlers = {};
+  static List<MockBaseRequest> _pending = [];
+
+  static void cancelMockRequest(MockBaseRequest request) {
+    if (_pending.contains(request)) {
+      _pending.remove(request);
     }
   }
 
-  void _expect(String method, dynamic uri,
+  static void handleMockRequest(MockBaseRequest request) {
+    var matchingExpectations = _expectations.where((e) {
+      bool methodMatches = e.method == request.method;
+      bool uriMatches = false;
+      if (e.uri is Uri) {
+        uriMatches = e.uri == request.uri;
+      } else if (e.uri is Pattern) {
+        uriMatches =
+            (e.uri as Pattern).allMatches(request.uri.toString()).isNotEmpty;
+      }
+      bool headersMatch;
+      if (e.headers == null) {
+        // Ignore headers check if expectation didn't specify.
+        headersMatch = true;
+      } else {
+        headersMatch = true;
+        e.headers.forEach((header, value) {
+          if (!request.headers.containsKey(header) ||
+              request.headers[header] != value) {
+            headersMatch = false;
+          }
+        });
+      }
+      return methodMatches && uriMatches && headersMatch;
+    });
+
+    if (matchingExpectations.isNotEmpty) {
+      /// If this request was expected, resolve it as planned.
+      _RequestExpectation expectation = matchingExpectations.first;
+      if (expectation.failWith != null) {
+        request.completeError(error: expectation.failWith);
+      } else if (expectation.respondWith != null) {
+        request.complete(response: expectation.respondWith);
+      }
+      _expectations.remove(expectation);
+      return;
+    }
+
+    var matchingRequestHandlerKey = _requestHandlers.keys.firstWhere((key) {
+      return key == _getUriKey(request.uri);
+    }, orElse: () => null);
+
+    Match match;
+    var matchingPatternRequestHandlerKey =
+        _patternRequestHandlers.keys.firstWhere((pattern) {
+      var matches = pattern.allMatches(request.uri.toString());
+      if (matches.isNotEmpty) {
+        match = matches.first;
+        return true;
+      }
+      return false;
+    }, orElse: () => null);
+
+    var handlersByMethod = [];
+    if (matchingRequestHandlerKey != null) {
+      handlersByMethod = _requestHandlers[matchingRequestHandlerKey];
+    } else if (matchingPatternRequestHandlerKey != null) {
+      handlersByMethod =
+          _patternRequestHandlers[matchingPatternRequestHandlerKey];
+    }
+
+    if (handlersByMethod.isNotEmpty) {
+      /// Try to find an applicable handler.
+      var handler;
+      if (handlersByMethod.containsKey(request.method)) {
+        handler = handlersByMethod[request.method];
+      } else if (handlersByMethod.containsKey('*')) {
+        handler = handlersByMethod['*'];
+      }
+
+      /// If a handler was set up for this type of request, call the handler.
+      if (handler != null) {
+        if (handler is RequestHandler) {
+          request.onSent.then((FinalizedRequest finalizedRequest) {
+            handler(finalizedRequest).then((response) {
+              request.complete(response: response);
+            }, onError: (error) {
+              request.completeError(error: error);
+            });
+          });
+          return;
+        } else if (handler is PatternRequestHandler) {
+          request.onSent.then((FinalizedRequest finalizedRequest) {
+            handler(finalizedRequest, match).then((response) {
+              request.complete(response: response);
+            }, onError: (error) {
+              request.completeError(error: error);
+            });
+          });
+          return;
+        }
+      }
+    }
+
+    /// Otherwise, store this request as pending.
+    _pending.add(request);
+  }
+
+  static void _expect(String method, dynamic uri,
       {Object failWith,
       Map<String, String> headers,
       BaseResponse respondWith}) {
@@ -246,7 +268,11 @@ class MockHttp {
         failWith: failWith, respondWith: respondWith));
   }
 
-  void _verifyRequestIsMock(BaseRequest request) {
+  // TODO: remove in 3.0.0
+  static String _getUriKey(Uri uri) =>
+      uri.replace(query: '', fragment: '').toString();
+
+  static void _verifyRequestIsMock(BaseRequest request) {
     if (request is! MockBaseRequest) {
       throw new ArgumentError.value(
           'Request must be of type MockBaseRequest. Make sure you configured w_transport for testing.');

--- a/lib/src/web_socket/mock/w_socket.dart
+++ b/lib/src/web_socket/mock/w_socket.dart
@@ -17,14 +17,15 @@ library w_transport.src.web_socket.mock.w_socket;
 import 'dart:async';
 
 import 'package:w_transport/src/mocks/web_socket.dart'
-    show handleWebSocketConnection;
+    show MockWebSocketInternal;
 import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 
 abstract class MockWSocket implements WSocket {
   static Future<WSocket> connect(Uri uri,
           {Iterable<String> protocols, Map<String, dynamic> headers}) =>
-      handleWebSocketConnection(uri, protocols: protocols, headers: headers);
+      MockWebSocketInternal.handleWebSocketConnection(uri,
+          protocols: protocols, headers: headers);
 
   factory MockWSocket() => new _MockWSocket();
 

--- a/lib/w_transport_mock.dart
+++ b/lib/w_transport_mock.dart
@@ -42,8 +42,10 @@ export 'package:w_transport/src/http/mock/response.dart'
     show MockResponse, MockStreamedResponse;
 
 export 'package:w_transport/src/mocks/http.dart'
-    show PatternRequestHandler, RequestHandler;
+    show MockHttpHandler, PatternRequestHandler, RequestHandler;
 export 'package:w_transport/src/mocks/transport.dart' show MockTransports;
+export 'package:w_transport/src/mocks/web_socket.dart'
+    show MockWebSocketHandler;
 
 export 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
 


### PR DESCRIPTION
_Fixes #167._

## Improvement
Update `when()/whenPattern()` mock methods to return "handler"s that can be canceled at any time. This lets consumers register and unregister mock handlers without having to call `MockTransports.reset()` or `MockTransports.uninstall()` which would be destructive to any mocking that had been set up by other parties.

In other words, this makes it easy for libraries to install mock handlers as necessary and clean up after themselves without affecting other libraries or the application.

## Changes
- Adds a `MockHttpHandler` class with a `cancel()` method.
- Adds a `MockWebSocketHandler` class with a `cancel()` method.
- `MockTransports.http.when()` returns a `MockHttpHandler` instance.
- `MockTransports.http.whenPattern()` returns a `MockHttpHandler` instance.
- `MockTransports.webSocket.when()` returns a `MockWebSocketHandler` instance.
- `MockTransports.webSocket.whenPattern()` returns a `MockWebSocketHandler` instance.

## Testing
- [ ] CI passes (tests have been added).

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 