### PR TITLE
CP-2059 Support auto-retying requests that fail with a null response

### DIFF
--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -492,13 +492,17 @@ abstract class CommonRequest extends Object
 
     // If the request failed due to exceeding the timeout threshold, check if
     // it is configured to retry for timeouts.
-    if (requestException.error is TimeoutException && autoRetry.forTimeouts)
-      return true;
+    if (requestException.error is TimeoutException) {
+      return autoRetry.forTimeouts;
+    }
 
-    if (response == null) return false;
-
-    bool willRetry = autoRetry.forHttpMethods.contains(method) &&
-        autoRetry.forStatusCodes.contains(response.status);
+    bool willRetry = autoRetry.forHttpMethods.contains(method);
+    if (response != null && response.status != null) {
+      willRetry =
+          willRetry && autoRetry.forStatusCodes.contains(response.status);
+    } else {
+      willRetry = false;
+    }
     if (autoRetry.test != null) {
       willRetry = await autoRetry.test(request, response, willRetry);
     }

--- a/test/integration/integration_paths.dart
+++ b/test/integration/integration_paths.dart
@@ -25,6 +25,7 @@ class IntegrationPaths {
   static final Uri downloadEndpointUri =
       hostUri.replace(path: '/test/http/download');
   static final Uri echoEndpointUri = hostUri.replace(path: '/test/http/echo');
+  static final Uri errorEndpointUri = hostUri.replace(path: '/test/http/error');
   static final Uri fourOhFourEndpointUri =
       hostUri.replace(path: '/test/http/404');
   static final Uri pingEndpointUri = hostUri.replace(path: '/test/http/ping');

--- a/tool/server/handler.dart
+++ b/tool/server/handler.dart
@@ -143,7 +143,6 @@ abstract class Handler {
       setCorsHeaders(request);
     } else {
       request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-      setCorsHeaders(request);
     }
   }
 }

--- a/tool/server/handlers/test/http/error.dart
+++ b/tool/server/handlers/test/http/error.dart
@@ -1,0 +1,31 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.tool.server.handlers.test.http.error;
+
+import 'dart:async';
+import 'dart:io';
+
+import '../../../handler.dart';
+
+/// Will cause an error with a 0 response code due to CORS.
+class ErrorHandler extends Handler {
+  ErrorHandler() : super();
+
+  Future get(HttpRequest request) async {
+    request.response.statusCode =
+        request.uri.queryParameters['status'] ?? HttpStatus.OK;
+    request.response.headers.contentType = request.headers.contentType;
+  }
+}

--- a/tool/server/handlers/test/http/routes.dart
+++ b/tool/server/handlers/test/http/routes.dart
@@ -20,6 +20,7 @@ import 'custom.dart';
 import 'download.dart';
 import 'ping_handler.dart';
 import 'echo.dart';
+import 'error.dart';
 import 'reflect_handler.dart';
 import 'timeout_handler.dart';
 import 'upload.dart';
@@ -30,6 +31,7 @@ Map<String, Handler> testHttpIntegrationRoutes = {
   '$pathPrefix/custom': new CustomHandler(),
   '$pathPrefix/download': new DownloadHandler(),
   '$pathPrefix/echo': new EchoHandler(),
+  '$pathPrefix/error': new ErrorHandler(),
   '$pathPrefix/ping': new PingHandler(),
   '$pathPrefix/reflect': new ReflectHandler(),
   '$pathPrefix/timeout': new TimeoutHandler(),


### PR DESCRIPTION
## Issue
Fix #173 

## Solution
This will allow auto-retrying of requests that have null responses. Consumers will need to add a `test` method to `request.autoRetry` that checks for a `null` response and returns `true` to enable the functionality.

@evanweible-wf thoughts?

## Testing
Added an integration test that causes a `null` response and ensures it gets retried.

@trentgrover-wf
@evanweible-wf
@dustinlessard-wf
@jayudey-wf
@sebastianmalysa-wf 
@srinivasdhanwada-wf 