### PR TITLE
CP-2062 Add tests exercising mock handlers for all HTTP methods

### DIFF
--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -259,6 +259,34 @@ void main() {
           expect(MockTransports.http.numPendingRequests, equals(1));
         });
 
+        test('supports all standard methods', () async {
+          var ok = new MockResponse.ok();
+          MockTransports.http
+              .when(requestUri, (_) async => ok, method: 'DELETE');
+          MockTransports.http.when(requestUri, (_) async => ok, method: 'GET');
+          MockTransports.http.when(requestUri, (_) async => ok, method: 'HEAD');
+          MockTransports.http
+              .when(requestUri, (_) async => ok, method: 'OPTIONS');
+          MockTransports.http
+              .when(requestUri, (_) async => ok, method: 'PATCH');
+          MockTransports.http.when(requestUri, (_) async => ok, method: 'POST');
+          MockTransports.http.when(requestUri, (_) async => ok, method: 'PUT');
+
+          await Http.delete(requestUri);
+          await Http.get(requestUri);
+          await Http.head(requestUri);
+          await Http.options(requestUri);
+          await Http.patch(requestUri);
+          await Http.post(requestUri);
+          await Http.put(requestUri);
+        });
+
+        test('supports custom method', () async {
+          var ok = new MockResponse.ok();
+          MockTransports.http.when(requestUri, (_) async => ok, method: 'COPY');
+          await Http.send('COPY', requestUri);
+        });
+
         test('registers handler that throws to cause request failure',
             () async {
           MockTransports.http


### PR DESCRIPTION
## Improvement
We have tests for the mock handler API, but we weren't exercising all of the standard HTTP methods, nor a custom method. This PR adds two tests to do that.

## Changes
- Add test to exercise all standard HTTP methods for `MockTransports.http.when()`
- Add test to exercise custom HTTP method for `MockTransports.http.when()`

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf
