### PR TITLE
CP-1976 Release w_transport 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.7.0
+version: 2.7.1
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1976

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.7.1 items =======

 CP-2063  - Update changelog for 2.7.1 release  - https://github.com/Workiva/w_transport/pull/181

 CP-2062  - Add tests exercising mock handlers for all HTTP methods  - https://github.com/Workiva/w_transport/pull/180

 CP-2059  - Support auto-retying requests that fail with a null response  - https://github.com/Workiva/w_transport/pull/176

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.7.0...CP-1976_release_2.7.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.7.0...2.7.1

