### PR TITLE
CP-2067 Release w_transport 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.7.1
+version: 2.8.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-2067

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.8.0 items =======

 CP-2064  - Add support for canceling mock handlers  - https://github.com/Workiva/w_transport/pull/170

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.7.1...CP-2067_release_2.8.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.7.1...2.8.0

