### PR TITLE
CP-2094 Add isDone to BaseRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.9.0](https://github.com/Workvia/w_transport/compare/2.8.1...2.9.0)
+_TBD_
+
+- **Improvement:** All request classes now have a `bool isDone` getter that can
+  be read to determine whether or not a request is complete (i.e. succeeded,
+  failed, or canceled).
+
 ## [2.8.0](https://github.com/Workvia/w_transport/compare/2.7.1...2.8.0)
 _TBD_
 

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -78,6 +78,10 @@ abstract class BaseRequest implements FluriMixin, RequestDispatchers {
   /// type of data in this request's body and the [encoding].
   Map<String, String> headers = {};
 
+  /// Returns `true` if this request is complete (successful or failed), `false`
+  /// otherwise.
+  bool get isDone;
+
   /// Hook into the request lifecycle right before the request is sent.
   ///
   /// If not null, this function will be called with the [BaseRequest] instance

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -222,6 +222,10 @@ abstract class CommonRequest extends Object
     _headers = new CaseInsensitiveMap.from(headers);
   }
 
+  /// Returns `true` if this request is complete (successful or failed), `false`
+  /// otherwise.
+  bool get isDone => isCanceled || _done.isCompleted;
+
   /// Request interceptor. Called right before request is sent.
   RequestInterceptor get requestInterceptor => _requestInterceptor;
 
@@ -289,8 +293,10 @@ abstract class CommonRequest extends Object
   /// Cancel this request. If the request has already finished, this will do
   /// nothing.
   void abort([Object error]) {
-    abortRequest();
+    if (isCanceled) return;
     isCanceled = true;
+
+    abortRequest();
     _cancellationError = error;
     _cancellationCompleter.complete();
   }


### PR DESCRIPTION
_Fixes #187._

## Improvement
An easy way to determine if a request is complete or not has been requested.

## Changes
- Added `isDone` getter to `BaseRequest`, along with relevant tests.
- _Bonus:_ Found an issue with the implementation of `abort()` - it does not check to see if the request has already been canceled, which makes it vulnerable to a `StateError` being thrown if a consumer called that method more than once. This has been fixed now and a test added.

## Testing
- [ ] CI passes (tests added)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 