### PR TITLE
Minimum sdk 1.14; Upgrade dependencies

### DIFF
--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -17,8 +17,6 @@ library w_transport.src.http.browser.request_mixin;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:stack_trace/stack_trace.dart';
-
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/browser/form_data_body.dart';
 import 'package:w_transport/src/http/browser/utils.dart' as browser_utils;
@@ -85,7 +83,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         BaseResponse response =
             await _createResponse(streamResponse: streamResponse);
         error = new RequestException(method, uri, this, response, error);
-        c.completeError(error, new Chain.current());
+        c.completeError(error, StackTrace.current);
       }
     }
     _request.onError.listen(onError);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,15 @@
 name: w_transport
 version: 2.8.0
+
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and
   multipart data, as well as custom encoding. WebSocket support includes native
   WebSockets in the browser and the VM with the option to use SockJS in the
   browser.
+
+homepage: https://github.com/Workiva/w_transport
+
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>
   - Dustin Lessard <dustin.lessard@workiva.com>
@@ -13,28 +17,29 @@ authors:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-homepage: https://github.com/Workiva/w_transport
+
+environment:
+  sdk: ">=1.9.0 <2.0.0"
+
 dependencies:
-  fluri: "^1.1.0"
-  http_parser: "^1.0.0"
-  mime: "^0.9.3"
+  fluri: ^1.1.0
+  http_parser: ">=2.2.0 <4.0.0"
+  mime: ^0.9.3
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.1
-  stack_trace: "^1.4.0"
+
 dev_dependencies:
-  ansicolor: "^0.0.9"
-  args: "^0.13.0"
-  browser: "^0.10.0+2"
-  coverage: "^0.7.4"
-  dart_dev: "^1.1.2"
-  dart_style: "^0.2.4"
-  http_server: "^0.9.5+1"
-  mockito: "^0.9.0"
-  path: "^1.3.5"
-  react: "^0.6.1"
-  test: "^0.12.3+5"
-  uuid: "^0.5.0"
-environment:
-  sdk: ">=1.9.0 <2.0.0"
+  ansicolor: ^0.0.9
+  args: ^0.13.0
+  browser: ^0.10.0+2
+  coverage: ^0.7.9
+  dart_dev: ^1.4.0
+  dart_style: ^0.2.4
+  http_server: ^0.9.5+1
+  mockito: ^0.11.0
+  path: ^1.3.9
+  react: ^0.6.1
+  test: ^0.12.15
+  uuid: ^0.5.0


### PR DESCRIPTION
_Fixes #188._

## Improvement
Currently the minimum SDK version for this package is `1.9.0`, which precludes us from using null-aware operators and `StackTrace.current`.

## Changes
- Bump the minimum SDK version to 1.14.0 so that we can use null-aware operators and `StackTrace.current`
- Upgrade dependencies where possible

## Testing
- [ ] CI passes (only one small change made to the source code - the rest are dependencies).

## Release Instructions
This PR is made to a `3.0.0-wip` branch because 2.8.1 and 2.9.0 are still in progress. Once those two are released, we can merge `3.0.0-wip` into master and make any further 3.0.0 PRs to master.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 