### PR TITLE
CP-2430 Minimum sdk 1.14; Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.0](https://github.com/Workvia/w_transport/compare/2.9.2...3.0.0)
+_TBD_
+
+### Breaking Changes
+- Minimum Dart SDK version bumped to 1.14.0
+
 ## [2.8.0](https://github.com/Workvia/w_transport/compare/2.7.1...2.8.0)
 _TBD_
 

--- a/example/common/global_example_menu_component.dart
+++ b/example/common/global_example_menu_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.common.global_example_menu_component;
-
 import 'dart:async';
 import 'dart:html';
 

--- a/example/common/loading_component.dart
+++ b/example/common/loading_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.common.loading_component;
-
 import 'dart:html';
 
 void removeLoadingOverlay() {

--- a/example/http/cross_origin_credentials/client.dart
+++ b/example/http/cross_origin_credentials/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_credentials.client;
-
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 

--- a/example/http/cross_origin_credentials/dom.dart
+++ b/example/http/cross_origin_credentials/dom.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_credentials.dom;
-
 import 'dart:async';
 import 'dart:html';
 

--- a/example/http/cross_origin_credentials/service.dart
+++ b/example/http/cross_origin_credentials/service.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_credentials.service;
-
 import 'dart:async';
 
 import 'package:w_transport/w_transport.dart';
@@ -37,7 +35,6 @@ Future<bool> checkStatus() async {
     // Server probably isn't running
     return false;
   }
-  return false;
 }
 
 /// Login by sending a POST request to the /session endpoint.

--- a/example/http/cross_origin_credentials/status.dart
+++ b/example/http/cross_origin_credentials/status.dart
@@ -12,7 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_credentials.status;
-
 /// Whether or not the client is authenticated with the server.
 bool authenticated = false;

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.client;
-
 import 'dart:html';
 
 import 'package:react/react.dart' as react;

--- a/example/http/cross_origin_file_transfer/components/app_component.dart
+++ b/example/http/cross_origin_file_transfer/components/app_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.app_component;
-
 import 'package:react/react.dart' as react;
 
 import 'download_page.dart';
@@ -26,7 +24,9 @@ var appComponent = react.registerComponent(() => new AppComponent());
 
 class AppComponent extends react.Component {
   Map getInitialState() {
-    return {'page': 'upload',};
+    return {
+      'page': 'upload',
+    };
   }
 
   void _goToUploadPage(e) {

--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.download_page;
-
 import 'dart:async';
 import 'dart:math' as math;
 
@@ -35,7 +33,9 @@ class DownloadPage extends react.Component {
   StreamSubscription fileStreamErrorSubscription;
 
   Map getDefaultProps() {
-    return {'active': false,};
+    return {
+      'active': false,
+    };
   }
 
   Map getInitialState() {
@@ -53,7 +53,10 @@ class DownloadPage extends react.Component {
     remoteFiles = RemoteFiles.connect();
     fileStreamSubscription = remoteFiles.stream
         .listen((List<RemoteFileDescription> fileDescriptions) {
-      this.setState({'fileDescriptions': fileDescriptions, 'error': null,});
+      this.setState({
+        'fileDescriptions': fileDescriptions,
+        'error': null,
+      });
     });
     fileStreamErrorSubscription = remoteFiles.errorStream.listen((error) {
       this.setState({'error': error});
@@ -134,7 +137,9 @@ class DownloadPage extends react.Component {
         'key': rfd.name,
         'onClick': _createDownloadFileCallback(rfd)
       }, [
-        react.div({'className': 'file-name',}, rfd.name),
+        react.div({
+          'className': 'file-name',
+        }, rfd.name),
         react.div({'className': 'file-size'}, _humanizeFileSize(rfd.size)),
       ]));
     });

--- a/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.drop_zone_component;
-
 import 'dart:async';
 import 'dart:html';
 
@@ -39,7 +37,11 @@ class DropZoneComponent extends react.Component {
   }
 
   Map getDefaultProps() {
-    return {'onNewUploads': (_) {}, 'onDragStart': () {}, 'onDragEnd': () {},};
+    return {
+      'onNewUploads': (_) {},
+      'onDragStart': () {},
+      'onDragEnd': () {},
+    };
   }
 
   void componentWillMount() {

--- a/example/http/cross_origin_file_transfer/components/file_transfer_list_component.dart
+++ b/example/http/cross_origin_file_transfer/components/file_transfer_list_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.file_transfer_list_component;
-
 import 'package:react/react.dart' as react;
 
 import '../services/file_transfer.dart';

--- a/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
+++ b/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.file_transfer_list_item_component;
-
 import 'dart:async';
 
 import 'package:react/react.dart' as react;
@@ -30,11 +28,18 @@ var fileTransferListItemComponent =
 
 class FileTransferListItemComponent extends react.Component {
   Map getInitialState() {
-    return {'done': false, 'success': false, 'will-remove': false,};
+    return {
+      'done': false,
+      'success': false,
+      'will-remove': false,
+    };
   }
 
   Map getDefaultProps() {
-    return {'transfer': null, 'onTransferDone': (_) {},};
+    return {
+      'transfer': null,
+      'onTransferDone': (_) {},
+    };
   }
 
   void componentWillMount() {

--- a/example/http/cross_origin_file_transfer/components/upload_page.dart
+++ b/example/http/cross_origin_file_transfer/components/upload_page.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.components.upload_page;
-
 import 'package:react/react.dart' as react;
 
 import '../services/file_transfer.dart';
@@ -24,7 +22,9 @@ var uploadPage = react.registerComponent(() => new UploadPage());
 
 class UploadPage extends react.Component {
   Map getDefaultProps() {
-    return {'active': true,};
+    return {
+      'active': true,
+    };
   }
 
   Map getInitialState() {

--- a/example/http/cross_origin_file_transfer/services/file_transfer.dart
+++ b/example/http/cross_origin_file_transfer/services/file_transfer.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.services.file_transfer;
-
 import 'dart:async';
 import 'dart:html';
 import 'dart:math' as math;

--- a/example/http/cross_origin_file_transfer/services/proxy.dart
+++ b/example/http/cross_origin_file_transfer/services/proxy.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.services.proxy;
-
 // Whether or not to route requests through a proxy server.
 bool proxyEnabled = false;
 

--- a/example/http/cross_origin_file_transfer/services/remote_files.dart
+++ b/example/http/cross_origin_file_transfer/services/remote_files.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.cross_origin_file_transfer.services.remote_files;
-
 import 'dart:async';
 
 import 'package:w_transport/w_transport.dart';

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.http.simple_client.client;
-
 import 'dart:async';
 import 'dart:html';
 

--- a/example/index.dart
+++ b/example/index.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.index;
-
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 

--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.example.web_socket.echo.client;
-
 import 'dart:convert';
 import 'dart:html';
 

--- a/lib/src/browser_adapter.dart
+++ b/lib/src/browser_adapter.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.browser_adapter;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/browser/client.dart';

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.auto_retry;
-
 import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.base_request;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/lib/src/http/browser/client.dart
+++ b/lib/src/http/browser/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.browser.client;
-
 import 'package:w_transport/src/http/browser/requests.dart';
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/client.dart';

--- a/lib/src/http/browser/form_data_body.dart
+++ b/lib/src/http/browser/form_data_body.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.browser.form_data_body;
-
 import 'dart:convert';
 import 'dart:html';
 

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.browser.multipart_request;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:html' hide Client;

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -17,8 +17,6 @@ library w_transport.src.http.browser.request_mixin;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:stack_trace/stack_trace.dart';
-
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/browser/form_data_body.dart';
 import 'package:w_transport/src/http/browser/utils.dart' as browser_utils;
@@ -85,7 +83,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         BaseResponse response =
             await _createResponse(streamResponse: streamResponse);
         error = new RequestException(method, uri, this, response, error);
-        c.completeError(error, new Chain.current());
+        c.completeError(error, StackTrace.current);
       }
     }
     _request.onError.listen(onError);

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.browser.request_mixin;
-
 import 'dart:async';
 import 'dart:html';
 
@@ -86,6 +84,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         c.completeError(error, StackTrace.current);
       }
     }
+
     _request.onError.listen(onError);
     _request.onAbort.listen(onError);
 

--- a/lib/src/http/browser/requests.dart
+++ b/lib/src/http/browser/requests.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.browser.requests;
-
 import 'package:w_transport/src/http/browser/request_mixin.dart';
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';

--- a/lib/src/http/browser/utils.dart
+++ b/lib/src/http/browser/utils.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.client.utils;
-
 import 'dart:async';
 import 'dart:html';
 

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.client;
-
 import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/src/http/http_interceptor.dart';
 import 'package:w_transport/src/http/requests.dart';

--- a/lib/src/http/common/client.dart
+++ b/lib/src/http/common/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.client;
-
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
 
 import 'package:w_transport/src/http/auto_retry.dart';

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.form_request;
-
 import 'dart:async';
 import 'dart:typed_data';
 

--- a/lib/src/http/common/json_request.dart
+++ b/lib/src/http/common/json_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.json_request;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.vm.multipart_request;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
@@ -176,6 +174,7 @@ abstract class CommonMultipartRequest extends CommonRequest
     void write(String content) {
       controller.add(UTF8.encode(content));
     }
+
     Future writeByteStream(Stream<List<int>> byteStream) {
       var c = new Completer();
       byteStream.listen(controller.add,

--- a/lib/src/http/common/plain_text_request.dart
+++ b/lib/src/http/common/plain_text_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.plain_text_request;
-
 import 'dart:async';
 import 'dart:typed_data';
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.request;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -612,6 +610,7 @@ abstract class CommonRequest extends Object
           responseCompleter.complete();
         }
       }
+
       _cancellationCompleter.future.then(breakOutOfResponseFetching);
       _timeoutCompleter.future.then(breakOutOfResponseFetching);
 

--- a/lib/src/http/common/streamed_request.dart
+++ b/lib/src/http/common/streamed_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.streamed_request;
-
 import 'dart:async';
 
 import 'package:http_parser/http_parser.dart' show MediaType;

--- a/lib/src/http/finalized_request.dart
+++ b/lib/src/http/finalized_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.common.finalized_request;
-
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
 
 import 'package:w_transport/src/http/http_body.dart';

--- a/lib/src/http/http.dart
+++ b/lib/src/http/http.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.http;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/requests.dart';

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.http_body;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.http_interceptor;
-
 import 'dart:async';
 
 import 'package:w_transport/w_transport.dart';

--- a/lib/src/http/mock/base_request.dart
+++ b/lib/src/http/mock/base_request.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.mock.base_request;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/base_request.dart';

--- a/lib/src/http/mock/client.dart
+++ b/lib/src/http/mock/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.mock.w_http;
-
 import 'package:w_transport/src/http/mock/requests.dart';
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/client.dart';

--- a/lib/src/http/mock/request_mixin.dart
+++ b/lib/src/http/mock/request_mixin.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.mock.request_mixin;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/common/request.dart';

--- a/lib/src/http/mock/requests.dart
+++ b/lib/src/http/mock/requests.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.mock.requests;
-
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';
 import 'package:w_transport/src/http/common/json_request.dart';

--- a/lib/src/http/mock/response.dart
+++ b/lib/src/http/mock/response.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.mock.response;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/lib/src/http/multipart_file.dart
+++ b/lib/src/http/multipart_file.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.multipart_file;
-
 import 'dart:async';
 
 import 'package:http_parser/http_parser.dart' show MediaType;

--- a/lib/src/http/request_dispatchers.dart
+++ b/lib/src/http/request_dispatchers.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.request_dispatchers;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/response.dart';

--- a/lib/src/http/request_exception.dart
+++ b/lib/src/http/request_exception.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.request_exception;
-
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/response.dart';
 

--- a/lib/src/http/request_progress.dart
+++ b/lib/src/http/request_progress.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.request_progress;
-
 /// A representation of a progress event at a specific point in time
 /// either for an HTTP request upload or download. Based on [ProgressEvent]
 /// but with an additional [percent] property for convenience.

--- a/lib/src/http/requests.dart
+++ b/lib/src/http/requests.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.requests;
-
 import 'dart:async';
 import 'dart:typed_data';
 

--- a/lib/src/http/response.dart
+++ b/lib/src/http/response.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.response;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/lib/src/http/response_format_exception.dart
+++ b/lib/src/http/response_format_exception.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.response_exception;
-
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/lib/src/http/utils.dart
+++ b/lib/src/http/utils.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.utils;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/lib/src/http/vm/client.dart
+++ b/lib/src/http/vm/client.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.vm.client;
-
 import 'dart:io';
 
 import 'package:w_transport/src/http/client.dart';

--- a/lib/src/http/vm/request_mixin.dart
+++ b/lib/src/http/vm/request_mixin.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.vm.request_mixin;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/http/vm/requests.dart
+++ b/lib/src/http/vm/requests.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.vm.requests;
-
 import 'dart:io';
 
 import 'package:w_transport/src/http/client.dart';

--- a/lib/src/http/vm/utils.dart
+++ b/lib/src/http/vm/utils.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.http.server.utils;
-
 import 'dart:io';
 
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;

--- a/lib/src/mock_adapter.dart
+++ b/lib/src/mock_adapter.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.mock_adapter;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/client.dart';

--- a/lib/src/mocks/http.dart
+++ b/lib/src/mocks/http.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.mocks.http;
-
 import 'dart:async';
 
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;

--- a/lib/src/mocks/transport.dart
+++ b/lib/src/mocks/transport.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.mocks.transport;
-
 import 'package:w_transport/src/mocks/http.dart';
 import 'package:w_transport/src/mocks/web_socket.dart';
 

--- a/lib/src/mocks/web_socket.dart
+++ b/lib/src/mocks/web_socket.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.mocks.web_socket;
-
 import 'dart:async';
 
 import 'package:w_transport/src/web_socket/mock/w_socket.dart';

--- a/lib/src/platform_adapter.dart
+++ b/lib/src/platform_adapter.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.platform_adapter;
-
 import 'dart:async';
 
 import 'package:w_transport/w_transport.dart';

--- a/lib/src/vm_adapter.dart
+++ b/lib/src/vm_adapter.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.vm_adapter;
-
 import 'dart:async';
 
 import 'package:w_transport/src/http/client.dart';

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.browser.sockjs;
-
 import 'dart:async';
 
 import 'package:sockjs_client/sockjs_client.dart' as sockjs;

--- a/lib/src/web_socket/browser/w_socket.dart
+++ b/lib/src/web_socket/browser/w_socket.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.browser.w_socket;
-
 import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.common.w_socket;
-
 import 'dart:async';
 
 import 'package:w_transport/src/web_socket/w_socket.dart';

--- a/lib/src/web_socket/mock/w_socket.dart
+++ b/lib/src/web_socket/mock/w_socket.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.mock.w_socket;
-
 import 'dart:async';
 
 import 'package:w_transport/src/mocks/web_socket.dart'

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.vm.w_socket;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -18,8 +18,6 @@
 /// If possible, APIs built using these classes should also avoid
 /// importing `dart:html` and `dart:io` in order to remain platform-agnostic,
 /// as it provides much greater reuse value.
-library w_transport.src.web_socket.w_socket;
-
 import 'dart:async';
 
 import 'package:w_transport/src/platform_adapter.dart';

--- a/lib/src/web_socket/w_socket_close_event.dart
+++ b/lib/src/web_socket/w_socket_close_event.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.w_socket_close_event;
-
 /// Represents the close event from a WebSocket.
 ///
 /// This was previously only used internally, but was erroneously exported as a

--- a/lib/src/web_socket/w_socket_exception.dart
+++ b/lib/src/web_socket/w_socket_exception.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.src.web_socket.w_socket_exception;
-
 /// Represents an exception in the connection process of a Web Socket.
 class WSocketException {
   String message;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,15 @@
 name: w_transport
 version: 2.8.0
+
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and
   multipart data, as well as custom encoding. WebSocket support includes native
   WebSockets in the browser and the VM with the option to use SockJS in the
   browser.
+
+homepage: https://github.com/Workiva/w_transport
+
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>
   - Dustin Lessard <dustin.lessard@workiva.com>
@@ -13,28 +17,29 @@ authors:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-homepage: https://github.com/Workiva/w_transport
+
+environment:
+  sdk: ">=1.9.0 <2.0.0"
+
 dependencies:
-  fluri: "^1.1.0"
-  http_parser: "^1.0.0"
-  mime: "^0.9.3"
+  fluri: ^1.1.0
+  http_parser: ">=2.2.0 <4.0.0"
+  mime: ^0.9.3
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.1
-  stack_trace: "^1.4.0"
+
 dev_dependencies:
-  ansicolor: "^0.0.9"
-  args: "^0.13.0"
-  browser: "^0.10.0+2"
-  coverage: "^0.7.4"
-  dart_dev: "^1.1.2"
-  dart_style: "^0.2.4"
-  http_server: "^0.9.5+1"
-  mockito: "^0.9.0"
-  path: "^1.3.5"
-  react: "^0.6.1"
-  test: "^0.12.3+5"
-  uuid: "^0.5.0"
-environment:
-  sdk: ">=1.9.0 <2.0.0"
+  ansicolor: ^0.0.9
+  args: ^0.13.0
+  browser: ^0.10.0+2
+  coverage: ^0.7.9
+  dart_dev: ^1.4.0
+  dart_style: ^0.2.4
+  http_server: ^0.9.5+1
+  mockito: ^0.11.0
+  path: ^1.3.9
+  react: ^0.6.1
+  test: ^0.12.15
+  uuid: ^0.5.0

--- a/test/integration/browser_integration_test.dart
+++ b/test/integration/browser_integration_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.browser_suite_test;
-
 import 'package:test/test.dart';
 
 import 'http/client/browser_test.dart' as http_client_browser;

--- a/test/integration/http/client/browser_test.dart
+++ b/test/integration/http/client/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.client.browser_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/browser.dart';
 

--- a/test/integration/http/client/mock_test.dart
+++ b/test/integration/http/client/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.client.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/client/suite.dart
+++ b/test/integration/http/client/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.client.suite;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/integration/http/client/vm_test.dart
+++ b/test/integration/http/client/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.client.vm_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/vm.dart';
 

--- a/test/integration/http/common_request/browser_test.dart
+++ b/test/integration/http/common_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.common_request.browser_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart';

--- a/test/integration/http/common_request/mock_test.dart
+++ b/test/integration/http/common_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.common_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.common_request.suite;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -28,6 +26,7 @@ void runCommonRequestSuite() {
       if (!withBody) return new FormRequest();
       return new FormRequest()..fields['field'] = 'value';
     }
+
     jsonReqFactory({bool withBody: false}) {
       if (!withBody) return new JsonRequest();
       return new JsonRequest()
@@ -35,14 +34,17 @@ void runCommonRequestSuite() {
           {'field': 'value'}
         ];
     }
+
     multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new MultipartRequest()..fields['field'] = 'value';
     }
+
     reqFactory({bool withBody: false}) {
       if (!withBody) return new Request();
       return new Request()..body = 'body';
     }
+
     streamedReqFactory({bool withBody: false}) {
       if (!withBody) return new StreamedRequest();
       return new StreamedRequest()

--- a/test/integration/http/common_request/vm_test.dart
+++ b/test/integration/http/common_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.common_request.vm_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/vm.dart';

--- a/test/integration/http/form_request/browser_test.dart
+++ b/test/integration/http/form_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.form_request.browser_test;
-
 import 'dart:html';
 
 import 'package:test/test.dart';

--- a/test/integration/http/form_request/mock_test.dart
+++ b/test/integration/http/form_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.form_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/form_request/suite.dart
+++ b/test/integration/http/form_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.form_request.suite;
-
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';

--- a/test/integration/http/form_request/vm_test.dart
+++ b/test/integration/http/form_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.form_request.vm_test;
-
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/integration/http/http_static/browser_test.dart
+++ b/test/integration/http/http_static/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.http_static.browser_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/browser.dart';
 

--- a/test/integration/http/http_static/mock_test.dart
+++ b/test/integration/http/http_static/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.http_static.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/http_static/suite.dart
+++ b/test/integration/http/http_static/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.http_static.suite;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/test/integration/http/http_static/vm_test.dart
+++ b/test/integration/http/http_static/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.http_static.vm_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/vm.dart';
 

--- a/test/integration/http/json_request/browser_test.dart
+++ b/test/integration/http/json_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.json_request.browser_test;
-
 import 'dart:html';
 
 import 'package:test/test.dart';

--- a/test/integration/http/json_request/mock_test.dart
+++ b/test/integration/http/json_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.json_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/json_request/suite.dart
+++ b/test/integration/http/json_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.json_request.suite;
-
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';

--- a/test/integration/http/json_request/vm_test.dart
+++ b/test/integration/http/json_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.json_request.vm_test;
-
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/integration/http/mock_endpoints/404.dart
+++ b/test/integration/http/mock_endpoints/404.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.fourOhFour;
-
 import 'package:w_transport/mock.dart';
 
 void mock404Endpoint(Uri uri) {

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.custom;
-
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/mock_endpoints/download.dart
+++ b/test/integration/http/mock_endpoints/download.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.download;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/integration/http/mock_endpoints/echo.dart
+++ b/test/integration/http/mock_endpoints/echo.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.echo;
-
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/mock_endpoints/ping.dart
+++ b/test/integration/http/mock_endpoints/ping.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.ping;
-
 import 'package:w_transport/mock.dart';
 
 void mockPingEndpoint(Uri uri) {

--- a/test/integration/http/mock_endpoints/reflect.dart
+++ b/test/integration/http/mock_endpoints/reflect.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.reflect;
-
 import 'dart:convert';
 
 import 'package:w_transport/mock.dart';

--- a/test/integration/http/mock_endpoints/timeout.dart
+++ b/test/integration/http/mock_endpoints/timeout.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.timeout;
-
 import 'dart:async';
 
 import 'package:w_transport/mock.dart';

--- a/test/integration/http/mock_endpoints/upload.dart
+++ b/test/integration/http/mock_endpoints/upload.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.upload;
-
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/multipart_request/browser_test.dart
+++ b/test/integration/http/multipart_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.multipart_request.browser_test;
-
 import 'dart:html';
 import 'dart:convert';
 

--- a/test/integration/http/multipart_request/mock_test.dart
+++ b/test/integration/http/multipart_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.multipart_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/multipart_request/suite.dart
+++ b/test/integration/http/multipart_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.multipart_request.suite;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/integration/http/multipart_request/vm_test.dart
+++ b/test/integration/http/multipart_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.multipart_request.vm_test;
-
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/integration/http/plain_text_request/browser_test.dart
+++ b/test/integration/http/plain_text_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.plain_text_request.browser_test;
-
 import 'dart:html';
 
 import 'package:test/test.dart';

--- a/test/integration/http/plain_text_request/mock_test.dart
+++ b/test/integration/http/plain_text_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.plain_text_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/plain_text_request/suite.dart
+++ b/test/integration/http/plain_text_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.plain_text_request.suite;
-
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';

--- a/test/integration/http/plain_text_request/vm_test.dart
+++ b/test/integration/http/plain_text_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.plain_text_request.vm_test;
-
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/integration/http/streamed_request/browser_test.dart
+++ b/test/integration/http/streamed_request/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.http.streamed_request.browser_test;
-
 import 'dart:html';
 
 import 'package:test/test.dart';

--- a/test/integration/http/streamed_request/mock_test.dart
+++ b/test/integration/http/streamed_request/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.http.streamed_request.mock_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
 

--- a/test/integration/http/streamed_request/suite.dart
+++ b/test/integration/http/streamed_request/suite.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.streamed_request.suite;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/integration/http/streamed_request/vm_test.dart
+++ b/test/integration/http/streamed_request/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.http.streamed_request.vm_test;
-
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/integration/integration_paths.dart
+++ b/test/integration/integration_paths.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.integration_paths;
-
 class IntegrationPaths {
   static final Uri hostUri = Uri.parse('http://localhost:8024');
   static final Uri wsHostUri = hostUri.replace(scheme: 'ws');

--- a/test/integration/mock_integration_test.dart
+++ b/test/integration/mock_integration_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.mock_suite_test;
-
 import 'package:test/test.dart';
 
 import 'http/client/mock_test.dart' as http_client_mock;

--- a/test/integration/platforms/browser_platform_test.dart
+++ b/test/integration/platforms/browser_platform_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.platforms.browser_platform_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart';

--- a/test/integration/platforms/mock_platform_test.dart
+++ b/test/integration/platforms/mock_platform_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.integration.platforms.mock_platform_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';

--- a/test/integration/platforms/platform_adapter_test.dart
+++ b/test/integration/platforms/platform_adapter_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.platform_adapter_test;
-
 import 'package:test/test.dart';
 
 import 'package:w_transport/src/platform_adapter.dart';

--- a/test/integration/platforms/vm_platform_test.dart
+++ b/test/integration/platforms/vm_platform_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.platforms.vm_platform_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/vm.dart';

--- a/test/integration/vm_integration_test.dart
+++ b/test/integration/vm_integration_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.vm_suite_test;
-
 import 'package:test/test.dart';
 
 import 'http/client/vm_test.dart' as http_client_vm;

--- a/test/integration/ws/browser_test.dart
+++ b/test/integration/ws/browser_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.ws.browser_test;
-
 import 'dart:html';
 import 'dart:typed_data';
 

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.ws.common;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.integration.ws.mock_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.integration.ws.sockjs_test;
-
 import 'dart:html';
 import 'dart:typed_data';
 

--- a/test/integration/ws/vm_test.dart
+++ b/test/integration/ws/vm_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm')
-library w_transport.test.integration.ws.vm_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/vm.dart';

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.naming;
-
 /// Platforms.
 const String platformBrowser = 'browser';
 const String platformBrowserSockjsWS = 'browser (SockJS WS)';

--- a/test/unit/browser_unit_test.dart
+++ b/test/unit/browser_unit_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.unit.browser_suite_test;
-
 import 'package:test/test.dart';
 
 import 'http/browser_utils_test.dart' as http_browser_utils_test;

--- a/test/unit/http/browser_utils_test.dart
+++ b/test/unit/http/browser_utils_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.unit.http.browser_utils_test;
-
 import 'dart:async';
 import 'dart:html';
 

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.http.client_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.form_request_test;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/unit/http/http_body_test.dart
+++ b/test/unit/http/http_body_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.unit.http.http_body_test;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/test/unit/http/http_interceptor_test.dart
+++ b/test/unit/http/http_interceptor_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.http.http_interceptor_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';

--- a/test/unit/http/http_static_test.dart
+++ b/test/unit/http/http_static_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.http.http_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.json_request_test;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/unit/http/multipart_file_test.dart
+++ b/test/unit/http/multipart_file_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.multipart_file_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/unit/http/multipart_request_test.dart
+++ b/test/unit/http/multipart_request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.multipart_request_test;
-
 import 'dart:convert';
 
 import 'package:test/test.dart';

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.plain_text_request_test;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/unit/http/request_exception_test.dart
+++ b/test/unit/http/request_exception_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.http.request_exception_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart' show RequestException, Response;
 import 'package:w_transport/mock.dart';

--- a/test/unit/http/request_progress_test.dart
+++ b/test/unit/http/request_progress_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.unit.http.request_progress_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.http.request_test;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -34,6 +32,7 @@ void main() {
       if (!withBody) return new FormRequest();
       return new FormRequest()..fields['field'] = 'value';
     }
+
     jsonReqFactory({bool withBody: false}) {
       if (!withBody) return new JsonRequest();
       return new JsonRequest()
@@ -41,14 +40,17 @@ void main() {
           {'field': 'value'}
         ];
     }
+
     multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new MultipartRequest()..fields['field'] = 'value';
     }
+
     reqFactory({bool withBody: false}) {
       if (!withBody) return new Request();
       return new Request()..body = 'body';
     }
+
     streamedReqFactory({bool withBody: false}) {
       if (!withBody) return new StreamedRequest();
       return new StreamedRequest()

--- a/test/unit/http/response_format_exception_test.dart
+++ b/test/unit/http/response_format_exception_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.unit.http.response_format_exception_test;
-
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart' show MediaType;

--- a/test/unit/http/response_test.dart
+++ b/test/unit/http/response_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.unit.http.response_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.http.streamed_request_test;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.unit.http.utils_test;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser')
-library w_transport.test.unit.mocks.mock_http_test;
-
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';

--- a/test/unit/mocks/mock_response_test.dart
+++ b/test/unit/mocks/mock_response_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.mocks.mock_w_response_test;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.mocks.mock_web_socket_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';
@@ -290,6 +288,7 @@ void main() {
             uriMatch = match;
             return new MockWSocket();
           }
+
           ;
           MockTransports.webSocket.whenPattern(uriPattern, handler: handler);
 

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('browser || vm')
-library w_transport.test.unit.unit_test_suite;
-
 import 'package:test/test.dart';
 
 import 'http/client_test.dart' as http_client_test;

--- a/test/unit/ws/w_socket_exception_test.dart
+++ b/test/unit/ws/w_socket_exception_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.ws.w_socket_exception_test;
-
 import 'package:test/test.dart';
 
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';

--- a/test/unit/ws/w_socket_subscription_test.dart
+++ b/test/unit/ws/w_socket_subscription_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.ws.w_socket_subscription_test;
-
 import 'dart:async';
 
 import 'package:mockito/mockito.dart';
@@ -41,8 +39,11 @@ void main() {
         var wsub = new WSocketSubscription(sub, () {},
             onCancel: onCancelCalled.complete);
 
-        await Future
-            .wait([wsub.cancel(), subCanceled.future, onCancelCalled.future,]);
+        await Future.wait([
+          wsub.cancel(),
+          subCanceled.future,
+          onCancelCalled.future,
+        ]);
       });
 
       test('isPaused should return the status of the underlying subscription',

--- a/test/unit/ws/w_socket_test.dart
+++ b/test/unit/ws/w_socket_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_transport.test.unit.ws.w_socket_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library tool.dev;
-
 import 'dart:async';
 
 import 'package:dart_dev/dart_dev.dart' show dev, config;

--- a/tool/server/handler.dart
+++ b/tool/server/handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handler;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/echo_handler.dart
+++ b/tool/server/handlers/echo_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.echo_handler;
-
 import '../handler.dart';
 import '../logger.dart';
 

--- a/tool/server/handlers/example/http/cross_origin_credentials_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_credentials_handlers.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.example.http.cross_origin_credentials_handlers;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.example.http.cross_origin_file_transfer_handlers;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.examples.http.proxy_cross_origin_file_transfer_handlers;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/example/ws/echo_handler.dart
+++ b/tool/server/handlers/example/ws/echo_handler.dart
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.example.ws.echo_handler;
-
 export '../../echo_handler.dart' show EchoHandler;

--- a/tool/server/handlers/example/ws/routes.dart
+++ b/tool/server/handlers/example/ws/routes.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.example.ws.routes;
-
 import '../../../handler.dart';
 import '../../../logger.dart';
 import 'echo_handler.dart';

--- a/tool/server/handlers/ping_handler.dart
+++ b/tool/server/handlers/ping_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.ping_handler;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/404_handler.dart
+++ b/tool/server/handlers/test/http/404_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.fourzerofour_handler;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/custom.dart
+++ b/tool/server/handlers/test/http/custom.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.custom;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/download.dart
+++ b/tool/server/handlers/test/http/download.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.download_handler;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/echo.dart
+++ b/tool/server/handlers/test/http/echo.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.echo;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/error.dart
+++ b/tool/server/handlers/test/http/error.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.error;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/ping_handler.dart
+++ b/tool/server/handlers/test/http/ping_handler.dart
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.ping_handler;
-
 export '../../ping_handler.dart' show PingHandler;

--- a/tool/server/handlers/test/http/reflect_handler.dart
+++ b/tool/server/handlers/test/http/reflect_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.reflect_handler;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/tool/server/handlers/test/http/routes.dart
+++ b/tool/server/handlers/test/http/routes.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.routes;
-
 import '../../../handler.dart';
 import '404_handler.dart';
 import 'custom.dart';

--- a/tool/server/handlers/test/http/timeout_handler.dart
+++ b/tool/server/handlers/test/http/timeout_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.ping_handler;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/http/upload.dart
+++ b/tool/server/handlers/test/http/upload.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.http.upload;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/handlers/test/ws/close_handler.dart
+++ b/tool/server/handlers/test/ws/close_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.ws.close_handler;
-
 import '../../../handler.dart';
 import '../../../logger.dart';
 

--- a/tool/server/handlers/test/ws/echo_handler.dart
+++ b/tool/server/handlers/test/ws/echo_handler.dart
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.ws.echo_handler;
-
 export '../../echo_handler.dart' show EchoHandler;

--- a/tool/server/handlers/test/ws/ping_handler.dart
+++ b/tool/server/handlers/test/ws/ping_handler.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.ws.ping_handler;
-
 import 'dart:async';
 
 import '../../../handler.dart';

--- a/tool/server/handlers/test/ws/routes.dart
+++ b/tool/server/handlers/test/ws/routes.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.handlers.test.ws.routes;
-
 import '../../../handler.dart';
 import '../../../logger.dart';
 import 'close_handler.dart';

--- a/tool/server/logger.dart
+++ b/tool/server/logger.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.logger;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/router.dart
+++ b/tool/server/router.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.router;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/server/server.dart
+++ b/tool/server/server.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.tool.server.server;
-
 import 'dart:async';
 import 'dart:io';
 


### PR DESCRIPTION
_Fixes #188._

## TODO
- [x] Update changelog
- [x] Remove library declarations

## Improvement
Currently the minimum SDK version for this package is `1.9.0`, which precludes us from using null-aware operators and `StackTrace.current`.

## Changes
- Bump the minimum SDK version to 1.14.0 so that we can use null-aware operators and `StackTrace.current`
- Upgrade dependencies where possible

## Testing
- [ ] CI passes (no functional source code has been changed).

## Release Instructions
This PR is made to a `3.0.0-wip` branch because 2.8.1 and 2.9.0 are still in progress. Once those two are released, we can merge `3.0.0-wip` into master and make any further 3.0.0 PRs to master.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 