### PR TITLE
CP-2090 Simplify entry point names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The end consumer will make the decision between browser and VM, most likely in a
 
 ### Browser
 ```dart
-import 'package:w_transport/w_transport_browser.dart'
+import 'package:w_transport/browser.dart'
     show configureWTransportForBrowser;
 
 void main() {
@@ -81,7 +81,7 @@ void main() {
 
 ### Dart VM
 ```dart
-import 'package:w_transport/w_transport_vm.dart'
+import 'package:w_transport/vm.dart'
     show configureWTransportForVM;
 
 void main() {
@@ -91,7 +91,7 @@ void main() {
 
 ### Tests
 ```dart
-import 'package:w_transport/w_transport_mock.dart'
+import 'package:w_transport/mock.dart'
     show configureWTransportForTest;
 
 void main() {
@@ -716,7 +716,7 @@ this library can be configured. By configuring `w_transport` for tests, mock
 implementations of all classes will be used.
 
 ```dart
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 main() {
   configureWTransportForTest();
@@ -725,8 +725,8 @@ main() {
 
 That's it. No changes to your source code are necessary! Once configured for
 test, you are in control of every HTTP request and every WebSocket connection.
-The APIs for controlling these transports are exported with the
-`w_transport_mock.dart` entry point as static APIs on a `MockTransports` class.
+The APIs for controlling these transports are exported with the `mock.dart`
+entry point as static APIs on a `MockTransports` class.
 
 > **Resetting Mocks:**
 >

--- a/example/http/cross_origin_credentials/client.dart
+++ b/example/http/cross_origin_credentials/client.dart
@@ -15,8 +15,7 @@
 library w_transport.example.http.cross_origin_credentials.client;
 
 import 'package:react/react_client.dart' as react_client;
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
+import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu_component.dart';
 import '../../common/loading_component.dart';

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -18,8 +18,7 @@ import 'dart:html';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart' as react_client;
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
+import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu_component.dart';
 import '../../common/loading_component.dart';

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -19,8 +19,7 @@ import 'dart:html';
 
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
+import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu_component.dart';
 import '../../common/loading_component.dart';

--- a/example/index.dart
+++ b/example/index.dart
@@ -15,8 +15,7 @@
 library w_transport.example.index;
 
 import 'package:react/react_client.dart' as react_client;
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
+import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import './common/global_example_menu_component.dart';
 import './common/loading_component.dart';

--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -19,8 +19,7 @@ import 'dart:html';
 
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart'
-    show configureWTransportForBrowser;
+import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu_component.dart';
 import '../../common/loading_component.dart';

--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -1,0 +1,60 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Transport for the browser. Exposes a single configuration method that must
+/// be called before instantiating any of the transport classes.
+///
+///     import 'package:w_transport/browser.dart'
+///         show configureWTransportForBrowser;
+///
+///     void main() {
+///       configureWTransportForBrowser();
+///     }
+///
+/// If you'd like WebSocket to fall back to XHR-streaming if native WebSockets
+/// are not available, w_transport can be configured to use a SockJS client.
+///
+///     import 'package:w_transport/browser.dart'
+///         show configureWTransportForBrowser;
+///
+///     void main() {
+///       configureWTransportForBrowser(
+///           useSockJS: true,
+///           sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
+///     }
+library w_transport.browser;
+
+import 'package:w_transport/src/browser_adapter.dart';
+import 'package:w_transport/src/platform_adapter.dart';
+
+/// Configures w_transport for use in the browser via dart:html.
+void configureWTransportForBrowser(
+    {bool useSockJS: false,
+    bool sockJSDebug: false,
+    bool sockJSNoCredentials: false,
+    List<String> sockJSProtocolsWhitelist}) {
+  // Configuring SockJS at this level is deprecated. SockJS configuration should
+  // occur on a per-socket basis.
+  if (useSockJS == true) {
+    print('Deprecation Warning: Configuring all w_transport sockets to use '
+        'SockJS is deprecated. Instead, SockJS usage should be configured on a '
+        'per-socket basis via the optional parameters in WSocket.connect().');
+  }
+
+  adapter = new BrowserAdapter(
+      useSockJS: useSockJS,
+      sockJSDebug: sockJSDebug,
+      sockJSNoCredentials: sockJSNoCredentials,
+      sockJSProtocolsWhitelist: sockJSProtocolsWhitelist);
+}

--- a/lib/mock.dart
+++ b/lib/mock.dart
@@ -1,0 +1,56 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Easily mock out the platform-specific details of w_transport. Exposes a
+/// single configuration method that must be called before instantiating any of
+/// the transport classes.
+///
+///     import 'package:w_transport/mock.dart'
+///         show configureWTransportForTest;
+///
+///     void main() {
+///       configureWTransportForTest();
+///     }
+library w_transport.mock;
+
+import 'package:w_transport/src/mock_adapter.dart';
+import 'package:w_transport/src/platform_adapter.dart';
+
+export 'package:w_transport/src/http/finalized_request.dart'
+    show FinalizedRequest;
+export 'package:w_transport/src/http/mock/base_request.dart'
+    show MockBaseRequest;
+export 'package:w_transport/src/http/mock/client.dart' show MockClient;
+export 'package:w_transport/src/http/mock/requests.dart'
+    show
+        MockFormRequest,
+        MockJsonRequest,
+        MockPlainTextRequest,
+        MockStreamedRequest;
+export 'package:w_transport/src/http/mock/response.dart'
+    show MockResponse, MockStreamedResponse;
+
+export 'package:w_transport/src/mocks/http.dart'
+    show MockHttpHandler, PatternRequestHandler, RequestHandler;
+export 'package:w_transport/src/mocks/transport.dart' show MockTransports;
+export 'package:w_transport/src/mocks/web_socket.dart'
+    show MockWebSocketHandler;
+
+export 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
+
+/// Configure w_transport for use in tests, allowing you to easily mock out the
+/// behavior of the w_transport classes.
+void configureWTransportForTest() {
+  adapter = new MockAdapter();
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,2 +1,2 @@
 // TODO: Add link to upgrade guide.
-const String v3Deprecation = 'in 4.0.0.';
+const String v3Deprecation = 'in 4.0.0. ';

--- a/lib/src/platform_adapter.dart
+++ b/lib/src/platform_adapter.dart
@@ -21,9 +21,9 @@ import 'package:w_transport/w_transport.dart';
 /// The currently selected platform adapter. Will be set by the configuration
 /// methods exposed in the platform-specific entry points:
 ///
-/// - w_transport/w_transport_browser.dart
-/// - w_transport/w_transport_mock.dart
-/// - w_transport/w_transport_server.dart
+/// - w_transport/browser.dart
+/// - w_transport/mock.dart
+/// - w_transport/vm.dart
 PlatformAdapter adapter;
 
 /// Defines how to construct the appropriate class instances for a certain

--- a/lib/vm.dart
+++ b/lib/vm.dart
@@ -12,14 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_transport.test.integration.http.mock_endpoints.timeout;
+/// Transport for the server. This exposes a single configuration method that
+/// must be called before instantiating any of the transport classes.
+///
+///     import 'package:w_transport/vm.dart'
+///         show configureWTransportForServer;
+///
+///     void main() {
+///       configureWTransportForVM();
+///     }
+library w_transport.vm;
 
-import 'dart:async';
+import 'package:w_transport/src/platform_adapter.dart';
+import 'package:w_transport/src/vm_adapter.dart';
 
-import 'package:w_transport/mock.dart';
-
-void mockTimeoutEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (_) async {
-    return new Completer().future;
-  });
+/// Configure w_transport for use on the server via dart:io.
+void configureWTransportForVM() {
+  adapter = new VMAdapter();
 }

--- a/lib/w_transport_browser.dart
+++ b/lib/w_transport_browser.dart
@@ -12,49 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Transport for the browser. Exposes a single configuration method that must
-/// be called before instantiating any of the transport classes.
-///
-///     import 'package:w_transport/w_transport_browser.dart'
-///         show configureWTransportForBrowser;
-///
-///     void main() {
-///       configureWTransportForBrowser();
-///     }
-///
-/// If you'd like WebSocket to fall back to XHR-streaming if native WebSockets
-/// are not available, w_transport can be configured to use a SockJS client.
-///
-///     import 'package:w_transport/w_transport_browser.dart'
-///         show configureWTransportForBrowser;
-///
-///     void main() {
-///       configureWTransportForBrowser(
-///           useSockJS: true,
-///           sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
-///     }
+@Deprecated(
+    v3Deprecation + 'Import \'package:w_transport/browser.dart\' instead.')
 library w_transport.w_transport_browser;
 
-import 'package:w_transport/src/browser_adapter.dart';
-import 'package:w_transport/src/platform_adapter.dart';
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 
-/// Configures w_transport for use in the browser via dart:html.
-void configureWTransportForBrowser(
-    {bool useSockJS: false,
-    bool sockJSDebug: false,
-    bool sockJSNoCredentials: false,
-    List<String> sockJSProtocolsWhitelist}) {
-  // Configuring SockJS at this level is deprecated. SockJS configuration should
-  // occur on a per-socket basis.
-  if (useSockJS == true) {
-    print('Deprecation Warning: Configuring all w_transport sockets to use '
-        'SockJS is deprecated. Instead, SockJS usage should be configured on a '
-        'per-socket basis via the optional parameters in WSocket.connect().');
-  }
-
-  adapter = new BrowserAdapter(
-      useSockJS: useSockJS,
-      sockJSDebug: sockJSDebug,
-      sockJSNoCredentials: sockJSNoCredentials,
-      sockJSProtocolsWhitelist: sockJSProtocolsWhitelist);
-}
+export 'package:w_transport/browser.dart' show configureWTransportForBrowser;

--- a/lib/w_transport_mock.dart
+++ b/lib/w_transport_mock.dart
@@ -12,45 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Easily mock out the platform-specific details of w_transport. Exposes a
-/// single configuration method that must be called before instantiating any of
-/// the transport classes.
-///
-///     import 'package:w_transport/w_transport_mock.dart'
-///         show configureWTransportForTest;
-///
-///     void main() {
-///       configureWTransportForTest();
-///     }
+@Deprecated(v3Deprecation + 'Import \'package:w_transport/mock.dart\' instead.')
 library w_transport.w_transport_mock;
 
-import 'package:w_transport/src/mock_adapter.dart';
-import 'package:w_transport/src/platform_adapter.dart';
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 
-export 'package:w_transport/src/http/finalized_request.dart'
-    show FinalizedRequest;
-export 'package:w_transport/src/http/mock/base_request.dart'
-    show MockBaseRequest;
-export 'package:w_transport/src/http/mock/client.dart' show MockClient;
-export 'package:w_transport/src/http/mock/requests.dart'
+export 'package:w_transport/mock.dart'
     show
+        FinalizedRequest,
+        MockBaseRequest,
+        MockClient,
         MockFormRequest,
+        MockHttpHandler,
         MockJsonRequest,
         MockPlainTextRequest,
-        MockStreamedRequest;
-export 'package:w_transport/src/http/mock/response.dart'
-    show MockResponse, MockStreamedResponse;
-
-export 'package:w_transport/src/mocks/http.dart'
-    show MockHttpHandler, PatternRequestHandler, RequestHandler;
-export 'package:w_transport/src/mocks/transport.dart' show MockTransports;
-export 'package:w_transport/src/mocks/web_socket.dart'
-    show MockWebSocketHandler;
-
-export 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
-
-/// Configure w_transport for use in tests, allowing you to easily mock out the
-/// behavior of the w_transport classes.
-void configureWTransportForTest() {
-  adapter = new MockAdapter();
-}
+        MockResponse,
+        MockStreamedRequest,
+        MockStreamedResponse,
+        MockTransports,
+        MockWSocket,
+        MockWebSocketHandler,
+        PatternRequestHandler,
+        RequestHandler,
+        configureWTransportForTest;

--- a/lib/w_transport_vm.dart
+++ b/lib/w_transport_vm.dart
@@ -12,21 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Transport for the server. This exposes a single configuration method that
-/// must be called before instantiating any of the transport classes.
-///
-///     import 'package:w_transport/w_transport_vm.dart'
-///         show configureWTransportForServer;
-///
-///     void main() {
-///       configureWTransportForVM();
-///     }
+@Deprecated(v3Deprecation + 'Import \'package:w_transport/vm.dart\' instead.')
 library w_transport.w_transport_vm;
 
-import 'package:w_transport/src/platform_adapter.dart';
-import 'package:w_transport/src/vm_adapter.dart';
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 
-/// Configure w_transport for use on the server via dart:io.
-void configureWTransportForVM() {
-  adapter = new VMAdapter();
-}
+export 'package:w_transport/vm.dart' show configureWTransportForVM;

--- a/test/integration/http/client/browser_test.dart
+++ b/test/integration/http/client/browser_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.client.browser_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import 'suite.dart';

--- a/test/integration/http/client/mock_test.dart
+++ b/test/integration/http/client/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.client.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../mock_endpoints/ping.dart';

--- a/test/integration/http/client/vm_test.dart
+++ b/test/integration/http/client/vm_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.client.vm_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import 'suite.dart';

--- a/test/integration/http/common_request/browser_test.dart
+++ b/test/integration/http/common_request/browser_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.http.common_request.browser_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../integration_paths.dart';
 import '../../../naming.dart';

--- a/test/integration/http/common_request/mock_test.dart
+++ b/test/integration/http/common_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.common_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/common_request/vm_test.dart
+++ b/test/integration/http/common_request/vm_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.http.common_request.vm_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import 'suite.dart';

--- a/test/integration/http/form_request/browser_test.dart
+++ b/test/integration/http/form_request/browser_test.dart
@@ -19,7 +19,7 @@ import 'dart:html';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/form_request/mock_test.dart
+++ b/test/integration/http/form_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.form_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/form_request/vm_test.dart
+++ b/test/integration/http/form_request/vm_test.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/http_static/browser_test.dart
+++ b/test/integration/http/http_static/browser_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.http_static.browser_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import 'suite.dart';

--- a/test/integration/http/http_static/mock_test.dart
+++ b/test/integration/http/http_static/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.http_static.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/http_static/vm_test.dart
+++ b/test/integration/http/http_static/vm_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.http_static.vm_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import 'suite.dart';

--- a/test/integration/http/json_request/browser_test.dart
+++ b/test/integration/http/json_request/browser_test.dart
@@ -19,7 +19,7 @@ import 'dart:html';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/json_request/mock_test.dart
+++ b/test/integration/http/json_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.json_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/json_request/vm_test.dart
+++ b/test/integration/http/json_request/vm_test.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/mock_endpoints/404.dart
+++ b/test/integration/http/mock_endpoints/404.dart
@@ -14,7 +14,7 @@
 
 library w_transport.test.integration.http.mock_endpoints.fourOhFour;
 
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mock404Endpoint(Uri uri) {
   MockTransports.http.when(

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -15,7 +15,7 @@
 library w_transport.test.integration.http.mock_endpoints.custom;
 
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockCustomEndpoint(Uri uri) {
   MockTransports.http.when(uri, (FinalizedRequest request) async {

--- a/test/integration/http/mock_endpoints/download.dart
+++ b/test/integration/http/mock_endpoints/download.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.http.mock_endpoints.download;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockDownloadEndpoint(Uri uri) {
   MockTransports.http.when(uri, (_) async {

--- a/test/integration/http/mock_endpoints/echo.dart
+++ b/test/integration/http/mock_endpoints/echo.dart
@@ -15,7 +15,7 @@
 library w_transport.test.integration.http.mock_endpoints.echo;
 
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockEchoEndpoint(Uri uri) {
   MockTransports.http.when(uri, (FinalizedRequest request) async {

--- a/test/integration/http/mock_endpoints/ping.dart
+++ b/test/integration/http/mock_endpoints/ping.dart
@@ -14,7 +14,7 @@
 
 library w_transport.test.integration.http.mock_endpoints.ping;
 
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockPingEndpoint(Uri uri) {
   MockTransports.http.when(uri, (_) async {

--- a/test/integration/http/mock_endpoints/reflect.dart
+++ b/test/integration/http/mock_endpoints/reflect.dart
@@ -16,7 +16,7 @@ library w_transport.test.integration.http.mock_endpoints.reflect;
 
 import 'dart:convert';
 
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockReflectEndpoint(Uri uri) {
   MockTransports.http.when(uri, (FinalizedRequest request) async {

--- a/test/integration/http/mock_endpoints/upload.dart
+++ b/test/integration/http/mock_endpoints/upload.dart
@@ -15,7 +15,7 @@
 library w_transport.test.integration.http.mock_endpoints.upload;
 
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 void mockUploadEndpoint(Uri uri) {
   MockTransports.http.when(uri, (FinalizedRequest request) async {

--- a/test/integration/http/multipart_request/browser_test.dart
+++ b/test/integration/http/multipart_request/browser_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/multipart_request/mock_test.dart
+++ b/test/integration/http/multipart_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.multipart_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/multipart_request/vm_test.dart
+++ b/test/integration/http/multipart_request/vm_test.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/plain_text_request/browser_test.dart
+++ b/test/integration/http/plain_text_request/browser_test.dart
@@ -19,7 +19,7 @@ import 'dart:html';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/plain_text_request/mock_test.dart
+++ b/test/integration/http/plain_text_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.plain_text_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/plain_text_request/vm_test.dart
+++ b/test/integration/http/plain_text_request/vm_test.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/streamed_request/browser_test.dart
+++ b/test/integration/http/streamed_request/browser_test.dart
@@ -19,7 +19,7 @@ import 'dart:html';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/streamed_request/mock_test.dart
+++ b/test/integration/http/streamed_request/mock_test.dart
@@ -16,7 +16,7 @@
 library w_transport.test.integration.http.streamed_request.mock_test;
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/http/streamed_request/vm_test.dart
+++ b/test/integration/http/streamed_request/vm_test.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../../naming.dart';
 import '../../integration_paths.dart';

--- a/test/integration/platforms/browser_platform_test.dart
+++ b/test/integration/platforms/browser_platform_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.platforms.browser_platform_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import 'package:w_transport/src/http/browser/client.dart';
 import 'package:w_transport/src/http/browser/requests.dart';

--- a/test/integration/platforms/mock_platform_test.dart
+++ b/test/integration/platforms/mock_platform_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.platforms.mock_platform_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import 'package:w_transport/src/http/mock/client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';

--- a/test/integration/platforms/vm_platform_test.dart
+++ b/test/integration/platforms/vm_platform_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.platforms.vm_platform_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import 'package:w_transport/src/http/vm/client.dart';
 import 'package:w_transport/src/http/vm/requests.dart';

--- a/test/integration/ws/browser_test.dart
+++ b/test/integration/ws/browser_test.dart
@@ -20,7 +20,7 @@ import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../naming.dart';
 import '../integration_paths.dart';

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -18,7 +18,7 @@ library w_transport.test.integration.ws.mock_test;
 import 'dart:async';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 import '../integration_paths.dart';

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -20,7 +20,7 @@ import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_browser.dart';
+import 'package:w_transport/browser.dart';
 
 import '../../naming.dart';
 import '../integration_paths.dart';

--- a/test/integration/ws/vm_test.dart
+++ b/test/integration/ws/vm_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.integration.ws.vm_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart';
+import 'package:w_transport/vm.dart';
 
 import '../../naming.dart';
 import '../integration_paths.dart';

--- a/test/unit/http/backoff_test.dart
+++ b/test/unit/http/backoff_test.dart
@@ -20,7 +20,7 @@ import 'package:test/test.dart';
 import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/http/common/backoff.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/http_interceptor_test.dart
+++ b/test/unit/http/http_interceptor_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.unit.http.http_interceptor_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/http_static_test.dart
+++ b/test/unit/http/http_static_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/multipart_request_test.dart
+++ b/test/unit/http/multipart_request_test.dart
@@ -19,7 +19,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/request_exception_test.dart
+++ b/test/unit/http/request_exception_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.unit.http.request_exception_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart' show RequestException, Response;
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -17,7 +17,7 @@ library w_transport.test.unit.mocks.mock_http_test;
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 import '../../utils.dart' show nextTick;

--- a/test/unit/mocks/mock_response_test.dart
+++ b/test/unit/mocks/mock_response_test.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 

--- a/test/unit/ws/w_socket_test.dart
+++ b/test/unit/ws/w_socket_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_mock.dart';
+import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';
 import '../../utils.dart' show nextTick;

--- a/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:w_transport/w_transport.dart';
-import 'package:w_transport/w_transport_vm.dart' show configureWTransportForVM;
+import 'package:w_transport/vm.dart' show configureWTransportForVM;
 
 import '../../../handler.dart';
 


### PR DESCRIPTION
_Fixes #172._

## TODO
- [ ] Update changelog

## Improvement
The entry points are overly verbose. No need to include the package name as a prefix for non-main entry points.

## Changes
- `w_transport_browser.dart` --> `browser.dart`
- `w_transport_mock.dart` --> `mock.dart`
- `w_transport_vm.dart` --> `vm.dart`
- Deprecated annotations have been added to the old entry points.
- All references within this package have been migrated.

## Testing
- [ ] CI passes
  - [ ] The analyze step should not produce any deprecation warnings for the newly deprecated entry points.

## Release Instructions
This PR is made to a `3.0.0-wip` branch because 2.8.1 and 2.9.0 are still in progress. Once those two are released, we can merge `3.0.0-wip` into master and make any further 3.0.0 PRs to master.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 