### PR TITLE
CP-2069 Release w_transport 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.8.0
+version: 2.9.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-2069

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.9.0 items =======

 CP-2096  - Update 2.9.0 release date and notes  - https://github.com/Workiva/w_transport/pull/200

 CP-2094  - Add isDone to BaseRequest  - https://github.com/Workiva/w_transport/pull/192

 CP-2076  - Increase duration tolerance for jitter tests  - https://github.com/Workiva/w_transport/pull/191

 CP-2078  - Update 2.8.0 release date  - https://github.com/Workiva/w_transport/pull/193

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.8.0...CP-2069_release_2.9.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.8.0...2.9.0

