### PR TITLE
CP-2286 Ensure WSocket always reaches "done" state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.9.1](https://github.com/Workvia/w_transport/compare/2.9.0...2.9.1)
+_August 2, 2016_
+
+- **Bug Fix:** previously, listening to a `WSocket` instance and then canceling
+  the subscription before closing the socket would result in the "done" state
+  never being reached. This is fixed now and the `Future` returned from
+  `WSocket.done` and `WSocket.close()` will always resolve once the connection
+  is closed.
+
 ## [2.9.0](https://github.com/Workvia/w_transport/compare/2.8.0...2.9.0)
 _July 26, 2016_
 

--- a/test/unit/ws/w_socket_subscription_test.dart
+++ b/test/unit/ws/w_socket_subscription_test.dart
@@ -33,16 +33,14 @@ void main() {
     group('WSocketSubscription', () {
       test('cancel() should cancel underlying subscription and call callback',
           () async {
-        var subCanceled = new Completer();
         var onCancelCalled = new Completer();
 
-        var sc = new StreamController(onCancel: subCanceled.complete);
+        var sc = new StreamController();
         var sub = sc.stream.listen((_) {});
         var wsub = new WSocketSubscription(sub, () {},
             onCancel: onCancelCalled.complete);
 
-        await Future
-            .wait([wsub.cancel(), subCanceled.future, onCancelCalled.future,]);
+        await Future.wait([wsub.cancel(), onCancelCalled.future,]);
       });
 
       test('isPaused should return the status of the underlying subscription',


### PR DESCRIPTION
_Fixes #171._

## Issue
In the current implementation of `WSocket`, the subscription to the underlying WebSocket stream is canceled when the subscription to the `WSocket` instance is canceled. This prevents us from receiving the "done" event when the WebSocket connection is closed, which we wait for before considering the `WSocket` instance "done". This means that if a consumer were to cancel their subscription to a `WSocket` instance prior to calling `.close()`, the future returned from the call to `.close()` (as well as the `WSocket.done` future) will never resolve.

```dart
var webSocket = await WSocket.connect(...);
var subscription = webSocket.listen(...);

// ...

subscription.cancel();
await webSocket.close(); // <-- this would never resolve, causing code execution to hang
```

This was reported here: #171.

## Solution
Instead of canceling the underlying WebSocket subscription when the consumer cancels their subscription to the `WSocket` instance, we simply move the `WSocketSubscription` instance into 
a "canceled" state that prevents any further action and changes the `onData`, `onError`, and `onDone` handlers to no-ops so that the listener does not receive any more events. This allows us to recieve the "done" event from the underlying WebSocket, at which point we have access to the close code and reason and can consider the `WSocket` instance "done".

## Testing
- [ ] CI passes (tests added)
- [ ] Consumer is able to cancel a subscription to a `WSocket` instance prior to closing it without having it hang (@johnkirchner-wf could supply the +10 for this)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 

fyi: @johnkirchner-wf 