### PR TITLE
CP-2098 Release w_transport 2.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w_transport",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "devDependencies": {
     "http": "0.0.0",
     "sockjs": "^0.3.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.0
+version: 2.9.1
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-2098

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_transport 2.9.1 items =======

 CP-2286  - Ensure WSocket always reaches "done" state.  - https://github.com/Workiva/w_transport/pull/202

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.0...CP-2098_release_2.9.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.0...2.9.1

