### PR TITLE
CP-2425 Widen http_parser dependency range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.9.2](https://github.com/Workvia/w_transport/compare/2.9.1...2.9.2)
+_August 11, 2016_
+
+- Widen the version range for the `http_parser` dependency to speed up and/or
+  fix downstream consumers experiencing version conflicts.
+
 ## [2.9.1](https://github.com/Workvia/w_transport/compare/2.9.0...2.9.1)
 _August 2, 2016_
 

--- a/example/http/cross_origin_file_transfer/components/app_component.dart
+++ b/example/http/cross_origin_file_transfer/components/app_component.dart
@@ -26,7 +26,9 @@ var appComponent = react.registerComponent(() => new AppComponent());
 
 class AppComponent extends react.Component {
   Map getInitialState() {
-    return {'page': 'upload',};
+    return {
+      'page': 'upload',
+    };
   }
 
   void _goToUploadPage(e) {

--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -35,7 +35,9 @@ class DownloadPage extends react.Component {
   StreamSubscription fileStreamErrorSubscription;
 
   Map getDefaultProps() {
-    return {'active': false,};
+    return {
+      'active': false,
+    };
   }
 
   Map getInitialState() {
@@ -53,7 +55,10 @@ class DownloadPage extends react.Component {
     remoteFiles = RemoteFiles.connect();
     fileStreamSubscription = remoteFiles.stream
         .listen((List<RemoteFileDescription> fileDescriptions) {
-      this.setState({'fileDescriptions': fileDescriptions, 'error': null,});
+      this.setState({
+        'fileDescriptions': fileDescriptions,
+        'error': null,
+      });
     });
     fileStreamErrorSubscription = remoteFiles.errorStream.listen((error) {
       this.setState({'error': error});
@@ -134,7 +139,9 @@ class DownloadPage extends react.Component {
         'key': rfd.name,
         'onClick': _createDownloadFileCallback(rfd)
       }, [
-        react.div({'className': 'file-name',}, rfd.name),
+        react.div({
+          'className': 'file-name',
+        }, rfd.name),
         react.div({'className': 'file-size'}, _humanizeFileSize(rfd.size)),
       ]));
     });

--- a/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -39,7 +39,11 @@ class DropZoneComponent extends react.Component {
   }
 
   Map getDefaultProps() {
-    return {'onNewUploads': (_) {}, 'onDragStart': () {}, 'onDragEnd': () {},};
+    return {
+      'onNewUploads': (_) {},
+      'onDragStart': () {},
+      'onDragEnd': () {},
+    };
   }
 
   void componentWillMount() {

--- a/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
+++ b/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
@@ -30,11 +30,18 @@ var fileTransferListItemComponent =
 
 class FileTransferListItemComponent extends react.Component {
   Map getInitialState() {
-    return {'done': false, 'success': false, 'will-remove': false,};
+    return {
+      'done': false,
+      'success': false,
+      'will-remove': false,
+    };
   }
 
   Map getDefaultProps() {
-    return {'transfer': null, 'onTransferDone': (_) {},};
+    return {
+      'transfer': null,
+      'onTransferDone': (_) {},
+    };
   }
 
   void componentWillMount() {

--- a/example/http/cross_origin_file_transfer/components/upload_page.dart
+++ b/example/http/cross_origin_file_transfer/components/upload_page.dart
@@ -24,7 +24,9 @@ var uploadPage = react.registerComponent(() => new UploadPage());
 
 class UploadPage extends react.Component {
   Map getDefaultProps() {
-    return {'active': true,};
+    return {
+      'active': true,
+    };
   }
 
   Map getInitialState() {

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -88,6 +88,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         c.completeError(error, new Chain.current());
       }
     }
+
     _request.onError.listen(onError);
     _request.onAbort.listen(onError);
 

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -176,6 +176,7 @@ abstract class CommonMultipartRequest extends CommonRequest
     void write(String content) {
       controller.add(UTF8.encode(content));
     }
+
     Future writeByteStream(Stream<List<int>> byteStream) {
       var c = new Completer();
       byteStream.listen(controller.add,

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -618,6 +618,7 @@ abstract class CommonRequest extends Object
           responseCompleter.complete();
         }
       }
+
       _cancellationCompleter.future.then(breakOutOfResponseFetching);
       _timeoutCompleter.future.then(breakOutOfResponseFetching);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,27 +14,30 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_transport
+
+environment:
+  sdk: ">=1.9.0 <2.0.0"
+
 dependencies:
-  fluri: "^1.1.0"
-  http_parser: "^1.0.0"
-  mime: "^0.9.3"
+  fluri: ^1.1.0
+  http_parser: ">=1.0.0 <4.0.0"
+  mime: ^0.9.3
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.1
-  stack_trace: "^1.4.0"
+  stack_trace: ^1.4.0
+
 dev_dependencies:
-  ansicolor: "^0.0.9"
-  args: "^0.13.0"
-  browser: "^0.10.0+2"
-  coverage: "^0.7.4"
-  dart_dev: "^1.1.2"
-  dart_style: "^0.2.4"
-  http_server: "^0.9.5+1"
-  mockito: "^0.9.0"
-  path: "^1.3.5"
-  react: "^0.6.1"
-  test: "^0.12.3+5"
-  uuid: "^0.5.0"
-environment:
-  sdk: ">=1.9.0 <2.0.0"
+  ansicolor: ^0.0.9
+  args: ^0.13.0
+  browser: ^0.10.0+2
+  coverage: ^0.7.4
+  dart_dev: ^1.1.2
+  dart_style: ^0.2.4
+  http_server: ^0.9.5+1
+  mockito: ^0.9.0
+  path: ^1.3.5
+  react: ^0.6.1
+  test: ^0.12.3+5
+  uuid: ^0.5.0

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -28,6 +28,7 @@ void runCommonRequestSuite() {
       if (!withBody) return new FormRequest();
       return new FormRequest()..fields['field'] = 'value';
     }
+
     jsonReqFactory({bool withBody: false}) {
       if (!withBody) return new JsonRequest();
       return new JsonRequest()
@@ -35,14 +36,17 @@ void runCommonRequestSuite() {
           {'field': 'value'}
         ];
     }
+
     multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new MultipartRequest()..fields['field'] = 'value';
     }
+
     reqFactory({bool withBody: false}) {
       if (!withBody) return new Request();
       return new Request()..body = 'body';
     }
+
     streamedReqFactory({bool withBody: false}) {
       if (!withBody) return new StreamedRequest();
       return new StreamedRequest()

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -34,6 +34,7 @@ void main() {
       if (!withBody) return new FormRequest();
       return new FormRequest()..fields['field'] = 'value';
     }
+
     jsonReqFactory({bool withBody: false}) {
       if (!withBody) return new JsonRequest();
       return new JsonRequest()
@@ -41,14 +42,17 @@ void main() {
           {'field': 'value'}
         ];
     }
+
     multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new MultipartRequest()..fields['field'] = 'value';
     }
+
     reqFactory({bool withBody: false}) {
       if (!withBody) return new Request();
       return new Request()..body = 'body';
     }
+
     streamedReqFactory({bool withBody: false}) {
       if (!withBody) return new StreamedRequest();
       return new StreamedRequest()

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -290,7 +290,7 @@ void main() {
             uriMatch = match;
             return new MockWSocket();
           }
-          ;
+
           MockTransports.webSocket.whenPattern(uriPattern, handler: handler);
 
           await WSocket.connect(Uri.parse('ws://github.com/ws/listen'));

--- a/test/unit/ws/w_socket_subscription_test.dart
+++ b/test/unit/ws/w_socket_subscription_test.dart
@@ -40,7 +40,10 @@ void main() {
         var wsub = new WSocketSubscription(sub, () {},
             onCancel: onCancelCalled.complete);
 
-        await Future.wait([wsub.cancel(), onCancelCalled.future,]);
+        await Future.wait([
+          wsub.cancel(),
+          onCancelCalled.future,
+        ]);
       });
 
       test('isPaused should return the status of the underlying subscription',


### PR DESCRIPTION
## Issue
The 1.x line of `http_parser` depended on an older version of the `crypto` package. This is causing some pain for downstream consumers (very slow or sometimes failed `pub get`s).

## Solution
Newer versions of the `http_parser` package no longer depend on `crypto` and don't have any breaking changes that would be an issue for `w_transport`. We can safely widen our dependency range to include both the 2.x and 3.x lines.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf
