### PR TITLE
CP-2243 Rename Client to HttpClient

### DIFF
--- a/lib/src/browser_adapter.dart
+++ b/lib/src/browser_adapter.dart
@@ -14,9 +14,9 @@
 
 import 'dart:async';
 
-import 'package:w_transport/src/http/browser/client.dart';
+import 'package:w_transport/src/http/browser/http_client.dart';
 import 'package:w_transport/src/http/browser/requests.dart';
-import 'package:w_transport/src/http/client.dart';
+import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
 import 'package:w_transport/src/web_socket/browser/sockjs.dart';
@@ -45,8 +45,8 @@ class BrowserAdapter implements PlatformAdapter {
         _sockJSNoCredentials = sockJSNoCredentials == true,
         _sockJSTimeout = sockJSTimeout;
 
-  /// Construct a new [BrowserClient] instance that implements [Client].
-  Client newClient() => new BrowserClient();
+  /// Construct a new [BrowserHttpClient] instance that implements [HttpClient].
+  HttpClient newHttpClient() => new BrowserHttpClient();
 
   /// Construct a new [BrowserFormRequest] instance that implements
   /// [FormRequest].

--- a/lib/src/http/browser/http_client.dart
+++ b/lib/src/http/browser/http_client.dart
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import 'package:w_transport/src/http/browser/requests.dart';
-import 'package:w_transport/src/http/client.dart';
-import 'package:w_transport/src/http/common/client.dart';
+import 'package:w_transport/src/http/common/http_client.dart';
+import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/http/requests.dart';
 
 /// Browser-specific implementation of an HTTP client. In the browser, there is
@@ -22,7 +22,7 @@ import 'package:w_transport/src/http/requests.dart';
 /// the Dart VM provides. Consequently, this implementation acts as a simple
 /// factory for each type of request. It does, however, still retain the benefit
 /// that all outstanding requests will be canceled when this client is closed.
-class BrowserClient extends CommonClient implements Client {
+class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   /// Constructs a new [FormRequest] that will use this client to send the
   /// request. Throws a [StateError] if this client has been closed.
   @override

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/src/http/http_interceptor.dart';
 import 'package:w_transport/src/http/requests.dart';
@@ -23,8 +24,11 @@ import 'package:w_transport/src/platform_adapter.dart';
 ///
 /// On the server, the Dart VM will also be able to take advantage of cached
 /// network connections between requests that share a client.
+///
+/// TODO: Remove this class in 4.0.0 and move the abstract definition into the `HttpClient` class.
+@Deprecated(v3Deprecation + 'Use `HttpClient` instead.')
 abstract class Client {
-  factory Client() => PlatformAdapter.retrieve().newClient();
+  factory Client() => PlatformAdapter.retrieve().newHttpClient();
 
   /// Configuration of automatic request retrying for failed requests. Use this
   /// object to enable or disable automatic retrying, configure the criteria

--- a/lib/src/http/common/http_client.dart
+++ b/lib/src/http/common/http_client.dart
@@ -16,11 +16,11 @@ import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
 
 import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/src/http/base_request.dart';
-import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/http_interceptor.dart';
+import 'package:w_transport/src/http/http_client.dart';
 
 /// HTTP client logic that can be shared across platforms.
-abstract class CommonClient implements Client {
+abstract class CommonHttpClient implements HttpClient {
   /// Configuration of automatic request retrying for failed requests. Use this
   /// object to enable or disable automatic retrying, configure the criteria
   /// that determines whether or not a request should be retried, as well as the

--- a/lib/src/http/http_client.dart
+++ b/lib/src/http/http_client.dart
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:w_transport/src/http/mock/http_client.dart';
-import 'package:w_transport/src/http/http_client.dart';
+import 'package:w_transport/src/http/client.dart';
+import 'package:w_transport/src/platform_adapter.dart';
 
-/// A mock implementation of an HTTP client. Factory methods simply return the
-/// mock implementations of each request. Since the mock request implementations
-/// don't ever actually send an HTTP request, this client doesn't need to do
-/// anything else.
-class MockClient extends MockHttpClient implements HttpClient {}
+/// An HTTP client acts as a single point from which many requests can be
+/// constructed. All requests constructed from a client will inherit [headers],
+/// the [withCredentials] flag, and the [timeoutThreshold].
+///
+/// On the server, the Dart VM will also be able to take advantage of cached
+/// network connections between requests that share a client.
+abstract class HttpClient extends Client {
+  factory HttpClient() => PlatformAdapter.retrieve().newHttpClient();
+}

--- a/lib/src/http/mock/http_client.dart
+++ b/lib/src/http/mock/http_client.dart
@@ -12,34 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:io';
-
-import 'package:w_transport/src/http/client.dart';
-import 'package:w_transport/src/http/common/client.dart';
+import 'package:w_transport/src/http/mock/requests.dart';
+import 'package:w_transport/src/http/common/http_client.dart';
+import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/http/requests.dart';
-import 'package:w_transport/src/http/vm/requests.dart';
 
-/// VM-specific implementation of an HTTP client. All requests created from this
-/// client will use the same dart:io.HttpClient. This allows for network
-/// connections to be cached.
-class VMClient extends CommonClient implements Client {
-  /// The underlying HTTP client used to open and send requests.
-  HttpClient _client = new HttpClient();
-
-  /// Close the underlying HTTP client.
-  @override
-  void closeClient() {
-    if (_client != null) {
-      _client.close();
-    }
-  }
-
+/// A mock implementation of an HTTP client. Factory methods simply return the
+/// mock implementations of each request. Since the mock request implementations
+/// don't ever actually send an HTTP request, this client doesn't need to do
+/// anything else.
+class MockHttpClient extends CommonHttpClient implements HttpClient {
   /// Constructs a new [FormRequest] that will use this client to send the
   /// request. Throws a [StateError] if this client has been closed.
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new VMFormRequest.fromClient(this, _client);
+    FormRequest request = new MockFormRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -49,7 +37,7 @@ class VMClient extends CommonClient implements Client {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new VMJsonRequest.fromClient(this, _client);
+    JsonRequest request = new MockJsonRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -59,7 +47,7 @@ class VMClient extends CommonClient implements Client {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new VMMultipartRequest.fromClient(this, _client);
+    MultipartRequest request = new MockMultipartRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -69,7 +57,7 @@ class VMClient extends CommonClient implements Client {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new VMPlainTextRequest.fromClient(this, _client);
+    Request request = new MockPlainTextRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -79,7 +67,7 @@ class VMClient extends CommonClient implements Client {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new VMStreamedRequest.fromClient(this, _client);
+    StreamedRequest request = new MockStreamedRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/vm/http_client.dart
+++ b/lib/src/http/vm/http_client.dart
@@ -1,0 +1,88 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io' as io;
+
+import 'package:w_transport/src/http/common/http_client.dart';
+import 'package:w_transport/src/http/http_client.dart';
+import 'package:w_transport/src/http/requests.dart';
+import 'package:w_transport/src/http/vm/requests.dart';
+
+/// VM-specific implementation of an HTTP client. All requests created from this
+/// client will use the same dart:io.HttpClient. This allows for network
+/// connections to be cached.
+class VMHttpClient extends CommonHttpClient implements HttpClient {
+  /// The underlying HTTP client used to open and send requests.
+  io.HttpClient _ioHttpClient = new io.HttpClient();
+
+  /// Close the underlying HTTP client.
+  @override
+  void closeClient() {
+    if (_ioHttpClient != null) {
+      _ioHttpClient.close();
+    }
+  }
+
+  /// Constructs a new [FormRequest] that will use this client to send the
+  /// request. Throws a [StateError] if this client has been closed.
+  @override
+  FormRequest newFormRequest() {
+    verifyNotClosed();
+    FormRequest request = new VMFormRequest.fromClient(this, _ioHttpClient);
+    registerAndDecorateRequest(request);
+    return request;
+  }
+
+  /// Constructs a new [JsonRequest] that will use this client to send the
+  /// request. Throws a [StateError] if this client has been closed.
+  @override
+  JsonRequest newJsonRequest() {
+    verifyNotClosed();
+    JsonRequest request = new VMJsonRequest.fromClient(this, _ioHttpClient);
+    registerAndDecorateRequest(request);
+    return request;
+  }
+
+  /// Constructs a new [MultipartRequest] that will use this client to send the
+  /// request. Throws a [StateError] if this client has been closed.
+  @override
+  MultipartRequest newMultipartRequest() {
+    verifyNotClosed();
+    MultipartRequest request =
+        new VMMultipartRequest.fromClient(this, _ioHttpClient);
+    registerAndDecorateRequest(request);
+    return request;
+  }
+
+  /// Constructs a new [Request] that will use this client to send the request.
+  /// Throws a [StateError] if this client has been closed.
+  @override
+  Request newRequest() {
+    verifyNotClosed();
+    Request request = new VMPlainTextRequest.fromClient(this, _ioHttpClient);
+    registerAndDecorateRequest(request);
+    return request;
+  }
+
+  /// Constructs a new [StreamedRequest] that will use this client to send the
+  /// request. Throws a [StateError] if this client has been closed.
+  @override
+  StreamedRequest newStreamedRequest() {
+    verifyNotClosed();
+    StreamedRequest request =
+        new VMStreamedRequest.fromClient(this, _ioHttpClient);
+    registerAndDecorateRequest(request);
+    return request;
+  }
+}

--- a/lib/src/mock_adapter.dart
+++ b/lib/src/mock_adapter.dart
@@ -14,8 +14,8 @@
 
 import 'dart:async';
 
-import 'package:w_transport/src/http/client.dart';
-import 'package:w_transport/src/http/mock/client.dart';
+import 'package:w_transport/src/http/http_client.dart';
+import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
@@ -26,8 +26,8 @@ import 'package:w_transport/src/web_socket/w_socket.dart';
 /// transport classes that return mock implementations that can be controlled
 /// by the mock transport API.
 class MockAdapter implements PlatformAdapter {
-  /// Construct a new [MockClient] instance that implements [Client].
-  Client newClient() => new MockClient();
+  /// Construct a new [MockHttpClient] instance that implements [HttpClient].
+  HttpClient newHttpClient() => new MockHttpClient();
 
   /// Construct a new [MockFormRequest] instance that implements
   /// [FormRequest].

--- a/lib/src/platform_adapter.dart
+++ b/lib/src/platform_adapter.dart
@@ -28,7 +28,7 @@ PlatformAdapter adapter;
 /// platform. The platform-agnostic API in w_transport is created by exposing
 /// several public abstract classes:
 ///
-/// - [Client]
+/// - [HttpClient]
 /// - [FormRequest]
 /// - [JsonRequest]
 /// - [MultipartRequest]
@@ -53,8 +53,8 @@ abstract class PlatformAdapter {
     return adapter;
   }
 
-  /// Constructs a new [Client] instance.
-  Client newClient();
+  /// Constructs a new [HttpClient] instance.
+  HttpClient newHttpClient();
 
   /// Constructs a new [FormRequest] instance.
   FormRequest newFormRequest();

--- a/lib/src/vm_adapter.dart
+++ b/lib/src/vm_adapter.dart
@@ -14,9 +14,9 @@
 
 import 'dart:async';
 
-import 'package:w_transport/src/http/client.dart';
+import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/http/requests.dart';
-import 'package:w_transport/src/http/vm/client.dart';
+import 'package:w_transport/src/http/vm/http_client.dart';
 import 'package:w_transport/src/http/vm/requests.dart';
 import 'package:w_transport/src/platform_adapter.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
@@ -25,8 +25,8 @@ import 'package:w_transport/src/web_socket/vm/w_socket.dart';
 /// Adapter for the Dart VM. Exposes factories for all of the transport classes
 /// that return VM-specific implementations that leverage dart:io.
 class VMAdapter implements PlatformAdapter {
-  /// Construct a new [VMClient] instance that implements [Client].
-  Client newClient() => new VMClient();
+  /// Construct a new [VMHttpClient] instance that implements [HttpClient].
+  HttpClient newHttpClient() => new VMHttpClient();
 
   /// Construct a new [VMFormRequest] instance that implements [FormRequest].
   FormRequest newFormRequest() => new VMFormRequest();

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -100,6 +100,7 @@ export 'package:w_transport/src/http/http_body.dart'
     show HttpBody, StreamedHttpBody;
 export 'package:w_transport/src/http/http_interceptor.dart'
     show HttpInterceptor, RequestPayload, ResponsePayload;
+export 'package:w_transport/src/http/http_client.dart' show HttpClient;
 export 'package:w_transport/src/http/multipart_file.dart' show MultipartFile;
 export 'package:w_transport/src/http/request_exception.dart'
     show RequestException;

--- a/test/integration/http/client/browser_test.dart
+++ b/test/integration/http/client/browser_test.dart
@@ -30,6 +30,6 @@ void main() {
       configureWTransportForBrowser();
     });
 
-    runClientSuite();
+    runHttpTransportClientSuite();
   });
 }

--- a/test/integration/http/client/mock_test.dart
+++ b/test/integration/http/client/mock_test.dart
@@ -37,7 +37,7 @@ void main() {
       mockTimeoutEndpoint(IntegrationPaths.timeoutEndpointUri);
     });
 
-    runClientSuite();
+    runHttpTransportClientSuite();
 
     tearDown(() {
       MockTransports.verifyNoOutstandingExceptions();

--- a/test/integration/http/client/vm_test.dart
+++ b/test/integration/http/client/vm_test.dart
@@ -30,6 +30,6 @@ void main() {
       configureWTransportForVM();
     });
 
-    runClientSuite();
+    runHttpTransportClientSuite();
   });
 }

--- a/test/integration/platforms/browser_platform_test.dart
+++ b/test/integration/platforms/browser_platform_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart';
 
-import 'package:w_transport/src/http/browser/client.dart';
+import 'package:w_transport/src/http/browser/http_client.dart';
 import 'package:w_transport/src/http/browser/requests.dart';
 
 import '../../naming.dart';
@@ -34,7 +34,11 @@ void main() {
     });
 
     test('newClient()', () {
-      expect(new Client(), new isInstanceOf<BrowserClient>());
+      expect(new Client(), new isInstanceOf<BrowserHttpClient>());
+    });
+
+    test('newHttpClient()', () {
+      expect(new HttpClient(), new isInstanceOf<BrowserHttpClient>());
     });
 
     test('newFormRequest()', () {

--- a/test/integration/platforms/mock_platform_test.dart
+++ b/test/integration/platforms/mock_platform_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
-import 'package:w_transport/src/http/mock/client.dart';
+import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';
 import 'package:w_transport/src/web_socket/mock/w_socket.dart';
 
@@ -35,7 +35,11 @@ void main() {
     });
 
     test('newClient()', () {
-      expect(new Client(), new isInstanceOf<MockClient>());
+      expect(new Client(), new isInstanceOf<MockHttpClient>());
+    });
+
+    test('newHttpTransportClient()', () {
+      expect(new HttpClient(), new isInstanceOf<MockHttpClient>());
     });
 
     test('newFormRequest()', () {

--- a/test/integration/platforms/vm_platform_test.dart
+++ b/test/integration/platforms/vm_platform_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/vm.dart';
 
-import 'package:w_transport/src/http/vm/client.dart';
+import 'package:w_transport/src/http/vm/http_client.dart';
 import 'package:w_transport/src/http/vm/requests.dart';
 
 import '../../naming.dart';
@@ -34,7 +34,11 @@ void main() {
     });
 
     test('newClient()', () {
-      expect(new Client(), new isInstanceOf<VMClient>());
+      expect(new Client(), new isInstanceOf<VMHttpClient>());
+    });
+
+    test('newHttpTransportClient()', () {
+      expect(new HttpClient(), new isInstanceOf<VMHttpClient>());
     });
 
     test('newFormRequest()', () {

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -88,222 +88,217 @@ void main() {
     ..topic = topicHttp;
 
   group(naming.toString(), () {
-    group('Client', () {
-      setUp(() {
-        configureWTransportForTest();
-        MockTransports.reset();
-      });
-
-      test('newFormRequest() should create a new request', () async {
-        Client client = new Client();
-        expect(client.newFormRequest(), new isInstanceOf<FormRequest>());
-      });
-
-      test('newFormRequest() should throw if closed', () async {
-        Client client = new Client();
-        client.close();
-        expect(client.newFormRequest, throwsStateError);
-      });
-
-      test('newJsonRequest() should create a new request', () async {
-        Client client = new Client();
-        expect(client.newJsonRequest(), new isInstanceOf<JsonRequest>());
-      });
-
-      test('newJsonRequest() should throw if closed', () async {
-        Client client = new Client();
-        client.close();
-        expect(client.newJsonRequest, throwsStateError);
-      });
-
-      test('newMultipartRequest() should create a new request', () async {
-        Client client = new Client();
-        expect(
-            client.newMultipartRequest(), new isInstanceOf<MultipartRequest>());
-      });
-
-      test('newMultipartRequest() should throw if closed', () async {
-        Client client = new Client();
-        client.close();
-        expect(client.newMultipartRequest, throwsStateError);
-      });
-
-      test('newRequest() should create a new request', () async {
-        Client client = new Client();
-        expect(client.newRequest(), new isInstanceOf<Request>());
-      });
-
-      test('newRequest() should throw if closed', () async {
-        Client client = new Client();
-        client.close();
-        expect(client.newRequest, throwsStateError);
-      });
-
-      test('newStreamedRequest() should create a new request', () async {
-        Client client = new Client();
-        expect(
-            client.newStreamedRequest(), new isInstanceOf<StreamedRequest>());
-      });
-
-      test('newStreamedRequest() should throw if closed', () async {
-        Client client = new Client();
-        client.close();
-        expect(client.newStreamedRequest, throwsStateError);
-      });
-
-      test('complete request', () async {
-        Client client = new Client();
-        Uri uri = Uri.parse('/test');
-        MockTransports.http.expect('GET', uri);
-        await client.newRequest().get(uri: uri);
-      });
-
-      test('baseUri should be inherited by all requests', () async {
-        var baseUri = Uri.parse('https://example.com/base/path');
-        Client client = new Client()..baseUri = baseUri;
-        for (var request in createAllRequestTypes(client)) {
-          expect(request.uri, equals(baseUri));
-        }
-      });
-
-      test('headers should be inherited by all requests', () async {
-        var headers = {'x-custom1': 'value', 'x-custom2': 'value2'};
-        Client client = new Client()..headers = headers;
-        expect(client.headers, equals(headers));
-        for (var request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          MockTransports.http.expect('GET', uri, headers: headers);
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          await request.get(uri: uri);
-        }
-      });
-
-      test('timeoutThreshold should be inherited by all requests', () async {
-        Duration tt = new Duration(seconds: 1);
-        Client client = new Client()..timeoutThreshold = tt;
-        expect(client.timeoutThreshold, equals(tt));
-        for (var request in createAllRequestTypes(client)) {
-          expect(request.timeoutThreshold, equals(tt));
-        }
-      });
-
-      test('withCredentials should be inherited by all requests', () async {
-        Client client = new Client()..withCredentials = true;
-        expect(client.withCredentials, isTrue);
-        for (var request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          Completer c = new Completer();
-          MockTransports.http.when(uri, (FinalizedRequest request) async {
-            request.withCredentials
-                ? c.complete()
-                : c.completeError(
-                    new Exception('withCredentials should be true'));
-            return new MockResponse.ok();
-          }, method: 'GET');
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          await request.get(uri: uri);
-          await c.future;
-        }
-      });
-
-      test('autoRetry should be inherited by all requests', () async {
-        Client client = new Client();
-        client.autoRetry
-          ..backOff = const RetryBackOff.fixed(const Duration(seconds: 2))
-          ..enabled = true
-          ..forHttpMethods = ['GET']
-          ..forStatusCodes = [404]
-          ..forTimeouts = false
-          ..maxRetries = 4
-          ..test = (request, response, willRetry) async => true;
-
-        for (var request in createAllRequestTypes(client)) {
-          expect(request.autoRetry.backOff.interval,
-              equals(client.autoRetry.backOff.interval));
-          expect(request.autoRetry.backOff.method,
-              equals(client.autoRetry.backOff.method));
-          expect(request.autoRetry.enabled, equals(client.autoRetry.enabled));
-          expect(request.autoRetry.forHttpMethods,
-              equals(client.autoRetry.forHttpMethods));
-          expect(request.autoRetry.forStatusCodes,
-              equals(client.autoRetry.forStatusCodes));
-          expect(request.autoRetry.forTimeouts,
-              equals(client.autoRetry.forTimeouts));
-          expect(request.autoRetry.maxRetries,
-              equals(client.autoRetry.maxRetries));
-          expect(request.autoRetry.test, equals(client.autoRetry.test));
-        }
-      });
-
-      test('addInterceptor() single interceptor (request only)', () async {
-        Client client = new Client()..addInterceptor(new ReqInt());
-        for (BaseRequest request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          MockTransports.http
-              .expect('GET', uri, headers: {'x-intercepted': 'true'});
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          await request.get(uri: uri);
-        }
-      });
-
-      test('addInterceptor() single interceptor (response only)', () async {
-        Client client = new Client()..addInterceptor(new RespInt());
-        for (BaseRequest request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          MockTransports.http.expect('GET', uri);
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          Response response = await request.get(uri: uri);
-          expect(response.headers, containsPair('x-intercepted', 'true'));
-        }
-      });
-
-      test('addInterceptor() single interceptor', () async {
-        Client client = new Client()..addInterceptor(new ReqRespInt());
-        for (BaseRequest request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          MockTransports.http
-              .expect('GET', uri, headers: {'x-intercepted': 'true'});
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          Response response = await request.get(uri: uri);
-          expect(response.headers, containsPair('x-intercepted', 'true'));
-        }
-      });
-
-      test('addInterceptor() multiple interceptors', () async {
-        Client client = new Client()
-          ..addInterceptor(new ReqRespInt())
-          ..addInterceptor(new AsyncInt());
-        for (BaseRequest request in createAllRequestTypes(client)) {
-          Uri uri = Uri.parse('/test');
-          Uri augmentedUri =
-              uri.replace(queryParameters: {'interceptor': 'asyncint'});
-          MockTransports.http
-              .expect('GET', augmentedUri, headers: {'x-intercepted': 'true'});
-          if (request is MultipartRequest) {
-            request.fields['f'] = 'v';
-          }
-          Response response = await request.get(uri: uri);
-          expect(response.headers, containsPair('x-intercepted', 'true'));
-          expect(response.headers, containsPair('x-interceptor', 'asyncint'));
-        }
-      });
-
-      test('close()', () async {
-        Client client = new Client();
-        Future future = client.newRequest().get(uri: Uri.parse('/test'));
-        client.close();
-        expect(future, throws);
-      });
+    setUp(() {
+      configureWTransportForTest();
+      MockTransports.reset();
     });
+
+    group('Client', () {
+      _runHttpClientSuite(() => new Client());
+    });
+
+    group('HttpClient', () {
+      _runHttpClientSuite(() => new HttpClient());
+    });
+  });
+}
+
+_runHttpClientSuite(Client getClient()) {
+  Client client;
+
+  setUp(() {
+    client = getClient();
+  });
+
+  test('newFormRequest() should create a new request', () async {
+    expect(client.newFormRequest(), new isInstanceOf<FormRequest>());
+  });
+
+  test('newFormRequest() should throw if closed', () async {
+    client.close();
+    expect(client.newFormRequest, throwsStateError);
+  });
+
+  test('newJsonRequest() should create a new request', () async {
+    expect(client.newJsonRequest(), new isInstanceOf<JsonRequest>());
+  });
+
+  test('newJsonRequest() should throw if closed', () async {
+    client.close();
+    expect(client.newJsonRequest, throwsStateError);
+  });
+
+  test('newMultipartRequest() should create a new request', () async {
+    expect(client.newMultipartRequest(), new isInstanceOf<MultipartRequest>());
+  });
+
+  test('newMultipartRequest() should throw if closed', () async {
+    client.close();
+    expect(client.newMultipartRequest, throwsStateError);
+  });
+
+  test('newRequest() should create a new request', () async {
+    expect(client.newRequest(), new isInstanceOf<Request>());
+  });
+
+  test('newRequest() should throw if closed', () async {
+    client.close();
+    expect(client.newRequest, throwsStateError);
+  });
+
+  test('newStreamedRequest() should create a new request', () async {
+    expect(client.newStreamedRequest(), new isInstanceOf<StreamedRequest>());
+  });
+
+  test('newStreamedRequest() should throw if closed', () async {
+    client.close();
+    expect(client.newStreamedRequest, throwsStateError);
+  });
+
+  test('complete request', () async {
+    Uri uri = Uri.parse('/test');
+    MockTransports.http.expect('GET', uri);
+    await client.newRequest().get(uri: uri);
+  });
+
+  test('baseUri should be inherited by all requests', () async {
+    var baseUri = Uri.parse('https://example.com/base/path');
+    client.baseUri = baseUri;
+    for (var request in createAllRequestTypes(client)) {
+      expect(request.uri, equals(baseUri));
+    }
+  });
+
+  test('headers should be inherited by all requests', () async {
+    var headers = {'x-custom1': 'value', 'x-custom2': 'value2'};
+    client.headers = headers;
+    expect(client.headers, equals(headers));
+    for (var request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      MockTransports.http.expect('GET', uri, headers: headers);
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      await request.get(uri: uri);
+    }
+  });
+
+  test('timeoutThreshold should be inherited by all requests', () async {
+    Duration tt = new Duration(seconds: 1);
+    client.timeoutThreshold = tt;
+    expect(client.timeoutThreshold, equals(tt));
+    for (var request in createAllRequestTypes(client)) {
+      expect(request.timeoutThreshold, equals(tt));
+    }
+  });
+
+  test('withCredentials should be inherited by all requests', () async {
+    client.withCredentials = true;
+    expect(client.withCredentials, isTrue);
+    for (var request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      Completer c = new Completer();
+      MockTransports.http.when(uri, (FinalizedRequest request) async {
+        request.withCredentials
+            ? c.complete()
+            : c.completeError(new Exception('withCredentials should be true'));
+        return new MockResponse.ok();
+      }, method: 'GET');
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      await request.get(uri: uri);
+      await c.future;
+    }
+  });
+
+  test('autoRetry should be inherited by all requests', () async {
+    client.autoRetry
+      ..backOff = const RetryBackOff.fixed(const Duration(seconds: 2))
+      ..enabled = true
+      ..forHttpMethods = ['GET']
+      ..forStatusCodes = [404]
+      ..forTimeouts = false
+      ..maxRetries = 4
+      ..test = (request, response, willRetry) async => true;
+
+    for (var request in createAllRequestTypes(client)) {
+      expect(request.autoRetry.backOff.interval,
+          equals(client.autoRetry.backOff.interval));
+      expect(request.autoRetry.backOff.method,
+          equals(client.autoRetry.backOff.method));
+      expect(request.autoRetry.enabled, equals(client.autoRetry.enabled));
+      expect(request.autoRetry.forHttpMethods,
+          equals(client.autoRetry.forHttpMethods));
+      expect(request.autoRetry.forStatusCodes,
+          equals(client.autoRetry.forStatusCodes));
+      expect(
+          request.autoRetry.forTimeouts, equals(client.autoRetry.forTimeouts));
+      expect(request.autoRetry.maxRetries, equals(client.autoRetry.maxRetries));
+      expect(request.autoRetry.test, equals(client.autoRetry.test));
+    }
+  });
+
+  test('addInterceptor() single interceptor (request only)', () async {
+    client.addInterceptor(new ReqInt());
+    for (BaseRequest request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      MockTransports.http
+          .expect('GET', uri, headers: {'x-intercepted': 'true'});
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      await request.get(uri: uri);
+    }
+  });
+
+  test('addInterceptor() single interceptor (response only)', () async {
+    client.addInterceptor(new RespInt());
+    for (BaseRequest request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      MockTransports.http.expect('GET', uri);
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      Response response = await request.get(uri: uri);
+      expect(response.headers, containsPair('x-intercepted', 'true'));
+    }
+  });
+
+  test('addInterceptor() single interceptor', () async {
+    client.addInterceptor(new ReqRespInt());
+    for (BaseRequest request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      MockTransports.http
+          .expect('GET', uri, headers: {'x-intercepted': 'true'});
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      Response response = await request.get(uri: uri);
+      expect(response.headers, containsPair('x-intercepted', 'true'));
+    }
+  });
+
+  test('addInterceptor() multiple interceptors', () async {
+    client..addInterceptor(new ReqRespInt())..addInterceptor(new AsyncInt());
+    for (BaseRequest request in createAllRequestTypes(client)) {
+      Uri uri = Uri.parse('/test');
+      Uri augmentedUri =
+          uri.replace(queryParameters: {'interceptor': 'asyncint'});
+      MockTransports.http
+          .expect('GET', augmentedUri, headers: {'x-intercepted': 'true'});
+      if (request is MultipartRequest) {
+        request.fields['f'] = 'v';
+      }
+      Response response = await request.get(uri: uri);
+      expect(response.headers, containsPair('x-intercepted', 'true'));
+      expect(response.headers, containsPair('x-interceptor', 'asyncint'));
+    }
+  });
+
+  test('close()', () async {
+    Future future = client.newRequest().get(uri: Uri.parse('/test'));
+    client.close();
+    expect(future, throws);
   });
 }

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -77,7 +77,7 @@ void main() {
         await new Future.delayed(new Duration(seconds: 10));
       }, method: 'GET');
 
-      Client client = new Client();
+      var client = new HttpClient();
       var clientReqs = [
         client.newFormRequest(),
         client.newJsonRequest(),


### PR DESCRIPTION
_Fixes #140._

## Problem
A `Client` class was recently added to the `dart:html` library, which conflicts with the `Client` class in `w_transport`. This can be worked around, but is annoying.

## Solution
Deprecate `Client` and add a new `HttpClient` class to replace it. They are identical in functionality. All public APIs still use the deprecated `Client` class to maintain backwards compatibility. `Client` and all references will be removed completely in 4.0.0.

## Changes
- Deprecate `Client`
- Add `HttpClient`

## Documentation
Docs/changelog will be updated in my docs overhaul WIP branch.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 