### PR TITLE
CP-2615 Prevent StateError when a request times out right after it is canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.9.3](https://github.com/Workvia/w_transport/compare/2.9.2...2.9.3)
+_September 8, 2016_
+
+- **Bug Fix:** if a request is canceled right before it would also have exceeded
+  the timeout threshold, a `StateError` may be thrown due to a `Completer` being
+  completed more than once. This is fixed now.
+
 ## [2.9.2](https://github.com/Workvia/w_transport/compare/2.9.1...2.9.2)
 _August 11, 2016_
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -522,7 +522,9 @@ abstract class CommonRequest extends Object
   }
 
   void _timeoutRequest() {
-    abortRequest();
+    if (!isCanceled) {
+      abortRequest();
+    }
     isTimedOut = true;
     _timeoutError = new TimeoutException(
         'Request took too long to complete.', timeoutThreshold);

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -558,6 +558,19 @@ void _runCommonRequestSuiteFor(
       })));
     });
 
+    test(
+        'timeoutThreshold cancels the request if exceeded but not if it has already been canceled',
+        () async {
+      BaseRequest request = requestFactory()
+        ..timeoutThreshold = new Duration(milliseconds: 500);
+      var future = request.get(uri: requestUri);
+      await new Future.delayed(new Duration(milliseconds: 250));
+      request.abort();
+      expect(future, throwsA(predicate((error) {
+        return error is RequestException && error.error is! TimeoutException;
+      })));
+    });
+
     test('configure() should throw if called after request has been sent',
         () async {
       MockTransports.http.expect('GET', requestUri);


### PR DESCRIPTION
## Issue
If a request exceeds the timeout threshold right after it was canceled, the timeout logic will also attempt to cancel the request, resulting in a `Completer` being completed more than once, which throws a `StateError`.

## Solution
- Add a check to see if the request has already been canceled in the timeout handler prior to calling `abortRequest()`.
- Add a test to exercise this scenario.

## Testing
- [ ] Checkout 52b8e74 and verify that the new tests fail
- [ ] Checkout 4d850cc and verify that all tests pass (as well as `format` and `analyze`)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf