### PR TITLE
CP-2426 Release w_transport 2.9.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.2
+version: 2.9.3
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2615 Prevent StateError when a request times out right after it is canceled](https://github.com/Workiva/w_transport/pull/215)


Requested by: charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.2...version-bump-w_transport-2-9-3
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.2...2.9.3