### PR TITLE
CP-2657 Standardize variable declarations

### DIFF
--- a/example/common/global_example_menu_component.dart
+++ b/example/common/global_example_menu_component.dart
@@ -18,24 +18,22 @@ import 'dart:html';
 import 'package:react/react.dart' as react;
 import 'package:w_transport/w_transport.dart';
 
-const int _pollingInterval = 10; // 10 seconds
-
 void renderGlobalExampleMenu({bool nav: true, bool serverStatus: false}) {
   // Insert a container div within which we will mount the global example menu.
-  var container = document.createElement('div');
+  final container = document.createElement('div');
   container.id = 'global-example-menu';
   document.body.insertBefore(container, document.body.firstChild);
 
   // Use react to render the menu.
-  var menu =
+  final menu =
       globalExampleMenuComponent({'nav': nav, 'serverStatus': serverStatus});
   react.render(menu, container);
 }
 
 Future<bool> _ping(Uri uri) async {
   try {
-    Response response = await Http.get(uri);
-    return response.status == 200;
+    await Http.get(uri);
+    return true;
   } on RequestException {
     return false;
   }
@@ -63,12 +61,12 @@ class GlobalExampleMenuComponent extends react.Component {
   @override
   void componentWillMount() {
     if (this.props['serverStatus']) {
-      _pingServer().then((bool status) {
+      _pingServer().then((status) {
         this.setState({'serverOnline': status});
       });
       serverPolling =
           new Timer.periodic(new Duration(seconds: 4), (Timer timer) async {
-        bool status = await _pingServer();
+        final status = await _pingServer();
         this.setState({'serverOnline': status});
       });
     }
@@ -99,19 +97,19 @@ class GlobalExampleMenuComponent extends react.Component {
 
   @override
   dynamic render() {
-    var nav;
+    dynamic nav;
     if (this.props['nav']) {
       nav = react.a({'href': '/'}, '\u2190 All Examples');
     }
 
-    var serverStatus;
+    dynamic serverStatus;
     if (this.props['serverStatus']) {
       serverStatus =
           _buildServerStatusComponent('Server', this.state['serverOnline']);
     }
 
-    var serverTip;
-    bool serverTipNeeded =
+    dynamic serverTip;
+    final serverTipNeeded =
         this.props['serverStatus'] && !this.state['serverOnline'];
     if (serverTipNeeded) {
       serverTip = react.div({

--- a/example/http/cross_origin_credentials/dom.dart
+++ b/example/http/cross_origin_credentials/dom.dart
@@ -20,8 +20,9 @@ import 'status.dart' as status;
 
 /// Update the authentication status in the DOM.
 void updateAuthenticationStatus() {
-  Element containerElement = querySelector('.status-container');
-  Element statusElement = querySelector('.status');
+  final Element containerElement = querySelector('.status-container');
+  final Element statusElement = querySelector('.status');
+
   if (status.authenticated) {
     containerElement.className = containerElement.className
         .replaceFirst('unauthenticated', 'authenticated');
@@ -35,7 +36,7 @@ void updateAuthenticationStatus() {
 
 /// Toggle between "Login"/"Logout" button.
 void updateToggleAuthButton() {
-  ButtonElement toggleAuthButton = querySelector('#toggle-auth');
+  final ButtonElement toggleAuthButton = querySelector('#toggle-auth');
   if (status.authenticated) {
     toggleAuthButton.text = 'Logout';
   } else {
@@ -45,14 +46,13 @@ void updateToggleAuthButton() {
 
 /// Display a message in the DOM.
 void display(String message, bool isSuccessful) {
-  String className = isSuccessful ? 'success' : 'warning';
-
-  var elem = querySelector('#response');
+  final className = isSuccessful ? 'success' : 'warning';
+  final Element elem = querySelector('#response');
   elem.innerHtml = '<p class="$className">$message</p>\n' + elem.innerHtml;
 }
 
 /// Setup bindings for the controls.
-Future setupControlBindings() async {
+Future<Null> setupControlBindings() async {
   // Handle login/logout
   querySelector('#toggle-auth').onClick.listen((_) async {
     if (!status.authenticated) {
@@ -87,7 +87,7 @@ Future setupControlBindings() async {
   // Send a request with credentials (will succeed if authenticated)
   querySelector('#make-credentialed-request').onClick.listen((_) async {
     try {
-      String response = await service.makeCredentialedRequest();
+      final response = await service.makeCredentialedRequest();
       display(response, true);
     } catch (e) {
       display(e.toString(), false);
@@ -97,7 +97,7 @@ Future setupControlBindings() async {
   // Send a request without credentials (will always fail)
   querySelector('#make-uncredentialed-request').onClick.listen((_) async {
     try {
-      String response = await service.makeUncredentialedRequest();
+      final response = await service.makeUncredentialedRequest();
       display(response, true);
     } catch (e) {
       display(e.toString(), false);

--- a/example/http/cross_origin_credentials/service.dart
+++ b/example/http/cross_origin_credentials/service.dart
@@ -17,19 +17,20 @@ import 'dart:async';
 import 'package:w_transport/w_transport.dart';
 
 /// URLs for this cross origin credentials example.
-Uri authenticationServerUrl = Uri.parse('http://localhost:8024');
-String pathPrefix = '/example/http/cross_origin_credentials';
-Uri sessionUrl = authenticationServerUrl.replace(path: '$pathPrefix/session');
-Uri credentialedEndpointUrl =
-    authenticationServerUrl.replace(path: '$pathPrefix/credentialed');
+final _authenticationServerUrl = Uri.parse('http://localhost:8024');
+final _pathPrefix = '/example/http/cross_origin_credentials';
+final _sessionUrl =
+    _authenticationServerUrl.replace(path: '$_pathPrefix/session');
+final _credentialedEndpointUrl =
+    _authenticationServerUrl.replace(path: '$_pathPrefix/credentialed');
 
 /// Send a request to the /session endpoint to check authentication status.
 /// Returns true if authenticated, false otherwise.
 Future<bool> checkStatus() async {
-  Request req = new Request()..withCredentials = true;
+  final req = new Request()..withCredentials = true;
 
   try {
-    Response response = await req.get(uri: sessionUrl);
+    final response = await req.get(uri: _sessionUrl);
     return response.body.asJson()['authenticated'];
   } catch (error) {
     // Server probably isn't running
@@ -39,10 +40,10 @@ Future<bool> checkStatus() async {
 
 /// Login by sending a POST request to the /session endpoint.
 Future<bool> login() async {
-  Request req = new Request()..withCredentials = true;
+  final req = new Request()..withCredentials = true;
   Response response;
   try {
-    response = await req.post(uri: sessionUrl);
+    response = await req.post(uri: _sessionUrl);
   } catch (e) {
     return false;
   }
@@ -51,10 +52,10 @@ Future<bool> login() async {
 
 /// Logout by sending a request to the /logout endpoint.
 Future<bool> logout() async {
-  Request req = new Request()..withCredentials = true;
+  final req = new Request()..withCredentials = true;
   Response response;
   try {
-    response = await req.delete(uri: sessionUrl);
+    response = await req.delete(uri: _sessionUrl);
   } catch (e) {
     return false;
   }
@@ -66,10 +67,8 @@ Future<bool> logout() async {
 /// means the session HTTP cookie (if set) will be included.
 /// Thus, if authenticated, this request should succeed.
 Future<String> makeCredentialedRequest() async {
-  Request req = new Request()..withCredentials = true;
-
-  Response response;
-  response = await req.get(uri: credentialedEndpointUrl);
+  final req = new Request()..withCredentials = true;
+  final response = await req.get(uri: _credentialedEndpointUrl);
   return response.body.asString();
 }
 
@@ -78,6 +77,6 @@ Future<String> makeCredentialedRequest() async {
 /// This request should fail regardless of authentication.
 Future<String> makeUncredentialedRequest() async {
   // withCredentials is unset by default, so no need to do anything special here
-  Response response = await Http.get(credentialedEndpointUrl);
+  final response = await Http.get(_credentialedEndpointUrl);
   return response.body.asString();
 }

--- a/example/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/http/cross_origin_file_transfer/components/download_page.dart
@@ -21,9 +21,9 @@ import '../services/file_transfer.dart';
 import '../services/remote_files.dart';
 import 'file_transfer_list_component.dart';
 
-final num _gb = math.pow(2, 30);
-final num _mb = math.pow(2, 20);
-final num _kb = math.pow(2, 10);
+final _gb = math.pow(2, 30);
+final _mb = math.pow(2, 20);
+final _kb = math.pow(2, 10);
 
 dynamic downloadPage = react.registerComponent(() => new DownloadPage());
 
@@ -89,7 +89,7 @@ class DownloadPage extends react.Component {
   }
 
   void _downloadFile(RemoteFileDescription rfd) {
-    List downloads = new List.from(this.state['downloads']);
+    final downloads = new List<Download>.from(this.state['downloads']);
     downloads.add(Download.start(rfd));
     this.setState({'downloads': downloads});
   }
@@ -123,7 +123,7 @@ class DownloadPage extends react.Component {
   /// and no longer needs to display it, meaning we can remove it
   /// from memory.
   void _removeDownload(Download download) {
-    List<Download> downloads = [];
+    final downloads = <Download>[];
     downloads.addAll(currentDownloads);
     downloads.remove(download);
     this.setState({'downloads': downloads});
@@ -131,13 +131,13 @@ class DownloadPage extends react.Component {
 
   @override
   dynamic render() {
-    var error = '';
+    dynamic error = '';
     if (this.state['error'] != null) {
       error = react.p({'className': 'error'},
           'Could not retrieve the remote file list from the server.');
     }
 
-    var fileDescriptions = [];
+    final fileDescriptions = <dynamic>[];
     this.state['fileDescriptions'].forEach((RemoteFileDescription rfd) {
       fileDescriptions.add(react.a({
         'className': 'file',

--- a/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -127,8 +127,8 @@ class DropZoneComponent extends react.Component {
       dropTargetClass += ' over';
     }
 
-    var dropZoneProps = {'className': dropZoneClass};
-    var dropTargetProps = {
+    final dropZoneProps = <String, String>{'className': dropZoneClass};
+    final dropTargetProps = <String, Object>{
       'className': dropTargetClass,
       'onDragOver': enlargeDropTarget,
       'onDragLeave': shrinkDropTarget,

--- a/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
+++ b/example/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
@@ -77,7 +77,7 @@ class FileTransferListItemComponent extends react.Component {
     _fadeTransferOut().then((_) => _removeTransfer());
   }
 
-  Future _fadeTransferOut() async {
+  Future<Null> _fadeTransferOut() async {
     // wait a few seconds before beginning to fade the item out
     await new Future.delayed(
         new Duration(seconds: _transferCompleteLingerDuration));
@@ -104,7 +104,7 @@ class FileTransferListItemComponent extends react.Component {
       transferClass += ' hide';
     }
 
-    var label = [transfer.name];
+    final label = <dynamic>[transfer.name];
     if (!this.state['done']) {
       label.addAll([
         ' (',

--- a/example/http/cross_origin_file_transfer/components/upload_page.dart
+++ b/example/http/cross_origin_file_transfer/components/upload_page.dart
@@ -44,7 +44,7 @@ class UploadPage extends react.Component {
 
   /// Listen for new file uploads and forward them to the file transfer list component.
   void _newUploads(List<Upload> newUploads) {
-    List<Upload> uploads = [];
+    final uploads = <Upload>[];
     uploads.addAll(currentUploads);
     uploads.addAll(newUploads);
     this.setState({'uploads': uploads});
@@ -54,7 +54,7 @@ class UploadPage extends react.Component {
   /// and no longer needs to display it, meaning we can remove it
   /// from memory.
   void _removeUpload(Upload upload) {
-    List<Upload> uploads = [];
+    final uploads = <Upload>[];
     uploads.addAll(currentUploads);
     uploads.remove(upload);
     this.setState({'uploads': uploads});

--- a/example/http/cross_origin_file_transfer/services/file_transfer.dart
+++ b/example/http/cross_origin_file_transfer/services/file_transfer.dart
@@ -24,12 +24,12 @@ import 'remote_files.dart';
 // Counter used to create unique upload IDs.
 int _transferNum = 0;
 
+// Current number of bytes in memory from concurrent file transfers.
+int _concurrentFileTransferSize = 0;
+
 // Maximum number of bytes from concurrent file transfers that can be
 // loaded into memory before potentially crashing the browser tab.
 final int _concurrentFileTransferSizeLimit = math.pow(2, 20) * 75; // 75 MB
-
-// Current number of bytes in memory from concurrent file transfers.
-int _concurrentFileTransferSize = 0;
 
 /// Encapsulates the file upload to or file download from the server.
 class FileTransfer {
@@ -39,7 +39,7 @@ class FileTransfer {
   FileTransfer(this.name)
       : id = 'fileTransfer${_transferNum++}',
         _canceled = false,
-        _doneCompleter = new Completer(),
+        _doneCompleter = new Completer<Null>(),
         _percentComplete = 0.0;
 
   /// Unique file transfer identifier.
@@ -57,8 +57,8 @@ class FileTransfer {
   double _percentComplete;
 
   /// Whether or not the request has finished.
-  Future get done => _doneCompleter.future;
-  Completer _doneCompleter;
+  Future<Null> get done => _doneCompleter.future;
+  Completer<Null> _doneCompleter;
 
   /// Cancel the request (will do nothing if the request has already finished).
   void cancel(String reason) {

--- a/example/http/cross_origin_file_transfer/services/proxy.dart
+++ b/example/http/cross_origin_file_transfer/services/proxy.dart
@@ -20,7 +20,7 @@ void toggleProxy({bool enabled: false}) {
 }
 
 String getServerUrl() {
-  String base =
+  final base =
       proxyEnabled ? 'http://localhost:8024/proxy' : 'http://localhost:8024';
   return '$base/example/http/cross_origin_file_transfer';
 }

--- a/example/http/cross_origin_file_transfer/services/remote_files.dart
+++ b/example/http/cross_origin_file_transfer/services/remote_files.dart
@@ -32,7 +32,7 @@ class RemoteFiles {
   /// via HTTP polling.
   RemoteFiles._() {
     _connected = true;
-    _errorStreamController = new StreamController();
+    _errorStreamController = new StreamController<RequestException>();
     _errorStream = _errorStreamController.stream.asBroadcastStream();
     _fileStreamController = new StreamController<List<RemoteFileDescription>>();
     _fileStream = _fileStreamController.stream.asBroadcastStream();
@@ -72,10 +72,10 @@ class RemoteFiles {
   }
 
   /// Send the HTTP polling request.
-  Future _poll() async {
+  Future<Null> _poll() async {
     if (!_connected) return;
     try {
-      Response response = await Http.get(getFilesEndpointUrl());
+      final response = await Http.get(getFilesEndpointUrl());
 
       // Parse the file list from the response
       List results = response.body.asJson()['results'];

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -30,8 +30,8 @@ Future<Null> handleFileClick(MouseEvent event) async {
   event.preventDefault();
 
   // Grab file path from anchor element
-  AnchorElement anchor = event.target;
-  String filePath = anchor.href;
+  final AnchorElement anchor = event.target;
+  final filePath = anchor.href;
 
   // Send GET request instead
   try {
@@ -43,7 +43,7 @@ Future<Null> handleFileClick(MouseEvent event) async {
 
 /// Requests the contents of a file using WRequest.
 Future<String> requestFile(String filePath) async {
-  Response response = await Http.get(Uri.parse(filePath));
+  final response = await Http.get(Uri.parse(filePath));
   return response.body.asString();
 }
 

--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -23,21 +23,21 @@ import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 import '../../common/global_example_menu_component.dart';
 import '../../common/loading_component.dart';
 
-final Uri wsServer = Uri.parse('ws://localhost:8024/example/ws/echo');
-final Uri sockJSServer = Uri.parse('ws://localhost:8026/example/ws/echo');
+final _wsServer = Uri.parse('ws://localhost:8024/example/ws/echo');
+final _sockJSServer = Uri.parse('ws://localhost:8026/example/ws/echo');
 
 String _echo(String message) =>
     JSON.encode({'action': 'echo', 'message': message});
 String _unecho(String response) => JSON.decode(response)['message'];
 
-ButtonElement connect = querySelector('#connect');
-FormElement form = querySelector('#prompt-form');
-TextInputElement prompt = querySelector('#prompt');
-PreElement logs = querySelector('#logs');
-NumberInputElement sockJSTimeout = querySelector('#sockjs-timeout');
-CheckboxInputElement sockJSWebSocket = querySelector('#sockjs-ws');
-CheckboxInputElement sockJSXhr = querySelector('#sockjs-xhr');
-CheckboxInputElement useSockJS = querySelector('#sockjs');
+ButtonElement _connect = querySelector('#connect');
+FormElement _form = querySelector('#prompt-form');
+TextInputElement _prompt = querySelector('#prompt');
+PreElement _logs = querySelector('#logs');
+NumberInputElement _sockJSTimeout = querySelector('#sockjs-timeout');
+CheckboxInputElement _sockJSWebSocket = querySelector('#sockjs-ws');
+CheckboxInputElement _sockJSXhr = querySelector('#sockjs-xhr');
+CheckboxInputElement _useSockJS = querySelector('#sockjs');
 
 Future<Null> main() async {
   react_client.setClientConfiguration();
@@ -48,21 +48,21 @@ Future<Null> main() async {
   WSocket webSocket;
 
   // Connect (or reconnect) when the connect button is clicked.
-  connect.onClick.listen((e) async {
-    logs.appendText('Connecting...\n');
+  _connect.onClick.listen((e) async {
+    _logs.appendText('Connecting...\n');
 
-    bool sockjs = useSockJS.checked;
-    Duration timeout = sockJSTimeout.value.isEmpty
+    final sockjs = _useSockJS.checked;
+    final timeout = _sockJSTimeout.value.isEmpty
         ? null
-        : new Duration(milliseconds: sockJSTimeout.valueAsNumber);
-    var protocols = <String>[];
-    if (sockJSWebSocket.checked) {
+        : new Duration(milliseconds: _sockJSTimeout.valueAsNumber);
+    final protocols = <String>[];
+    if (_sockJSWebSocket.checked) {
       protocols.add('websocket');
     }
-    if (sockJSXhr.checked) {
+    if (_sockJSXhr.checked) {
       protocols.add('xhr-streaming');
     }
-    Uri uri = sockjs ? sockJSServer : wsServer;
+    final uri = sockjs ? _sockJSServer : _wsServer;
 
     try {
       webSocket = await WSocket.connect(uri,
@@ -72,25 +72,25 @@ Future<Null> main() async {
 
       // Display messages from web socket
       webSocket.listen((message) {
-        logs.appendText('${_unecho(message)}\n');
+        _logs.appendText('${_unecho(message)}\n');
       });
 
-      logs.appendText('Connected.\n');
+      _logs.appendText('Connected.\n');
     } on WebSocketException catch (e, stackTrace) {
-      logs.appendText(
-          '> ERROR: Could not connect to web socket on $wsServer\n');
+      _logs.appendText(
+          '> ERROR: Could not connect to web socket on $_wsServer\n');
       print('Could not connect to web socket.\n$e\n$stackTrace');
     }
   });
 
   // Send message upon form submit.
-  form.onSubmit.listen((e) {
+  _form.onSubmit.listen((e) {
     e.preventDefault();
 
     if (webSocket == null) return;
 
-    String message = prompt.value;
-    logs.appendText('> $message\n');
+    final message = _prompt.value;
+    _logs.appendText('> $message\n');
     webSocket.add(_echo(message));
   });
 

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -149,7 +149,7 @@ class RequestAutoRetry extends AutoRetryConfig {
   /// field/value pairs. If the request contains files (byte streams or blobs),
   /// it cannot be retried because they cannot be read more than once.
   bool get supported {
-    var request = _request;
+    final request = _request;
     if (request is StreamedRequest) return false;
     if (request is MultipartRequest && request.files.isNotEmpty) return false;
     return true;

--- a/lib/src/http/browser/http_client.dart
+++ b/lib/src/http/browser/http_client.dart
@@ -28,7 +28,7 @@ class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new BrowserFormRequest.fromClient(this);
+    final request = new BrowserFormRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -38,7 +38,7 @@ class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new BrowserJsonRequest.fromClient(this);
+    final request = new BrowserJsonRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -48,7 +48,7 @@ class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new BrowserMultipartRequest.fromClient(this);
+    final request = new BrowserMultipartRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -58,7 +58,7 @@ class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new BrowserPlainTextRequest.fromClient(this);
+    final request = new BrowserPlainTextRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -68,7 +68,7 @@ class BrowserHttpClient extends CommonHttpClient implements HttpClient {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new BrowserStreamedRequest.fromClient(this);
+    final request = new BrowserStreamedRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -58,29 +58,29 @@ class BrowserMultipartRequest extends CommonRequest
 
   @override
   Map<String, String> get fields =>
-      isSent ? new Map.unmodifiable(_fields) : _fields;
+      isSent ? new Map<String, String>.unmodifiable(_fields) : _fields;
 
   @override
   set fields(Map<String, String> fields) {
     verifyUnsent();
-    _fields = new Map.from(fields);
+    _fields = new Map<String, String>.from(fields);
   }
 
   @override
   Map<String, dynamic> get files {
-    if (isSent) return new Map.unmodifiable(_files);
+    if (isSent) return new Map<String, Blob>.unmodifiable(_files);
     return _files;
   }
 
   @override
   set files(Map<String, dynamic> files) {
     verifyUnsent();
-    _files = new Map.from(files);
+    _files = new Map<String, Blob>.from(files);
   }
 
   @override
   MultipartRequest clone() {
-    MultipartRequest requestClone = super.clone();
+    final MultipartRequest requestClone = super.clone();
     return requestClone
       ..fields = fields
       ..files = files;
@@ -88,12 +88,13 @@ class BrowserMultipartRequest extends CommonRequest
 
   @override
   Map<String, String> finalizeHeaders() {
-    var headers = new CaseInsensitiveMap.from(super.finalizeHeaders());
+    final headers =
+        new CaseInsensitiveMap<String>.from(super.finalizeHeaders());
 
     // Remove the content-type header to allow the browser to set it.
     headers.remove('content-type');
 
-    return new Map.unmodifiable(headers);
+    return new Map<String, String>.unmodifiable(headers);
   }
 
   @override
@@ -103,23 +104,23 @@ class BrowserMultipartRequest extends CommonRequest
           'The body of a Multipart request must be set via `fields` and/or `files`.');
     }
 
-    FormData formData = new FormData();
+    final formData = new FormData();
 
     // Add each text field.
     fields.forEach((name, value) {
       if (http_utils.isAsciiOnly(value)) {
         formData.append(name, value);
       } else {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': UTF8.name});
-        Blob blob = new Blob([UTF8.encode(value)], contentType.toString());
+        final blob = new Blob([UTF8.encode(value)], contentType.toString());
         formData.appendBlob(name, blob);
       }
     });
     fields.forEach(formData.append);
 
     // Add each blob/file.
-    List<Future> additions = [];
+    final additions = <Future>[];
     files.forEach((name, value) {
       additions.add(() async {
         if (value is File) {
@@ -127,9 +128,9 @@ class BrowserMultipartRequest extends CommonRequest
         } else if (value is Blob) {
           formData.appendBlob(name, value);
         } else if (value is MultipartFile) {
-          String contentType =
+          final contentType =
               value.contentType != null ? value.contentType.toString() : null;
-          Blob blob = new Blob(await value.byteStream.toList(), contentType);
+          final blob = new Blob(await value.byteStream.toList(), contentType);
           formData.appendBlob(name, blob, value.filename);
         }
       }());

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -35,7 +35,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
   }
 
   @override
-  Future openRequest([_]) async {
+  Future<Null> openRequest([_]) async {
     _request = new HttpRequest();
     _request.open(method, uri.toString());
   }
@@ -44,17 +44,17 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
   Future<BaseResponse> sendRequestAndFetchResponse(
       FinalizedRequest finalizedRequest,
       {bool streamResponse: false}) async {
-    Completer<BaseResponse> c = new Completer();
+    final c = new Completer<BaseResponse>();
 
     // Add request headers.
     if (finalizedRequest.headers != null) {
       // The browser forbids setting these two headers:
       // - connection
       // - content-length
-      Map headersToAdd = new Map.from(finalizedRequest.headers);
+      final headersToAdd =
+          new Map<String, String>.from(finalizedRequest.headers);
       headersToAdd.remove('connection');
       headersToAdd.remove('content-length');
-
       headersToAdd.forEach(_request.setRequestHeader);
     }
 
@@ -80,10 +80,9 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
         c.complete(_createResponse(streamResponse: streamResponse));
       }
     });
-    Future onError(Object error) async {
+    Future<Null> onError(Object error) async {
       if (!c.isCompleted) {
-        BaseResponse response =
-            await _createResponse(streamResponse: streamResponse);
+        final response = await _createResponse(streamResponse: streamResponse);
         error = new RequestException(method, uri, this, response, error);
         c.completeError(error, StackTrace.current);
       }
@@ -127,8 +126,8 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
 
     BaseResponse response;
     if (streamResponse) {
-      var result = new Completer<List<int>>();
-      FileReader reader = new FileReader();
+      final result = new Completer<List<int>>();
+      final reader = new FileReader();
       // ignore: unawaited_futures
       reader.onLoad.first.then((_) {
         result.complete(reader.result);
@@ -137,8 +136,8 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
       reader.onError.first.then(result.completeError);
       reader.readAsArrayBuffer(
           _request.response != null ? _request.response : new Blob([]));
-      List<int> bytes = await result.future;
-      var byteStream = new Stream.fromIterable([bytes]);
+      final bytes = await result.future;
+      final byteStream = new Stream.fromIterable([bytes]);
       response = new StreamedResponse.fromByteStream(_request.status,
           _request.statusText, _request.responseHeaders, byteStream);
     } else {

--- a/lib/src/http/common/backoff.dart
+++ b/lib/src/http/common/backoff.dart
@@ -25,7 +25,7 @@ class Backoff {
         min(autoRetry.backOff.maxInterval.inMilliseconds, backOffInMs);
 
     if (autoRetry.backOff.withJitter == true) {
-      Random random = new Random();
+      final random = new Random();
       backOffInMs = random.nextInt(backOffInMs);
     }
     return new Duration(milliseconds: backOffInMs);
@@ -35,7 +35,7 @@ class Backoff {
     Duration backOff;
 
     if (autoRetry.backOff.withJitter == true) {
-      Random random = new Random();
+      final random = new Random();
       backOff = new Duration(
           milliseconds: autoRetry.backOff.interval.inMilliseconds ~/ 2 +
               random

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -39,7 +39,7 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
 
   @override
   Map<String, dynamic> get fields =>
-      isSent ? new Map.unmodifiable(_fields) : _fields;
+      isSent ? new Map<String, dynamic>.unmodifiable(_fields) : _fields;
 
   @override
   set fields(Map<String, dynamic> fields) {
@@ -62,7 +62,7 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
 
   @override
   FormRequest clone() {
-    FormRequest requestClone = super.clone();
+    final FormRequest requestClone = super.clone();
     return requestClone..fields = fields;
   }
 

--- a/lib/src/http/common/http_client.dart
+++ b/lib/src/http/common/http_client.dart
@@ -64,7 +64,7 @@ abstract class CommonHttpClient implements HttpClient {
 
   @override
   set headers(Map<String, String> headers) {
-    _headers = new CaseInsensitiveMap.from(headers);
+    _headers = new CaseInsensitiveMap<String>.from(headers);
   }
 
   /// Whether or not this HTTP client has been closed.
@@ -83,7 +83,7 @@ abstract class CommonHttpClient implements HttpClient {
     if (isClosed) return;
     _isClosed = true;
     closeClient();
-    for (var request in _requests) {
+    for (final request in _requests) {
       request.abort(new Exception(
           'HTTP client was closed before this request could complete.'));
     }
@@ -121,7 +121,7 @@ abstract class CommonHttpClient implements HttpClient {
     }
     if (_responsePathway.hasInterceptors) {
       request.responseInterceptor = (request, response, [exception]) async {
-        var payload = new ResponsePayload(request, response, exception);
+        final payload = new ResponsePayload(request, response, exception);
         return (await _responsePathway.process(payload)).response;
       };
     }

--- a/lib/src/http/common/json_request.dart
+++ b/lib/src/http/common/json_request.dart
@@ -61,7 +61,7 @@ abstract class CommonJsonRequest extends CommonRequest implements JsonRequest {
 
   @override
   JsonRequest clone() {
-    JsonRequest requestClone = super.clone();
+    final JsonRequest requestClone = super.clone();
     return requestClone..body = _source;
   }
 

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -65,8 +65,8 @@ abstract class CommonMultipartRequest extends CommonRequest
       : super.fromClient(wTransportClient, client);
 
   static String _generateBoundaryString() {
-    String senderPrefix = 'dart-w-transport-boundary-';
-    var boundaryChars =
+    final senderPrefix = 'dart-w-transport-boundary-';
+    final boundaryChars =
         new List<int>.generate(_boundaryLength - senderPrefix.length, (_) {
       return _boundaryChars[_random.nextInt(_boundaryChars.length)];
     }, growable: false);
@@ -129,27 +129,27 @@ abstract class CommonMultipartRequest extends CommonRequest
 
   @override
   Map<String, String> get fields =>
-      isSent ? new Map.unmodifiable(_fields) : _fields;
+      isSent ? new Map<String, String>.unmodifiable(_fields) : _fields;
 
   @override
   set fields(Map<String, String> fields) {
     verifyUnsent();
-    _fields = new Map.from(fields);
+    _fields = new Map<String, String>.from(fields);
   }
 
   @override
   Map<String, dynamic> get files =>
-      isSent ? new Map.unmodifiable(_files) : _files;
+      isSent ? new Map<String, dynamic>.unmodifiable(_files) : _files;
 
   @override
   set files(Map<String, dynamic> files) {
     verifyUnsent();
-    _files = new Map.from(files);
+    _files = new Map<String, dynamic>.from(files);
   }
 
   @override
   MultipartRequest clone() {
-    MultipartRequest requestClone = super.clone();
+    final MultipartRequest requestClone = super.clone();
     return requestClone
       ..fields = fields
       ..files = files;
@@ -157,10 +157,10 @@ abstract class CommonMultipartRequest extends CommonRequest
 
   @override
   Map<String, String> finalizeHeaders() {
-    var headers = super.finalizeHeaders();
-    var finalizedHeaders = new Map.from(headers);
+    final headers = super.finalizeHeaders();
+    final finalizedHeaders = new Map<String, String>.from(headers);
     finalizedHeaders['content-transfer-encoding'] = 'binary';
-    return new Map.unmodifiable(finalizedHeaders);
+    return new Map<String, String>.unmodifiable(finalizedHeaders);
   }
 
   @override
@@ -175,13 +175,13 @@ abstract class CommonMultipartRequest extends CommonRequest
           'The body of a Multipart request cannot be empty.');
     }
 
-    StreamController<List<int>> controller = new StreamController();
+    final controller = new StreamController<List<int>>();
     void write(String content) {
       controller.add(UTF8.encode(content));
     }
 
-    Future writeByteStream(Stream<List<int>> byteStream) {
-      var c = new Completer();
+    Future<Null> writeByteStream(Stream<List<int>> byteStream) {
+      final c = new Completer<Null>();
       byteStream.listen(controller.add,
           onError: controller.addError, onDone: c.complete);
       return c.future;
@@ -194,7 +194,7 @@ abstract class CommonMultipartRequest extends CommonRequest
       write(_crlf); // Ending newline.
     });
 
-    var fileList = [];
+    final fileList = <Map<String, dynamic>>[];
     files.forEach((name, file) {
       fileList.add({
         'headers': _multipartFileHeaders(name, file),
@@ -206,7 +206,7 @@ abstract class CommonMultipartRequest extends CommonRequest
     Future.forEach(fileList, (Map file) {
       // TODO: make this better
       Stream<List<int>> byteStream;
-      var bs = file['byteStream'];
+      final bs = file['byteStream'];
       if (bs is Stream<List<int>>) {
         byteStream = bs;
       } else {
@@ -245,7 +245,7 @@ abstract class CommonMultipartRequest extends CommonRequest
   }
 
   String _multipartFieldHeaders(String name, String value) {
-    var headers = [
+    final headers = <String>[
       'content-disposition: form-data; name="${_encodeName(name)}"'
     ];
     if (!http_utils.isAsciiOnly(value)) {
@@ -257,9 +257,9 @@ abstract class CommonMultipartRequest extends CommonRequest
   }
 
   String _multipartFileHeaders(String field, MultipartFile file) {
-    var headers = ['content-type: ${file.contentType}'];
+    final headers = <String>['content-type: ${file.contentType}'];
 
-    var disposition =
+    String disposition =
         'content-disposition: form-data; name="${_encodeName(field)}"';
     if (file.filename != null) {
       disposition = '$disposition; filename="${_encodeName(file.filename)}"';

--- a/lib/src/http/common/plain_text_request.dart
+++ b/lib/src/http/common/plain_text_request.dart
@@ -74,7 +74,7 @@ abstract class CommonPlainTextRequest extends CommonRequest implements Request {
 
   @override
   Request clone() {
-    Request requestClone = super.clone();
+    final Request requestClone = super.clone();
     if (_body != null) {
       requestClone.body = body;
     } else if (_bodyBytes != null) {

--- a/lib/src/http/finalized_request.dart
+++ b/lib/src/http/finalized_request.dart
@@ -37,6 +37,6 @@ class FinalizedRequest {
 
   FinalizedRequest(this.method, this.uri, Map<String, String> headers,
       this.body, this.withCredentials)
-      : this.headers =
-            new Map.unmodifiable(new CaseInsensitiveMap.from(headers));
+      : this.headers = new Map<String, String>.unmodifiable(
+            new CaseInsensitiveMap<String>.from(headers));
 }

--- a/lib/src/http/http.dart
+++ b/lib/src/http/http.dart
@@ -186,7 +186,7 @@ class Http {
 
   static Request _createRequest(Uri uri,
       {String body, Map<String, String> headers, bool withCredentials}) {
-    var request = new Request()..uri = uri;
+    final request = new Request()..uri = uri;
     if (body != null) {
       request.body = body;
     }

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -75,14 +75,14 @@ class Pathway<T> {
   }
 
   Future<T> process(T payload) async {
-    for (var interceptor in _interceptors) {
-      var result = interceptor(payload);
+    for (final interceptor in _interceptors) {
+      final result = interceptor(payload);
       if (result is Future<T>) {
         payload = await result;
       } else if (result is T) {
         payload = result;
       } else {
-        var msg = 'Interceptor returned a value of the incorrect type.\n'
+        final msg = 'Interceptor returned a value of the incorrect type.\n'
             '  Expected: ${T.runtimeType}\n'
             '  Actual:   ${result.runtimeType}';
         throw new Exception(msg);

--- a/lib/src/http/mock/base_request.dart
+++ b/lib/src/http/mock/base_request.dart
@@ -19,7 +19,7 @@ import 'package:w_transport/src/http/finalized_request.dart';
 import 'package:w_transport/src/http/response.dart';
 
 abstract class MockBaseRequest extends BaseRequest {
-  Future get onCanceled;
+  Future<Null> get onCanceled;
   Future<FinalizedRequest> get onSent;
   void complete({BaseResponse response});
   void completeError({Object error, BaseResponse response});

--- a/lib/src/http/mock/http_client.dart
+++ b/lib/src/http/mock/http_client.dart
@@ -27,7 +27,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new MockFormRequest.fromClient(this);
+    final request = new MockFormRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -37,7 +37,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new MockJsonRequest.fromClient(this);
+    final request = new MockJsonRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -47,7 +47,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request = new MockMultipartRequest.fromClient(this);
+    final request = new MockMultipartRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -57,7 +57,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new MockPlainTextRequest.fromClient(this);
+    final request = new MockPlainTextRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -67,7 +67,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request = new MockStreamedRequest.fromClient(this);
+    final request = new MockStreamedRequest.fromClient(this);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/mock/response.dart
+++ b/lib/src/http/mock/response.dart
@@ -30,11 +30,12 @@ class MockResponse implements Response {
       Map<String, String> headers,
       String statusText}) {
     // Ensure the headers are case insensitive.
-    headers = new CaseInsensitiveMap.from(headers != null ? headers : {});
+    headers =
+        new CaseInsensitiveMap<String>.from(headers != null ? headers : {});
 
     // If an encoding was given, update the content-type charset parameter.
     if (encoding != null) {
-      var contentType = http_utils.parseContentTypeFromHeaders(headers);
+      MediaType contentType = http_utils.parseContentTypeFromHeaders(headers);
       contentType = contentType.change(parameters: {'charset': encoding.name});
       headers['content-type'] = contentType.toString();
     }
@@ -150,11 +151,12 @@ class MockStreamedResponse implements StreamedResponse {
       Map<String, String> headers,
       String statusText}) {
     // Ensure the headers are case insensitive.
-    headers = new CaseInsensitiveMap.from(headers != null ? headers : {});
+    headers =
+        new CaseInsensitiveMap<String>.from(headers != null ? headers : {});
 
     // If an encoding was given, update the content-type charset parameter.
     if (encoding != null) {
-      var contentType = http_utils.parseContentTypeFromHeaders(headers);
+      MediaType contentType = http_utils.parseContentTypeFromHeaders(headers);
       contentType = contentType.change(parameters: {'charset': encoding.name});
       headers['content-type'] = contentType.toString();
     }

--- a/lib/src/http/multipart_file.dart
+++ b/lib/src/http/multipart_file.dart
@@ -38,7 +38,7 @@ class MultipartFile {
     if (contentType != null) {
       _contentType = contentType;
     } else {
-      var mimeType = filename != null ? mime.lookupMimeType(filename) : null;
+      String mimeType = filename != null ? mime.lookupMimeType(filename) : null;
       if (mimeType == null) {
         mimeType = 'application/octet-stream';
       }

--- a/lib/src/http/request_exception.dart
+++ b/lib/src/http/request_exception.dart
@@ -44,9 +44,9 @@ class RequestException implements Exception {
     String msg;
     if (request != null && request.autoRetry.numAttempts > 1) {
       msg = '$method $uri';
-      for (var i = 0; i < request.autoRetry.failures.length; i++) {
-        var failure = request.autoRetry.failures[i];
-        var attempt = '\n\tAttempt #${i+1}:';
+      for (int i = 0; i < request.autoRetry.failures.length; i++) {
+        final failure = request.autoRetry.failures[i];
+        String attempt = '\n\tAttempt #${i+1}:';
         if (failure.response != null) {
           attempt +=
               ' ${failure.response.status} ${failure.response.statusText}';

--- a/lib/src/http/response.dart
+++ b/lib/src/http/response.dart
@@ -35,7 +35,8 @@ abstract class BaseResponse {
   Map<String, String> _headers;
 
   BaseResponse(this.status, this.statusText, Map<String, String> headers) {
-    _headers = new Map.unmodifiable(new CaseInsensitiveMap.from(headers));
+    _headers = new Map<String, String>.unmodifiable(
+        new CaseInsensitiveMap<String>.from(headers));
     _encoding = http_utils.parseEncodingFromHeaders(_headers, fallback: LATIN1);
     _contentType = http_utils.parseContentTypeFromHeaders(_headers);
   }

--- a/lib/src/http/response_format_exception.dart
+++ b/lib/src/http/response_format_exception.dart
@@ -48,8 +48,8 @@ class ResponseFormatException implements Exception {
       bodyLine = 'Bytes: $bytes';
     }
 
-    var msg = description;
-    var encodingName = encoding != null ? encoding.name : 'null';
+    String msg = description;
+    final encodingName = encoding != null ? encoding.name : 'null';
     msg += '\n\tContent-Type: $contentType';
     msg += '\n\tEncoding: $encodingName';
     msg += '\n\t$bodyLine';

--- a/lib/src/http/utils.dart
+++ b/lib/src/http/utils.dart
@@ -21,7 +21,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:w_transport/src/http/request_progress.dart';
 
 /// RegExp that only matches strings containing only ASCII-compatible chars.
-final RegExp _asciiOnly = new RegExp(r"^[\x00-\x7F]+$");
+final RegExp _asciiOnly = new RegExp(r'^[\x00-\x7F]+$');
 
 /// Returns true if all characters in [value] are ASCII-compatible chars.
 /// Returns false otherwise.
@@ -31,19 +31,22 @@ bool isAsciiOnly(String value) => _asciiOnly.hasMatch(value);
 /// query string can be used as a URI query string or the body of a
 /// `application/x-www-form-urlencoded` request or response.
 String mapToQuery(Map<String, Object> map, {Encoding encoding}) {
-  List<String> params = [];
+  final params = <String>[];
   map.forEach((key, value) {
     // Support fields with multiple values.
-    var valueList = value is List ? value : [value];
-    for (var v in valueList) {
-      var encoded;
+    final valueList = value is List ? value : [value];
+    for (final v in valueList) {
+      Iterable<String> encoded;
       if (encoding != null) {
-        encoded = [
+        encoded = <String>[
           Uri.encodeQueryComponent(key, encoding: encoding),
           Uri.encodeQueryComponent(v, encoding: encoding)
         ];
       } else {
-        encoded = [Uri.encodeQueryComponent(key), Uri.encodeQueryComponent(v)];
+        encoded = <String>[
+          Uri.encodeQueryComponent(key),
+          Uri.encodeQueryComponent(v)
+        ];
       }
       params.add(encoded.join('='));
     }
@@ -58,7 +61,7 @@ String mapToQuery(Map<String, Object> map, {Encoding encoding}) {
 /// http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1).
 MediaType parseContentTypeFromHeaders(Map<String, String> headers) {
   // Ensure the headers are case-insensitive.
-  headers = new CaseInsensitiveMap.from(headers);
+  headers = new CaseInsensitiveMap<String>.from(headers);
   if (headers['content-type'] != null)
     return new MediaType.parse(headers['content-type']);
   return new MediaType('application', 'octet-stream');
@@ -74,7 +77,7 @@ Encoding parseEncodingFromContentType(MediaType contentType,
     {Encoding fallback}) {
   if (contentType == null) return fallback;
   if (contentType.parameters['charset'] == null) return fallback;
-  var encoding = Encoding.getByName(contentType.parameters['charset']);
+  final encoding = Encoding.getByName(contentType.parameters['charset']);
   return encoding != null ? encoding : fallback;
 }
 
@@ -87,9 +90,11 @@ Encoding parseEncodingFromContentType(MediaType contentType,
 /// [FormatException] will be thrown.
 Encoding parseEncodingFromContentTypeOrFail(MediaType contentType,
     {Encoding fallback}) {
-  var encoding = parseEncodingFromContentType(contentType, fallback: fallback);
+  final encoding =
+      parseEncodingFromContentType(contentType, fallback: fallback);
   if (encoding != null) return encoding;
-  var charset = contentType != null ? contentType.parameters['charset'] : null;
+  final charset =
+      contentType != null ? contentType.parameters['charset'] : null;
   throw new FormatException('Unsupported charset: $charset');
 }
 
@@ -102,19 +107,19 @@ Encoding parseEncodingFromContentTypeOrFail(MediaType contentType,
 /// will be returned.
 Encoding parseEncodingFromHeaders(Map<String, String> headers,
     {Encoding fallback}) {
-  MediaType contentType = parseContentTypeFromHeaders(headers);
+  final contentType = parseContentTypeFromHeaders(headers);
   return parseEncodingFromContentType(contentType, fallback: fallback);
 }
 
 /// Converts a query string to a [Map] of parameter names to values. Works for
 /// URI query string or an `application/x-www-form-urlencoded` body.
 Map<String, Object> queryToMap(String query, {Encoding encoding}) {
-  var fields = <String, Object>{};
-  for (var pair in query.split('&')) {
-    var pieces = pair.split('=');
+  final fields = <String, Object>{};
+  for (final pair in query.split('&')) {
+    final pieces = pair.split('=');
     if (pieces.isEmpty) continue;
-    var key = pieces.first;
-    var value = pieces.length > 1 ? pieces.sublist(1).join('') : '';
+    String key = pieces.first;
+    String value = pieces.length > 1 ? pieces.sublist(1).join('') : '';
     if (encoding != null) {
       key = Uri.decodeQueryComponent(key, encoding: encoding);
       value = Uri.decodeQueryComponent(value, encoding: encoding);
@@ -126,7 +131,7 @@ Map<String, Object> queryToMap(String query, {Encoding encoding}) {
       if (fields[key] is! List) {
         fields[key] = [fields[key]];
       }
-      List currentFields = fields[key];
+      final List currentFields = fields[key];
       currentFields.add(value);
     } else {
       fields[key] = value;
@@ -138,9 +143,8 @@ Map<String, Object> queryToMap(String query, {Encoding encoding}) {
 /// Reduces a byte stream to a single list of bytes.
 Future<Uint8List> reduceByteStream(Stream<List<int>> byteStream) async {
   try {
-    List<int> bytes = await byteStream.reduce((prev, next) {
-      var combined = new List<int>.from(prev)..addAll(next);
-      return combined;
+    final bytes = await byteStream.reduce((prev, next) {
+      return new List<int>.from(prev)..addAll(next);
     });
     return new Uint8List.fromList(bytes);
   } on StateError {
@@ -151,7 +155,7 @@ Future<Uint8List> reduceByteStream(Stream<List<int>> byteStream) async {
 
 class ByteStreamProgressListener {
   StreamController<RequestProgress> _progressController =
-      new StreamController();
+      new StreamController<RequestProgress>();
 
   Stream<List<int>> _transformed;
 
@@ -166,7 +170,7 @@ class ByteStreamProgressListener {
   Stream<List<int>> _listenTo(Stream<List<int>> byteStream, {int total}) {
     int loaded = 0;
 
-    var progressListener = new StreamTransformer<List<int>, List<int>>(
+    final progressListener = new StreamTransformer<List<int>, List<int>>(
         (Stream<List<int>> input, bool cancelOnError) {
       StreamController<List<int>> controller;
       StreamSubscription<List<int>> subscription;

--- a/lib/src/http/vm/http_client.dart
+++ b/lib/src/http/vm/http_client.dart
@@ -39,7 +39,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
-    FormRequest request = new VMFormRequest.fromClient(this, _ioHttpClient);
+    final request = new VMFormRequest.fromClient(this, _ioHttpClient);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -49,7 +49,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
-    JsonRequest request = new VMJsonRequest.fromClient(this, _ioHttpClient);
+    final request = new VMJsonRequest.fromClient(this, _ioHttpClient);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -59,8 +59,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
-    MultipartRequest request =
-        new VMMultipartRequest.fromClient(this, _ioHttpClient);
+    final request = new VMMultipartRequest.fromClient(this, _ioHttpClient);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -70,7 +69,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   @override
   Request newRequest() {
     verifyNotClosed();
-    Request request = new VMPlainTextRequest.fromClient(this, _ioHttpClient);
+    final request = new VMPlainTextRequest.fromClient(this, _ioHttpClient);
     registerAndDecorateRequest(request);
     return request;
   }
@@ -80,8 +79,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
-    StreamedRequest request =
-        new VMStreamedRequest.fromClient(this, _ioHttpClient);
+    final request = new VMStreamedRequest.fromClient(this, _ioHttpClient);
     registerAndDecorateRequest(request);
     return request;
   }

--- a/lib/src/http/vm/request_mixin.dart
+++ b/lib/src/http/vm/request_mixin.dart
@@ -49,8 +49,8 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
   }
 
   @override
-  Future openRequest([Object client]) async {
-    HttpClient httpClient = client;
+  Future<Null> openRequest([Object client]) async {
+    final HttpClient httpClient = client;
     if (httpClient != null) {
       _client = httpClient;
       _isSingle = false;
@@ -89,10 +89,10 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
     }
 
     if (finalizedRequest.body is StreamedHttpBody) {
-      StreamedHttpBody body = finalizedRequest.body;
+      final StreamedHttpBody body = finalizedRequest.body;
       // Use a byte stream progress listener to transform the request body such
       // that it produces a stream of progress events.
-      var progressListener = new http_utils.ByteStreamProgressListener(
+      final progressListener = new http_utils.ByteStreamProgressListener(
           body.byteStream,
           total: finalizedRequest.body.contentLength);
 
@@ -102,7 +102,7 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
       // Map the progress stream back to this request's upload progress.
       progressListener.progressStream.listen(uploadProgressController.add);
     } else {
-      HttpBody body = finalizedRequest.body;
+      final HttpBody body = finalizedRequest.body;
       // The entire request body is available immediately as bytes.
       _request.add(body.asBytes());
 
@@ -119,26 +119,25 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
     }
 
     // Close the request now that data has been sent and wait for the response.
-    HttpClientResponse response = await _request.close();
+    final response = await _request.close();
 
     // Use a byte stream progress listener to transform the response stream such
     // that it produces a stream of progress events.
-    var progressListener = new http_utils.ByteStreamProgressListener(response,
+    final progressListener = new http_utils.ByteStreamProgressListener(response,
         total: response.contentLength);
 
     // Response body now resides in this transformed byte stream.
-    Stream<List<int>> byteStream = progressListener.byteStream;
+    final byteStream = progressListener.byteStream;
 
     // Map the progress stream back to this request's download progress.
     progressListener.progressStream.listen(downloadProgressController.add);
 
     // Parse the response headers into a platform-independent format.
-    Map<String, String> responseHeaders =
-        vm_utils.parseServerHeaders(response.headers);
+    final responseHeaders = vm_utils.parseServerHeaders(response.headers);
 
     // By default, responses in the VM are streamed. If this is the desired
     // format, simply return it.
-    StreamedResponse streamedResponse = new StreamedResponse.fromByteStream(
+    final streamedResponse = new StreamedResponse.fromByteStream(
         response.statusCode,
         response.reasonPhrase,
         responseHeaders,

--- a/lib/src/http/vm/utils.dart
+++ b/lib/src/http/vm/utils.dart
@@ -17,7 +17,7 @@ import 'dart:io';
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
 
 CaseInsensitiveMap<String> parseServerHeaders(HttpHeaders httpHeaders) {
-  CaseInsensitiveMap<String> headers = new CaseInsensitiveMap();
+  final headers = new CaseInsensitiveMap<String>();
   httpHeaders.forEach((String name, List<String> values) {
     headers[name] = values.join(',');
   });

--- a/lib/src/mocks/http.dart
+++ b/lib/src/mocks/http.dart
@@ -33,13 +33,13 @@ class MockHttp {
 
   void causeFailureOnOpen(BaseRequest request) {
     MockHttpInternal._verifyRequestIsMock(request);
-    MockBaseRequest mockRequest = request;
+    final MockBaseRequest mockRequest = request;
     mockRequest.causeFailureOnOpen();
   }
 
   void completeRequest(BaseRequest request, {BaseResponse response}) {
     MockHttpInternal._verifyRequestIsMock(request);
-    MockBaseRequest mockRequest = request;
+    final MockBaseRequest mockRequest = request;
     mockRequest.complete(response: response);
     MockHttpInternal._pending.remove(request);
   }
@@ -62,7 +62,7 @@ class MockHttp {
 
   void failRequest(BaseRequest request, {Object error, BaseResponse response}) {
     MockHttpInternal._verifyRequestIsMock(request);
-    MockBaseRequest mockRequest = request;
+    final MockBaseRequest mockRequest = request;
     mockRequest.completeError(error: error, response: response);
     MockHttpInternal._pending.remove(request);
   }
@@ -78,14 +78,14 @@ class MockHttp {
     String errorMsg = '';
     if (MockHttpInternal._pending.isNotEmpty) {
       errorMsg += 'Unresolved mock requests:\n';
-      var requestLines =
+      final requestLines =
           MockHttpInternal._pending.map((e) => '\t${e.method} ${e.uri}');
       errorMsg += requestLines.join('\n');
       errorMsg += '\n';
     }
     if (MockHttpInternal._expectations.isNotEmpty) {
       errorMsg += 'Unsatisfied requests:\n';
-      var requestLines =
+      final requestLines =
           MockHttpInternal._expectations.map((e) => '\t${e.method} ${e.uri}');
       errorMsg += requestLines.join('\n');
       errorMsg += '\n';
@@ -99,14 +99,14 @@ class MockHttp {
     // used anywhere else. The consumer should just be expected to pass in an
     // exact match here. At the next breaking release, this method and related
     // ones should be cleaned up & clarified.
-    String uriKey = MockHttpInternal._getUriKey(uri);
+    final uriKey = MockHttpInternal._getUriKey(uri);
     if (!MockHttpInternal._requestHandlers.containsKey(uriKey)) {
       MockHttpInternal._requestHandlers[uriKey] = {};
     }
-    var methodKey = method == null ? '*' : method.toUpperCase();
+    final methodKey = method == null ? '*' : method.toUpperCase();
     MockHttpInternal._requestHandlers[uriKey][methodKey] = handler;
     return new MockHttpHandler._(() {
-      var handlers = MockHttpInternal._requestHandlers[uriKey];
+      final handlers = MockHttpInternal._requestHandlers[uriKey];
       if (handlers != null &&
           handlers[methodKey] != null &&
           handlers[methodKey] == handler) {
@@ -120,10 +120,10 @@ class MockHttp {
     if (!MockHttpInternal._patternRequestHandlers.containsKey(uriPattern)) {
       MockHttpInternal._patternRequestHandlers[uriPattern] = {};
     }
-    var methodKey = method == null ? '*' : method.toUpperCase();
+    final methodKey = method == null ? '*' : method.toUpperCase();
     MockHttpInternal._patternRequestHandlers[uriPattern][methodKey] = handler;
     return new MockHttpHandler._(() {
-      var handlers = MockHttpInternal._patternRequestHandlers[uriPattern];
+      final handlers = MockHttpInternal._patternRequestHandlers[uriPattern];
       if (handlers != null &&
           handlers[methodKey] != null &&
           handlers[methodKey] == handler) {
@@ -156,14 +156,14 @@ class MockHttpInternal {
   }
 
   static void handleMockRequest(MockBaseRequest request) {
-    var matchingExpectations = _expectations.where((e) {
-      bool methodMatches = e.method == request.method;
+    final matchingExpectations = _expectations.where((e) {
+      final methodMatches = e.method == request.method;
       bool uriMatches = false;
       if (e.uri is Uri) {
-        Uri uri = e.uri;
+        final Uri uri = e.uri;
         uriMatches = uri == request.uri;
       } else if (e.uri is Pattern) {
-        Pattern pattern = e.uri;
+        final Pattern pattern = e.uri;
         uriMatches = pattern.allMatches(request.uri.toString()).isNotEmpty;
       }
       bool headersMatch;
@@ -194,14 +194,14 @@ class MockHttpInternal {
       return;
     }
 
-    var matchingRequestHandlerKey = _requestHandlers.keys.firstWhere((key) {
+    final matchingRequestHandlerKey = _requestHandlers.keys.firstWhere((key) {
       return key == _getUriKey(request.uri);
     }, orElse: () => null);
 
     Match match;
-    var matchingPatternRequestHandlerKey =
+    final matchingPatternRequestHandlerKey =
         _patternRequestHandlers.keys.firstWhere((pattern) {
-      var matches = pattern.allMatches(request.uri.toString());
+      final matches = pattern.allMatches(request.uri.toString());
       if (matches.isNotEmpty) {
         match = matches.first;
         return true;
@@ -209,17 +209,19 @@ class MockHttpInternal {
       return false;
     }, orElse: () => null);
 
-    var handlersByMethod = <String, Object>{};
+    Map<String, Object> handlersByMethod;
     if (matchingRequestHandlerKey != null) {
       handlersByMethod = _requestHandlers[matchingRequestHandlerKey];
     } else if (matchingPatternRequestHandlerKey != null) {
       handlersByMethod =
           _patternRequestHandlers[matchingPatternRequestHandlerKey];
+    } else {
+      handlersByMethod = {};
     }
 
     if (handlersByMethod.isNotEmpty) {
       /// Try to find an applicable handler.
-      var handler;
+      Object handler;
       if (handlersByMethod.containsKey(request.method)) {
         handler = handlersByMethod[request.method];
       } else if (handlersByMethod.containsKey('*')) {
@@ -265,7 +267,7 @@ class MockHttpInternal {
       respondWith = new MockResponse.ok();
     }
     _expectations.add(new _RequestExpectation(method, uri,
-        headers == null ? null : new CaseInsensitiveMap.from(headers),
+        headers == null ? null : new CaseInsensitiveMap<String>.from(headers),
         failWith: failWith, respondWith: respondWith));
   }
 

--- a/lib/src/mocks/web_socket.dart
+++ b/lib/src/mocks/web_socket.dart
@@ -52,7 +52,7 @@ class MockWebSocket {
     MockWebSocketInternal._handlers[uri.toString()] = handler;
 
     return new MockWebSocketHandler._(() {
-      var currentHandler = MockWebSocketInternal._handlers[uri.toString()];
+      final currentHandler = MockWebSocketInternal._handlers[uri.toString()];
       if (currentHandler != null && currentHandler == handler) {
         MockWebSocketInternal._handlers.remove(uri.toString());
       }
@@ -70,7 +70,7 @@ class MockWebSocket {
     MockWebSocketInternal._patternHandlers[uriPattern] = handler;
 
     return new MockWebSocketHandler._(() {
-      var currentHandler = MockWebSocketInternal._patternHandlers[uriPattern];
+      final currentHandler = MockWebSocketInternal._patternHandlers[uriPattern];
       if (currentHandler != null && currentHandler == handler) {
         MockWebSocketInternal._patternHandlers.remove(uriPattern);
       }
@@ -94,11 +94,11 @@ class MockWebSocketInternal {
 
   static Future<WSocket> handleWebSocketConnection(Uri uri,
       {Iterable<String> protocols, Map<String, dynamic> headers}) async {
-    Iterable matchingExpectations = _expectations.where((e) {
+    final matchingExpectations = _expectations.where((e) {
       if (e.uri is Uri) {
         return e.uri == uri;
       } else if (e.uri is Pattern) {
-        Pattern pattern = e.uri;
+        final Pattern pattern = e.uri;
         return pattern.allMatches(uri.toString()).isNotEmpty;
       }
     });
@@ -106,8 +106,9 @@ class MockWebSocketInternal {
       /// If this connection was expected, resolve it as planned.
       _WebSocketConnectExpectation expectation = matchingExpectations.first;
       _expectations.remove(expectation);
-      if (expectation.reject != null && expectation.reject)
+      if (expectation.reject != null && expectation.reject) {
         throw new WebSocketException('Mock connection to $uri rejected.');
+      }
       return expectation.connectTo;
     }
 
@@ -118,8 +119,8 @@ class MockWebSocketInternal {
     }
 
     Match match;
-    var matchingHandlerKey = _patternHandlers.keys.firstWhere((uriPattern) {
-      var matches = uriPattern.allMatches(uri.toString());
+    final matchingHandlerKey = _patternHandlers.keys.firstWhere((uriPattern) {
+      final matches = uriPattern.allMatches(uri.toString());
       if (matches.isNotEmpty) {
         match = matches.first;
         return true;

--- a/lib/src/web_socket/browser/web_socket.dart
+++ b/lib/src/web_socket/browser/web_socket.dart
@@ -41,7 +41,7 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
   static Future<WebSocket> connect(Uri uri,
       {Iterable<String> protocols, Map<String, dynamic> headers}) async {
     // Establish a Web Socket connection.
-    var webSocket = new html.WebSocket(uri.toString(), protocols);
+    final webSocket = new html.WebSocket(uri.toString(), protocols);
     if (webSocket == null) {
       throw new WebSocketException('Could not connect to $uri');
     }
@@ -49,15 +49,15 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
     // Listen for and store the close event. This will determine whether or
     // not the socket connected successfully, and will also be used later
     // to handle the web socket closing.
-    Future<html.CloseEvent> closed = webSocket.onClose.first;
+    final closedFuture = webSocket.onClose.first;
 
     // Will complete if the socket successfully opens, or complete with
     // an error if the socket moves straight to the closed state.
-    var connected = new Completer<Null>();
+    final connected = new Completer<Null>();
     // ignore: unawaited_futures
     webSocket.onOpen.first.then((_) => connected.complete());
     // ignore: unawaited_futures
-    closed.then((_) {
+    closedFuture.then((_) {
       if (!connected.isCompleted) {
         connected
             .completeError(new WebSocketException('Could not connect to $uri'));
@@ -65,7 +65,7 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
     });
 
     await connected.future;
-    return new BrowserWebSocket._(webSocket, closed);
+    return new BrowserWebSocket._(webSocket, closedFuture);
   }
 
   @override

--- a/lib/src/web_socket/common/web_socket.dart
+++ b/lib/src/web_socket/common/web_socket.dart
@@ -41,18 +41,18 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
   /// A completer that completes when both the outgoing stream sink and the
   /// incoming stream have been closed. This is used to determine when this
   /// [WebSocket] instance can be considered completely closed.
-  Completer<Null> _allClosed = new Completer();
+  Completer<Null> _allClosed = new Completer<Null>();
 
   /// A completer that completes when this [WebSocket] instance is completely
   /// "done" - both outgoing and incoming.
-  Completer<Null> _done = new Completer();
+  Completer<Null> _done = new Completer<Null>();
 
   /// Any error that may be caught during the life of the underlying WebSocket.
-  var _error;
+  Object _error;
 
   /// A `StreamController` used to expose the incoming stream of events from the
   /// underlying WebSocket.
-  StreamController _incoming;
+  StreamController<dynamic> _incoming;
 
   /// Whether or not the incoming stream of WebSocket events is closed.
   bool _isIncomingClosed = false;
@@ -62,7 +62,7 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
 
   /// A `StreamController` used to pipe outgoing events to the underlying
   /// WebSocket.
-  StreamController _outgoing;
+  StreamController<dynamic> _outgoing;
 
   /// The stack trace for any error that may be caught during the life of the
   /// underlying WebSocket.
@@ -87,14 +87,14 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
     });
 
     // Outgoing communication will be handled by this stream controller.
-    _outgoing = new StreamController();
+    _outgoing = new StreamController<dynamic>();
     _outgoing.stream.listen(onOutgoingData,
         onError: onOutgoingError, onDone: onOutgoingDone);
 
     // Map events from the underlying socket to the incoming controller.
     // It is important to have handlers for start/stop/pause/resume so that the
     // controller properly respects the StreamSubscription API.
-    _incoming = new StreamController(
+    _incoming = new StreamController<dynamic>(
         onListen: onIncomingListen,
         onPause: onIncomingPause,
         onResume: onIncomingResume,
@@ -137,14 +137,14 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
   /// Sending additional data before this stream has completed may
   /// result in a [StateError].
   @override
-  Future addStream(Stream stream) async {
+  Future<Null> addStream(Stream stream) async {
     return _outgoing.addStream(stream);
   }
 
   /// Closes the WebSocket connection. Optionally set [code] and [reason]
   /// to send close information to the remote peer.
   @override
-  Future close([int code, String reason]) {
+  Future<Null> close([int code, String reason]) {
     shutDown(code: code, reason: reason);
     return done;
   }
@@ -152,7 +152,7 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
   @override
   StreamSubscription listen(void onData(dynamic event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    var sub = _incoming.stream
+    final sub = _incoming.stream
         .listen(onData, onError: onError, cancelOnError: cancelOnError);
     _incomingSubscription = new WSocketSubscription(sub, onDone, onCancel: () {
       _incomingSubscription = null;
@@ -163,9 +163,9 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
 
   /// Called when the subscription to the incoming `StreamController` is
   /// canceled.
-  Future onIncomingCancel() async {
+  Future<Null> onIncomingCancel() async {
     await webSocketSubscription.cancel();
-    return _incoming.close();
+    await _incoming.close();
   }
 
   /// Called when a message event with [data] is received from the underlying

--- a/lib/src/web_socket/mock/web_socket.dart
+++ b/lib/src/web_socket/mock/web_socket.dart
@@ -62,7 +62,7 @@ class _MockWebSocket extends CommonWebSocket
 
   /// The mock underlying WebSocket. Events are added manually via the
   /// [MockWebSocket] api.
-  StreamController _mocket = new StreamController();
+  StreamController<dynamic> _mocket = new StreamController<dynamic>();
 
   _MockWebSocket() : super() {
     webSocketSubscription = _mocket.stream.listen(onIncomingData);

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -143,10 +143,10 @@ abstract class WSocket implements Stream, StreamSink {
   /// Sending additional data before this stream has completed may
   /// result in a [StateError].
   @override
-  Future addStream(Stream stream);
+  Future<Null> addStream(Stream stream);
 
   /// Closes the WebSocket connection. Optionally set [code] and [reason]
   /// to send close information to the remote peer.
   @override
-  Future close([int code, String reason]);
+  Future<Null> close([int code, String reason]);
 }

--- a/lib/src/web_socket/w_socket_exception.dart
+++ b/lib/src/web_socket/w_socket_exception.dart
@@ -17,7 +17,7 @@ import 'package:w_transport/src/constants.dart' show v3Deprecation;
 /// Represents an exception in the connection process of a Web Socket.
 @Deprecated(v3Deprecation + 'Use WebSocketException instead.')
 class WSocketException implements Exception {
-  String message;
+  final String message;
   WSocketException([this.message]);
   @override
   String toString() => 'WSocketException: $message';

--- a/lib/src/web_socket/w_socket_subscription.dart
+++ b/lib/src/web_socket/w_socket_subscription.dart
@@ -41,7 +41,7 @@ class WSocketSubscription<T> implements StreamSubscription<T> {
 
   @override
   Future/*<E>*/ asFuture/*<E>*/([var/*=E*/ futureValue]) {
-    var c = new Completer/*<E>*/();
+    final c = new Completer/*<E>*/();
     _doneHandler = () {
       c.complete(futureValue);
     };
@@ -49,7 +49,7 @@ class WSocketSubscription<T> implements StreamSubscription<T> {
   }
 
   @override
-  Future cancel() async {
+  Future<Null> cancel() async {
     await _sub.cancel();
     if (_onCancel != null) {
       await _onCancel();

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -143,10 +143,10 @@ abstract class WebSocket extends WSocket implements Stream, StreamSink {
   /// Sending additional data before this stream has completed may
   /// result in a [StateError].
   @override
-  Future addStream(Stream stream);
+  Future<Null> addStream(Stream stream);
 
   /// Closes the WebSocket connection. Optionally set [code] and [reason]
   /// to send close information to the remote peer.
   @override
-  Future close([int code, String reason]);
+  Future<Null> close([int code, String reason]);
 }

--- a/test/integration/http/client/browser_test.dart
+++ b/test/integration/http/client/browser_test.dart
@@ -20,7 +20,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/client/mock_test.dart
+++ b/test/integration/http/client/mock_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/client/suite.dart
+++ b/test/integration/http/client/suite.dart
@@ -37,38 +37,38 @@ void _runHttpClientSuite(Client getClient()) {
   });
 
   test('newFormRequest()', () async {
-    FormRequest request = client.newFormRequest();
+    final request = client.newFormRequest();
     await _testRequest(request);
     client.close();
   });
 
   test('newJsonRequest()', () async {
-    JsonRequest request = client.newJsonRequest();
+    final request = client.newJsonRequest();
     await _testRequest(request);
     client.close();
   });
 
   test('newMultipartRequest()', () async {
-    MultipartRequest request = client.newMultipartRequest();
+    final request = client.newMultipartRequest();
     request.fields['key'] = 'value';
     await _testRequest(request);
     client.close();
   });
 
   test('newRequest()', () async {
-    Request request = client.newRequest();
+    final request = client.newRequest();
     await _testRequest(request);
     client.close();
   });
 
   test('newStreamedRequest()', () async {
-    StreamedRequest request = client.newStreamedRequest();
+    final request = client.newStreamedRequest();
     await _testRequest(request);
     client.close();
   });
 
   test('should support multiple concurrent requests', () async {
-    List<Future> requests = [
+    final requests = <Future>[
       client.newFormRequest().post(uri: IntegrationPaths.reflectEndpointUri),
       client.newJsonRequest().put(uri: IntegrationPaths.reflectEndpointUri),
       (client.newMultipartRequest()..fields['f'] = 'v')
@@ -93,12 +93,12 @@ void _runHttpClientSuite(Client getClient()) {
 
   test('close() should abort all in-flight requests', () async {
     // We will let this request finish before closing the client.
-    Request willComplete = client.newRequest();
+    final willComplete = client.newRequest();
     await willComplete.get(uri: IntegrationPaths.pingEndpointUri);
 
     // This request should be canceled before it times out.
-    Request willNotComplete = client.newRequest();
-    Future willThrow =
+    final willNotComplete = client.newRequest();
+    final willThrow =
         willNotComplete.get(uri: IntegrationPaths.timeoutEndpointUri);
 
     // Closing the client should not affect the completed request, but should
@@ -112,7 +112,7 @@ void _runHttpClientSuite(Client getClient()) {
 Future<Null> _testRequest(BaseRequest request) async {
   request.uri = IntegrationPaths.reflectEndpointUri;
   request.headers = {'x-custom': 'value', 'x-tokens': 'token1, token2'};
-  Response response = await request.get();
+  final response = await request.get();
   expect(response.body.asJson()['method'], equals('GET'));
   expect(response.body.asJson()['headers'], containsPair('x-custom', 'value'));
   expect(response.body.asJson()['headers'],

--- a/test/integration/http/client/vm_test.dart
+++ b/test/integration/http/client/vm_test.dart
@@ -20,7 +20,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/common_request/browser_test.dart
+++ b/test/integration/http/common_request/browser_test.dart
@@ -22,7 +22,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -36,7 +36,7 @@ void main() {
 
     group('autoRetry browser', () {
       test('null response default behavior', () async {
-        BaseRequest request = new Request()
+        final request = new Request()
           ..headers.addAll({'x-custom': 'causes-CORS-request'})
           ..uri = IntegrationPaths.errorEndpointUri;
         request.autoRetry
@@ -50,7 +50,7 @@ void main() {
       });
 
       test('null response should be retried', () async {
-        BaseRequest request = new Request()
+        final request = new Request()
           ..headers.addAll({'x-custom': 'causes-CORS-request'})
           ..uri = IntegrationPaths.errorEndpointUri;
         request.autoRetry

--- a/test/integration/http/common_request/mock_test.dart
+++ b/test/integration/http/common_request/mock_test.dart
@@ -26,7 +26,7 @@ import '../mock_endpoints/timeout.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -68,24 +68,24 @@ void runCommonRequestSuite() {
 void _runCommonRequestSuiteFor(
     String name, BaseRequest requestFactory({bool withBody})) {
   group(name, () {
-    var headers = {
+    final headers = <String, String>{
       'authorization': 'test',
       'x-custom': 'value',
       'x-tokens': 'token1, token2'
     };
 
     test('"done" should complete when the request succeeds', () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       // ignore: unawaited_futures
       request.post(uri: IntegrationPaths.reflectEndpointUri);
       await request.done;
     });
 
     test('"done" should complete when the request is canceled', () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
 
       try {
-        Future future = request.post(uri: IntegrationPaths.timeoutEndpointUri);
+        final future = request.post(uri: IntegrationPaths.timeoutEndpointUri);
         await new Future.delayed(new Duration(milliseconds: 5));
         request.abort();
         await future;
@@ -95,7 +95,7 @@ void _runCommonRequestSuiteFor(
     });
 
     test('"done" should complete when the request fails', () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       try {
         await request.post(uri: IntegrationPaths.fourOhFourEndpointUri);
       } on RequestException catch (_) {}
@@ -103,84 +103,84 @@ void _runCommonRequestSuiteFor(
     });
 
     test('DELETE (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamDelete(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('GET (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamGet(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('HEAD (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamHead(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
     });
 
     test('OPTIONS (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response = await request.streamOptions(
+      final request = requestFactory();
+      final response = await request.streamOptions(
           uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('PATCH (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamPatch(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('POST (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamPost(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('PUT (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response =
+      final request = requestFactory();
+      final response =
           await request.streamPut(uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('custom HTTP method (streamed)', () async {
-      BaseRequest request = requestFactory();
-      StreamedResponse response = await request.streamSend('COPY',
+      final request = requestFactory();
+      final response = await request.streamSend('COPY',
           uri: IntegrationPaths.downloadEndpointUri);
       expect(response.status, equals(200));
       expect(await response.body.byteStream.isEmpty, isFalse);
     });
 
     test('DELETE request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.delete(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('DELETE'));
     });
 
     test('DELETE request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.delete();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.delete();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('DELETE'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -191,21 +191,21 @@ void _runCommonRequestSuiteFor(
     });
 
     test('GET request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.get(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('GET'));
     });
 
     test('GET request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.get();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.get();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('GET'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -216,36 +216,36 @@ void _runCommonRequestSuiteFor(
     });
 
     test('HEAD request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.head(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
     });
 
     test('HEAD request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.head();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.head();
       expect(response.status, equals(200));
     });
 
     test('OPTIONS request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.options(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('OPTIONS'));
     });
 
     test('OPTIONS request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.options();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.options();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('OPTIONS'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -256,21 +256,21 @@ void _runCommonRequestSuiteFor(
     });
 
     test('PATCH request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.patch(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('PATCH'));
     });
 
     test('PATCH request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.patch();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.patch();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('PATCH'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -281,21 +281,21 @@ void _runCommonRequestSuiteFor(
     });
 
     test('POST request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.post(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('POST'));
     });
 
     test('POST request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.post();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.post();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('POST'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -306,21 +306,21 @@ void _runCommonRequestSuiteFor(
     });
 
     test('PUT request', () async {
-      BaseRequest request = requestFactory();
-      Response response =
+      final request = requestFactory();
+      final response =
           await request.put(uri: IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('PUT'));
     });
 
     test('PUT request with headers', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.reflectEndpointUri
-        ..headers = new Map.from(headers);
-      Response response = await request.put();
+        ..headers = new Map<String, String>.from(headers);
+      final response = await request.put();
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('PUT'));
       expect(json['headers'],
           containsPair('authorization', request.headers['authorization']));
@@ -331,8 +331,8 @@ void _runCommonRequestSuiteFor(
     });
 
     test('upload progress stream', () async {
-      Completer uploadProgressListenedTo = new Completer();
-      BaseRequest request = requestFactory(withBody: true)
+      final uploadProgressListenedTo = new Completer<Null>();
+      final request = requestFactory(withBody: true)
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.uploadProgress.listen((RequestProgress progress) {
         if (progress.percent > 0 && !uploadProgressListenedTo.isCompleted) {
@@ -344,8 +344,8 @@ void _runCommonRequestSuiteFor(
     });
 
     test('download progress stream', () async {
-      Completer downloadProgressListenedTo = new Completer();
-      BaseRequest request = requestFactory()
+      final downloadProgressListenedTo = new Completer<Null>();
+      final request = requestFactory()
         ..uri = IntegrationPaths.downloadEndpointUri;
       request.downloadProgress.listen((RequestProgress progress) {
         if (progress.percent > 0 && !downloadProgressListenedTo.isCompleted) {
@@ -357,7 +357,7 @@ void _runCommonRequestSuiteFor(
     });
 
     test('should throw RequestException on failed requests', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.fourOhFourEndpointUri;
       expect(
           request.get(),
@@ -371,7 +371,7 @@ void _runCommonRequestSuiteFor(
 
     test('request cancellation prior to dispatch should cause request to fail',
         () async {
-      BaseRequest request = requestFactory()..uri = IntegrationPaths.hostUri;
+      final request = requestFactory()..uri = IntegrationPaths.hostUri;
       request.abort();
       expect(request.get(), throwsA(predicate((exception) {
         return exception is RequestException &&
@@ -382,9 +382,9 @@ void _runCommonRequestSuiteFor(
     test(
         'request cancellation after dispatch but prior to resolution should cause request to fail',
         () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = IntegrationPaths.timeoutEndpointUri;
-      Future future = request.get();
+      final future = request.get();
 
       // Wait a sufficient amount of time to allow the request to open.
       // Since we're hitting a timeout endpoint, it shouldn't complete.
@@ -397,13 +397,13 @@ void _runCommonRequestSuiteFor(
 
     test('timeoutThreshold does nothing if request completes in time',
         () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..timeoutThreshold = new Duration(seconds: 5);
       await request.get(uri: IntegrationPaths.pingEndpointUri);
     });
 
     test('timeoutThreshold cancels the request if exceeded', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..timeoutThreshold = new Duration(milliseconds: 250);
       expect(request.get(uri: IntegrationPaths.timeoutEndpointUri),
           throwsA(predicate((error) {
@@ -418,7 +418,7 @@ void _runAutoRetryTestSuiteFor(
   group(name, () {
     group('auto retry', () {
       test('disabled', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
 
         defineResponseChain(request, [500]);
 
@@ -429,7 +429,7 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('no retries', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -442,7 +442,7 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('1 successful retry', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -455,7 +455,7 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('1 failed retry, 1 successful retry', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -468,7 +468,7 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('maximum retries exceeded', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;

--- a/test/integration/http/common_request/vm_test.dart
+++ b/test/integration/http/common_request/vm_test.dart
@@ -21,7 +21,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -35,7 +35,7 @@ void main() {
 
     group('MultipartRequest', () {
       test('adding invalid type as file throws', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         request.files['test'] = 'not a file';
         expect(() => request.contentLength, throwsUnsupportedError);
         expect(request.post(uri: Uri.parse('/test')), throwsUnsupportedError);

--- a/test/integration/http/form_request/browser_test.dart
+++ b/test/integration/http/form_request/browser_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,19 +37,19 @@ void main() {
     runFormRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpRequest xhr = request;
         xhr.setRequestHeader('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
 
     group('withCredentials', () {
       test('set to true', () async {
-        FormRequest request = new FormRequest()
+        final request = new FormRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = true;
         request.configure((request) async {
@@ -60,7 +60,7 @@ void main() {
       });
 
       test('set to false', () async {
-        FormRequest request = new FormRequest()
+        final request = new FormRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = false;
         request.configure((request) async {

--- a/test/integration/http/form_request/mock_test.dart
+++ b/test/integration/http/form_request/mock_test.dart
@@ -24,7 +24,7 @@ import '../mock_endpoints/reflect.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/form_request/suite.dart
+++ b/test/integration/http/form_request/suite.dart
@@ -26,10 +26,10 @@ void runFormRequestSuite() {
   group('FormRequest', () {
     test('content-length should be set automatically', () async {
       // Empty request.
-      FormRequest emptyRequest = new FormRequest();
-      Response response =
+      final emptyRequest = new FormRequest();
+      final response =
           await emptyRequest.post(uri: IntegrationPaths.reflectEndpointUri);
-      int contentLength =
+      final contentLength =
           int.parse(response.body.asJson()['headers']['content-length']);
       expect(contentLength, equals(0),
           reason: 'Empty form request\'s content-length should be 0.');
@@ -39,91 +39,91 @@ void runFormRequestSuite() {
         ..uri = IntegrationPaths.reflectEndpointUri
         ..fields['field1'] = 'value1'
         ..fields['field2'] = 'value2';
-      response = await nonEmptyRequest.post();
-      contentLength =
-          int.parse(response.body.asJson()['headers']['content-length']);
-      expect(contentLength, greaterThan(0),
+      final response2 = await nonEmptyRequest.post();
+      final contentLength2 =
+          int.parse(response2.body.asJson()['headers']['content-length']);
+      expect(contentLength2, greaterThan(0),
           reason:
               'Non-empty form request\'s content-length should be greater than 0.');
     });
 
     test('content-type should be set automatically', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..fields['field'] = 'value';
-      Response response = await request.post();
-      MediaType contentType = new MediaType.parse(
+      final response = await request.post();
+      final contentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(contentType.mimeType, equals('application/x-www-form-urlencoded'));
     });
 
     test('content-type should be overridable', () async {
-      var contentType = new MediaType('application', 'x-custom');
-      FormRequest request = new FormRequest()
+      final contentType = new MediaType('application', 'x-custom');
+      final request = new FormRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..fields['field'] = 'value'
         ..contentType = contentType;
-      Response response = await request.post();
-      var reflectedContentType = new MediaType.parse(
+      final response = await request.post();
+      final reflectedContentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(reflectedContentType.mimeType, equals(contentType.mimeType));
     });
 
     test('UTF8', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = UTF8
         ..fields['field1'] = 'value1'
         ..fields['field2'] = 'ç®å';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(UTF8.name));
-      Map echo = http_utils.queryToMap(response.body.asString(),
+      final echo = http_utils.queryToMap(response.body.asString(),
           encoding: response.encoding);
       expect(echo, containsPair('field1', 'value1'));
       expect(echo, containsPair('field2', 'ç®å'));
     });
 
     test('LATIN1', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = LATIN1
         ..fields['field1'] = 'value1'
         ..fields['field2'] = 'ç®å';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(LATIN1.name));
-      Map echo = http_utils.queryToMap(response.body.asString(),
+      final echo = http_utils.queryToMap(response.body.asString(),
           encoding: response.encoding);
       expect(echo, containsPair('field1', 'value1'));
       expect(echo, containsPair('field2', 'ç®å'));
     });
 
     test('ASCII', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = ASCII
         ..fields['field1'] = 'value1'
         ..fields['field2'] = 'value2';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(ASCII.name));
-      Map echo = http_utils.queryToMap(response.body.asString(),
+      final echo = http_utils.queryToMap(response.body.asString(),
           encoding: response.encoding);
       expect(echo, containsPair('field1', 'value1'));
       expect(echo, containsPair('field2', 'value2'));
     });
 
     test('should support multiple values for a single field', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..fields['items'] = ['one', 'two'];
-      Response response = await request.post();
-      Map echo = http_utils.queryToMap(response.body.asString());
+      final response = await request.post();
+      final echo = http_utils.queryToMap(response.body.asString());
       expect(echo['items'], equals(['one', 'two']));
     });
 
     test(
         'should prevent unsupported value types (anything other than String and List<String>)',
         () {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..fields['invalid'] = 10;
 

--- a/test/integration/http/form_request/vm_test.dart
+++ b/test/integration/http/form_request/vm_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,13 +37,13 @@ void main() {
     runFormRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      FormRequest request = new FormRequest()
+      final request = new FormRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpClientRequest ioRequest = request;
         ioRequest.headers.set('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/integration/http/http_static/browser_test.dart
+++ b/test/integration/http/http_static/browser_test.dart
@@ -20,7 +20,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/http_static/mock_test.dart
+++ b/test/integration/http/http_static/mock_test.dart
@@ -22,7 +22,7 @@ import '../mock_endpoints/reflect.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/http_static/suite.dart
+++ b/test/integration/http/http_static/suite.dart
@@ -23,25 +23,24 @@ import '../../integration_paths.dart';
 
 void runHttpStaticSuite() {
   group('Http static methods', () {
-    var headers = {
+    final headers = <String, String>{
       'authorization': 'test',
       'x-custom': 'value',
       'x-tokens': 'token1, token2'
     };
 
     test('DELETE request', () async {
-      Response response =
-          await Http.delete(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.delete(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('DELETE'));
     });
 
     test('DELETE request with headers', () async {
-      Response response = await Http.delete(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.delete(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('DELETE'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -50,17 +49,17 @@ void runHttpStaticSuite() {
     });
 
     test('GET request', () async {
-      Response response = await Http.get(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.get(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('GET'));
     });
 
     test('GET request with headers', () async {
-      Response response = await Http.get(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.get(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('GET'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -69,30 +68,28 @@ void runHttpStaticSuite() {
     });
 
     test('HEAD request', () async {
-      Response response = await Http.head(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.head(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
     });
 
     test('HEAD request with headers', () async {
-      Response response = await Http.head(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.head(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
     });
 
     test('OPTIONS request', () async {
-      Response response =
-          await Http.options(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.options(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('OPTIONS'));
     });
 
     test('OPTIONS request with headers', () async {
-      Response response = await Http.options(
-          IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.options(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('OPTIONS'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -101,17 +98,17 @@ void runHttpStaticSuite() {
     });
 
     test('PATCH request', () async {
-      Response response = await Http.patch(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.patch(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('PATCH'));
     });
 
     test('PATCH request with headers', () async {
-      Response response = await Http.patch(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.patch(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('PATCH'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -120,23 +117,23 @@ void runHttpStaticSuite() {
     });
 
     test('PATCH request with body', () async {
-      Response response =
+      final response =
           await Http.patch(IntegrationPaths.echoEndpointUri, body: 'body');
       expect(response.body.asString(), equals('body'));
     });
 
     test('POST request', () async {
-      Response response = await Http.post(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.post(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('POST'));
     });
 
     test('POST request with headers', () async {
-      Response response = await Http.post(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.post(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('POST'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -145,23 +142,23 @@ void runHttpStaticSuite() {
     });
 
     test('POST request with body', () async {
-      Response response =
+      final response =
           await Http.post(IntegrationPaths.echoEndpointUri, body: 'body');
       expect(response.body.asString(), equals('body'));
     });
 
     test('PUT request', () async {
-      Response response = await Http.put(IntegrationPaths.reflectEndpointUri);
+      final response = await Http.put(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('PUT'));
     });
 
     test('PUT request with headers', () async {
-      Response response = await Http.put(IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.put(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('PUT'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -170,25 +167,25 @@ void runHttpStaticSuite() {
     });
 
     test('PUT request with body', () async {
-      Response response =
+      final response =
           await Http.put(IntegrationPaths.echoEndpointUri, body: 'body');
       expect(response.body.asString(), equals('body'));
     });
 
     test('custom HTTP method request', () async {
-      Response response =
+      final response =
           await Http.send('COPY', IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
       expect(response.body.asJson()['method'], equals('COPY'));
     });
 
     test('custom HTTP method request with headers', () async {
-      Response response = await Http.send(
+      final response = await Http.send(
           'COPY', IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      var json = response.body.asJson();
+      final json = response.body.asJson();
       expect(json['method'], equals('COPY'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -197,14 +194,14 @@ void runHttpStaticSuite() {
     });
 
     test('custom HTTP method request with body', () async {
-      Response response = await Http
-          .send('COPY', IntegrationPaths.echoEndpointUri, body: 'body');
+      final response = await Http.send('COPY', IntegrationPaths.echoEndpointUri,
+          body: 'body');
       expect(response.body.asString(), equals('body'));
     });
 
     Future<String> _decodeStreamedResponseToString(
         StreamedResponse response) async {
-      Uint8List bytes = await response.body.toBytes();
+      final bytes = await response.body.toBytes();
       return response.encoding.decode(bytes.toList());
     }
 
@@ -213,20 +210,20 @@ void runHttpStaticSuite() {
     }
 
     test('streamed DELETE request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamDelete(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('DELETE'));
     });
 
     test('streamed DELETE request with headers', () async {
-      StreamedResponse response = await Http.streamDelete(
+      final response = await Http.streamDelete(
           IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('DELETE'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -235,20 +232,19 @@ void runHttpStaticSuite() {
     });
 
     test('streamed GET request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamGet(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('GET'));
     });
 
     test('streamed GET request with headers', () async {
-      StreamedResponse response = await Http.streamGet(
-          IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.streamGet(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('GET'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -257,33 +253,33 @@ void runHttpStaticSuite() {
     });
 
     test('streamed HEAD request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamHead(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
     });
 
     test('streamed HEAD request with headers', () async {
-      StreamedResponse response = await Http.streamHead(
+      final response = await Http.streamHead(
           IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
     });
 
     test('streamed OPTIONS request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamOptions(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('OPTIONS'));
     });
 
     test('streamed OPTIONS request with headers', () async {
-      StreamedResponse response = await Http.streamOptions(
+      final response = await Http.streamOptions(
           IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('OPTIONS'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -292,20 +288,20 @@ void runHttpStaticSuite() {
     });
 
     test('streamed PATCH request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamPatch(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('PATCH'));
     });
 
     test('streamed PATCH request with headers', () async {
-      StreamedResponse response = await Http.streamPatch(
+      final response = await Http.streamPatch(
           IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('PATCH'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -314,27 +310,27 @@ void runHttpStaticSuite() {
     });
 
     test('streamed PATCH request with body', () async {
-      StreamedResponse response = await Http
-          .streamPatch(IntegrationPaths.echoEndpointUri, body: 'body');
-      String body = await _decodeStreamedResponseToString(response);
+      final response = await Http.streamPatch(IntegrationPaths.echoEndpointUri,
+          body: 'body');
+      final body = await _decodeStreamedResponseToString(response);
       expect(body, equals('body'));
     });
 
     test('streamed POST request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamPost(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('POST'));
     });
 
     test('streamed POST request with headers', () async {
-      StreamedResponse response = await Http.streamPost(
+      final response = await Http.streamPost(
           IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('POST'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -343,27 +339,26 @@ void runHttpStaticSuite() {
     });
 
     test('streamed POST request with body', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamPost(IntegrationPaths.echoEndpointUri, body: 'body');
-      String body = await _decodeStreamedResponseToString(response);
+      final body = await _decodeStreamedResponseToString(response);
       expect(body, equals('body'));
     });
 
     test('streamed PUT request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamPut(IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('PUT'));
     });
 
     test('streamed PUT request with headers', () async {
-      StreamedResponse response = await Http.streamPut(
-          IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+      final response = await Http.streamPut(IntegrationPaths.reflectEndpointUri,
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('PUT'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -372,27 +367,27 @@ void runHttpStaticSuite() {
     });
 
     test('streamed PUT request with body', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamPut(IntegrationPaths.echoEndpointUri, body: 'body');
-      String body = await _decodeStreamedResponseToString(response);
+      final body = await _decodeStreamedResponseToString(response);
       expect(body, equals('body'));
     });
 
     test('streamed custom HTTP method request', () async {
-      StreamedResponse response =
+      final response =
           await Http.streamSend('COPY', IntegrationPaths.reflectEndpointUri);
       expect(response.status, equals(200));
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('COPY'));
     });
 
     test('streamed custom HTTP method request with headers', () async {
-      StreamedResponse response = await Http.streamSend(
+      final response = await Http.streamSend(
           'COPY', IntegrationPaths.reflectEndpointUri,
-          headers: new Map.from(headers));
+          headers: new Map<String, String>.from(headers));
       expect(response.status, equals(200));
 
-      Map json = await _decodeStreamedResponseToJson(response);
+      final json = await _decodeStreamedResponseToJson(response);
       expect(json['method'], equals('COPY'));
       expect(json['headers'],
           containsPair('authorization', headers['authorization']));
@@ -401,9 +396,9 @@ void runHttpStaticSuite() {
     });
 
     test('streamed custom HTTP method request with body', () async {
-      StreamedResponse response = await Http
+      final response = await Http
           .streamSend('COPY', IntegrationPaths.echoEndpointUri, body: 'body');
-      String body = await _decodeStreamedResponseToString(response);
+      final body = await _decodeStreamedResponseToString(response);
       expect(body, equals('body'));
     });
   });

--- a/test/integration/http/http_static/vm_test.dart
+++ b/test/integration/http/http_static/vm_test.dart
@@ -20,7 +20,7 @@ import '../../../naming.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/json_request/browser_test.dart
+++ b/test/integration/http/json_request/browser_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,19 +37,19 @@ void main() {
     runJsonRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpRequest xhr = request;
         xhr.setRequestHeader('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
 
     group('withCredentials', () {
       test('set to true (JsonRequest)', () async {
-        JsonRequest request = new JsonRequest()
+        final request = new JsonRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = true;
         request.configure((request) async {
@@ -60,7 +60,7 @@ void main() {
       });
 
       test('set to false (JsonRequest)', () async {
-        JsonRequest request = new JsonRequest()
+        final request = new JsonRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = false;
         request.configure((request) async {

--- a/test/integration/http/json_request/mock_test.dart
+++ b/test/integration/http/json_request/mock_test.dart
@@ -24,7 +24,7 @@ import '../mock_endpoints/reflect.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/json_request/suite.dart
+++ b/test/integration/http/json_request/suite.dart
@@ -23,75 +23,75 @@ import '../../integration_paths.dart';
 void runJsonRequestSuite() {
   group('JsonRequest', () {
     test('contentLength should be set automatically', () async {
-      JsonRequest emptyRequest = new JsonRequest();
-      Response response =
+      final emptyRequest = new JsonRequest();
+      final response =
           await emptyRequest.post(uri: IntegrationPaths.reflectEndpointUri);
-      int contentLength =
+      final contentLength =
           int.parse(response.body.asJson()['headers']['content-length']);
       expect(contentLength, equals(0),
           reason: 'Empty JSON request\'s content-length should be 0.');
 
-      JsonRequest nonEmptyRequest = new JsonRequest()
+      final nonEmptyRequest = new JsonRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = {'field1': 'value1', 'field2': 'value2'};
-      response = await nonEmptyRequest.post();
-      contentLength =
-          int.parse(response.body.asJson()['headers']['content-length']);
-      expect(contentLength, greaterThan(0),
+      final response2 = await nonEmptyRequest.post();
+      final contentLength2 =
+          int.parse(response2.body.asJson()['headers']['content-length']);
+      expect(contentLength2, greaterThan(0),
           reason:
               'Non-empty JSON request\'s content-length should be greater than 0.');
     });
 
     test('content-type should be set automatically', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = {'field1': 'value1', 'field2': 'value2'};
-      Response response = await request.post();
-      MediaType contentType = new MediaType.parse(
+      final response = await request.post();
+      final contentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(contentType.mimeType, equals('application/json'));
     });
 
     test('content-type should be overridable', () async {
-      var contentType = new MediaType('application', 'x-custom');
-      JsonRequest request = new JsonRequest()
+      final contentType = new MediaType('application', 'x-custom');
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = {'field1': 'value1', 'field2': 'value2'}
         ..contentType = contentType;
-      Response response = await request.post();
-      var reflectedContentType = new MediaType.parse(
+      final response = await request.post();
+      final reflectedContentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(reflectedContentType.mimeType, equals(contentType.mimeType));
     });
 
     test('UTF8', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = UTF8
         ..body = {'field1': 'value1', 'field2': 'ç®å'};
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(UTF8.name));
       expect(response.body.asJson(), containsPair('field1', 'value1'));
       expect(response.body.asJson(), containsPair('field2', 'ç®å'));
     });
 
     test('LATIN1', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = LATIN1
         ..body = {'field1': 'value1', 'field2': 'ç®å'};
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(LATIN1.name));
       expect(response.body.asJson(), containsPair('field1', 'value1'));
       expect(response.body.asJson(), containsPair('field2', 'ç®å'));
     });
 
     test('ASCII', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = ASCII
         ..body = {'field1': 'value1', 'field2': 'value2'};
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(ASCII.name));
       expect(response.body.asJson(), containsPair('field1', 'value1'));
       expect(response.body.asJson(), containsPair('field2', 'value2'));

--- a/test/integration/http/json_request/vm_test.dart
+++ b/test/integration/http/json_request/vm_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,13 +37,13 @@ void main() {
     runJsonRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      JsonRequest request = new JsonRequest()
+      final request = new JsonRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpClientRequest ioRequest = request;
         ioRequest.headers.set('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/integration/http/mock_endpoints/404.dart
+++ b/test/integration/http/mock_endpoints/404.dart
@@ -15,6 +15,5 @@
 import 'package:w_transport/mock.dart';
 
 void mock404Endpoint(Uri uri) {
-  MockTransports.http.when(
-      uri, (FinalizedRequest request) async => new MockResponse.notFound());
+  MockTransports.http.when(uri, (request) async => new MockResponse.notFound());
 }

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -16,8 +16,8 @@ import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
 void mockCustomEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (FinalizedRequest request) async {
-    var status = int.parse(request.uri.queryParameters['status'] ?? '200');
+  MockTransports.http.when(uri, (request) async {
+    final status = int.parse(request.uri.queryParameters['status'] ?? '200');
     return new MockResponse(status);
   });
 }

--- a/test/integration/http/mock_endpoints/download.dart
+++ b/test/integration/http/mock_endpoints/download.dart
@@ -19,7 +19,7 @@ import 'package:w_transport/mock.dart';
 
 void mockDownloadEndpoint(Uri uri) {
   MockTransports.http.when(uri, (_) async {
-    var byteStream = new Stream.fromIterable([UTF8.encode('file')]);
+    final byteStream = new Stream.fromIterable([UTF8.encode('file')]);
     return new MockStreamedResponse.ok(byteStream: byteStream);
   });
 }

--- a/test/integration/http/mock_endpoints/echo.dart
+++ b/test/integration/http/mock_endpoints/echo.dart
@@ -16,8 +16,10 @@ import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
 void mockEchoEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (FinalizedRequest request) async {
-    var headers = {'content-type': request.headers['content-type']};
+  MockTransports.http.when(uri, (request) async {
+    final headers = <String, String>{
+      'content-type': request.headers['content-type']
+    };
     if (request.body is HttpBody) {
       HttpBody body = request.body;
       return new MockResponse.ok(body: body.asString(), headers: headers);

--- a/test/integration/http/mock_endpoints/reflect.dart
+++ b/test/integration/http/mock_endpoints/reflect.dart
@@ -17,8 +17,8 @@ import 'dart:convert';
 import 'package:w_transport/mock.dart';
 
 void mockReflectEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (FinalizedRequest request) async {
-    Map reflection = {
+  MockTransports.http.when(uri, (request) async {
+    final reflection = <String, Object>{
       'method': request.method,
       'path': request.uri.path,
       'headers': request.headers,

--- a/test/integration/http/mock_endpoints/timeout.dart
+++ b/test/integration/http/mock_endpoints/timeout.dart
@@ -15,9 +15,10 @@
 import 'dart:async';
 
 import 'package:w_transport/mock.dart';
+import 'package:w_transport/w_transport.dart';
 
 void mockTimeoutEndpoint(Uri uri) {
   MockTransports.http.when(uri, (_) async {
-    return new Completer().future;
+    return new Completer<BaseResponse>().future;
   });
 }

--- a/test/integration/http/mock_endpoints/upload.dart
+++ b/test/integration/http/mock_endpoints/upload.dart
@@ -16,7 +16,7 @@ import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
 void mockUploadEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (FinalizedRequest request) async {
+  MockTransports.http.when(uri, (request) async {
     StreamedHttpBody body = request.body;
     await body.byteStream.drain();
     return new MockResponse.ok();

--- a/test/integration/http/multipart_request/browser_test.dart
+++ b/test/integration/http/multipart_request/browser_test.dart
@@ -25,7 +25,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -39,21 +39,21 @@ void main() {
 
     group('MultipartRequest', () {
       test('underlying HttpRequest configuration', () async {
-        MultipartRequest request = new MultipartRequest()
+        final request = new MultipartRequest()
           ..uri = IntegrationPaths.reflectEndpointUri
           ..fields['field'] = 'value';
         request.configure((request) async {
           HttpRequest xhr = request;
           xhr.setRequestHeader('x-configured', 'true');
         });
-        Response response = await request.get();
+        final response = await request.get();
         expect(
             response.body.asJson()['headers']['x-configured'], equals('true'));
       });
 
       group('withCredentials', () {
         test('set to true (MultipartRequest)', () async {
-          MultipartRequest request = new MultipartRequest()
+          final request = new MultipartRequest()
             ..uri = IntegrationPaths.pingEndpointUri
             ..fields['field'] = 'value'
             ..withCredentials = true;
@@ -65,7 +65,7 @@ void main() {
         });
 
         test('set to false (MultipartRequest)', () async {
-          MultipartRequest request = new MultipartRequest()
+          final request = new MultipartRequest()
             ..uri = IntegrationPaths.pingEndpointUri
             ..fields['field'] = 'value'
             ..withCredentials = false;
@@ -78,21 +78,21 @@ void main() {
       });
 
       test('setting content-length is unsupported', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         expect(() {
           request.contentLength = 10;
         }, throwsUnsupportedError);
       });
 
       test('setting body in request dispatcher is unsupported', () async {
-        MultipartRequest request = new MultipartRequest()
+        final request = new MultipartRequest()
           ..uri = IntegrationPaths.reflectEndpointUri;
         expect(request.post(body: 'invalid'), throwsUnsupportedError);
       });
 
       test('should support Blob file', () async {
-        Blob blob = new Blob([UTF8.encode('file')]);
-        MultipartRequest request = new MultipartRequest()
+        final blob = new Blob([UTF8.encode('file')]);
+        final request = new MultipartRequest()
           ..uri = IntegrationPaths.reflectEndpointUri
           ..files['blob'] = blob;
         await request.post();
@@ -103,9 +103,8 @@ void main() {
       });
 
       test('clone()', () {
-        MultipartRequest orig = new MultipartRequest()
-          ..fields = {'field1': 'value1'};
-        MultipartRequest clone = orig.clone();
+        final orig = new MultipartRequest()..fields = {'field1': 'value1'};
+        final clone = orig.clone();
         expect(clone.fields, equals(orig.fields));
       });
     });

--- a/test/integration/http/multipart_request/mock_test.dart
+++ b/test/integration/http/multipart_request/mock_test.dart
@@ -24,7 +24,7 @@ import '../mock_endpoints/upload.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/multipart_request/suite.dart
+++ b/test/integration/http/multipart_request/suite.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 void runMultipartRequestSuite() {
   group('MultipartRequest', () {
     test('contentLength should be set automatically', () async {
-      List<List<int>> chunks = [
+      final chunks = <List<int>>[
         UTF8.encode('chunk1'),
         UTF8.encode('chunk2'),
         UTF8.encode('chunk3')
@@ -33,17 +33,17 @@ void runMultipartRequestSuite() {
       chunks.forEach((chunk) {
         size += chunk.length;
       });
-      var fileStream = new Stream<List<int>>.fromIterable(chunks);
-      MultipartFile file = new MultipartFile(fileStream, size);
+      final fileStream = new Stream.fromIterable(chunks);
+      final file = new MultipartFile(fileStream, size);
 
-      MultipartRequest request = new MultipartRequest()
+      final request = new MultipartRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..files['file'] = file
         ..fields['field'] = 'value';
 
-      Response response =
+      final response =
           await request.post(uri: IntegrationPaths.reflectEndpointUri);
-      var contentLength =
+      final contentLength =
           int.parse(response.body.asJson()['headers']['content-length']);
       expect(contentLength, greaterThan(0),
           reason:
@@ -51,17 +51,17 @@ void runMultipartRequestSuite() {
     });
 
     test('content-type should be set automatically', () async {
-      MultipartRequest request = new MultipartRequest()
+      final request = new MultipartRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..fields['field'] = 'value';
-      Response response = await request.post();
-      MediaType contentType = new MediaType.parse(
+      final response = await request.post();
+      final contentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(contentType.mimeType, equals('multipart/form-data'));
     });
 
     test('text fields with non-ASCII chars', () async {
-      MultipartRequest request = new MultipartRequest()
+      final request = new MultipartRequest()
         ..uri = IntegrationPaths.uploadEndpointUri
         ..fields['field'] = 'ç®å';
       await request.post();
@@ -69,39 +69,39 @@ void runMultipartRequestSuite() {
 
     test('uploading multiple files with different charsets', () async {
       // UTF8-encoded file.
-      List<List<int>> utf8Chunks = [UTF8.encode('chunk1'), UTF8.encode('ç®å')];
-      Stream<List<int>> utf8Stream = new Stream.fromIterable(utf8Chunks);
-      int utf8Size = utf8Chunks[0].length + utf8Chunks[1].length;
-      MediaType utf8ContentType =
+      final utf8Chunks = <List<int>>[UTF8.encode('chunk1'), UTF8.encode('ç®å')];
+      final utf8Stream = new Stream.fromIterable(utf8Chunks);
+      final utf8Size = utf8Chunks[0].length + utf8Chunks[1].length;
+      final utf8ContentType =
           new MediaType('text', 'plain', {'charset': UTF8.name});
-      MultipartFile utf8File = new MultipartFile(utf8Stream, utf8Size,
+      final utf8File = new MultipartFile(utf8Stream, utf8Size,
           contentType: utf8ContentType, filename: 'utf8-file');
 
       // LATIN1-encoded file.
-      List<List<int>> latin1Chunks = [
+      final latin1Chunks = <List<int>>[
         LATIN1.encode('chunk1'),
         LATIN1.encode('ç®å')
       ];
-      Stream<List<int>> latin1Stream = new Stream.fromIterable(latin1Chunks);
-      int latin1Size = latin1Chunks[0].length + latin1Chunks[1].length;
-      MediaType latin1ContentType =
+      final latin1Stream = new Stream.fromIterable(latin1Chunks);
+      final latin1Size = latin1Chunks[0].length + latin1Chunks[1].length;
+      final latin1ContentType =
           new MediaType('text', 'plain', {'charset': LATIN1.name});
-      MultipartFile latin1File = new MultipartFile(latin1Stream, latin1Size,
+      final latin1File = new MultipartFile(latin1Stream, latin1Size,
           contentType: latin1ContentType, filename: 'latin1-file');
 
       // ASCII-encoded file.
-      List<List<int>> asciiChunks = [
+      final asciiChunks = <List<int>>[
         ASCII.encode('chunk1'),
         ASCII.encode('chunk2')
       ];
-      Stream<List<int>> asciiStream = new Stream.fromIterable(asciiChunks);
-      int asciiSize = asciiChunks[0].length + asciiChunks[1].length;
-      MediaType asciiContentType =
+      final asciiStream = new Stream.fromIterable(asciiChunks);
+      final asciiSize = asciiChunks[0].length + asciiChunks[1].length;
+      final asciiContentType =
           new MediaType('text', 'plain', {'charset': ASCII.name});
-      MultipartFile asciiFile = new MultipartFile(asciiStream, asciiSize,
+      final asciiFile = new MultipartFile(asciiStream, asciiSize,
           contentType: asciiContentType, filename: 'ascii-file');
 
-      MultipartRequest request = new MultipartRequest()
+      final request = new MultipartRequest()
         ..uri = IntegrationPaths.uploadEndpointUri
         ..files['utf8File'] = utf8File
         ..files['latin1File'] = latin1File

--- a/test/integration/http/multipart_request/vm_test.dart
+++ b/test/integration/http/multipart_request/vm_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,14 +37,14 @@ void main() {
     runMultipartRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      MultipartRequest request = new MultipartRequest()
+      final request = new MultipartRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..fields['field'] = 'value';
       request.configure((request) async {
         HttpClientRequest ioRequest = request;
         ioRequest.headers.set('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/integration/http/plain_text_request/browser_test.dart
+++ b/test/integration/http/plain_text_request/browser_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,19 +37,18 @@ void main() {
     runPlainTextRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      Request request = new Request()
-        ..uri = IntegrationPaths.reflectEndpointUri;
+      final request = new Request()..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpRequest xhr = request;
         xhr.setRequestHeader('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
 
     group('withCredentials', () {
       test('set to true (Request)', () async {
-        Request request = new Request()
+        final request = new Request()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = true;
         request.configure((request) async {
@@ -60,7 +59,7 @@ void main() {
       });
 
       test('set to false (Request)', () async {
-        Request request = new Request()
+        final request = new Request()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = false;
         request.configure((request) async {

--- a/test/integration/http/plain_text_request/mock_test.dart
+++ b/test/integration/http/plain_text_request/mock_test.dart
@@ -24,7 +24,7 @@ import '../mock_endpoints/reflect.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/plain_text_request/suite.dart
+++ b/test/integration/http/plain_text_request/suite.dart
@@ -23,73 +23,73 @@ import '../../integration_paths.dart';
 void runPlainTextRequestSuite() {
   group('Request', () {
     test('contentLength should be set automatically', () async {
-      Request emptyRequest = new Request();
-      Response response =
+      final emptyRequest = new Request();
+      final response =
           await emptyRequest.post(uri: IntegrationPaths.reflectEndpointUri);
-      var contentLength =
+      final contentLength =
           int.parse(response.body.asJson()['headers']['content-length']);
       expect(contentLength, equals(0),
           reason: 'Empty plain-text request\'s content-length should be 0.');
 
-      Request nonEmptyRequest = new Request()
+      final nonEmptyRequest = new Request()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = 'data';
-      response = await nonEmptyRequest.post();
-      contentLength =
-          int.parse(response.body.asJson()['headers']['content-length']);
-      expect(contentLength, greaterThan(0),
+      final response2 = await nonEmptyRequest.post();
+      final contentLength2 =
+          int.parse(response2.body.asJson()['headers']['content-length']);
+      expect(contentLength2, greaterThan(0),
           reason:
               'Non-empty plain-text request\'s content-length should be greater than 0.');
     });
 
     test('content-type should be set automatically', () async {
-      Request request = new Request()
+      final request = new Request()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = 'data';
-      Response response = await request.post();
-      MediaType contentType = new MediaType.parse(
+      final response = await request.post();
+      final contentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(contentType.mimeType, equals('text/plain'));
     });
 
     test('content-type should be overridable', () async {
-      var contentType = new MediaType('application', 'x-custom');
-      Request request = new Request()
+      final contentType = new MediaType('application', 'x-custom');
+      final request = new Request()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = 'data'
         ..contentType = contentType;
-      Response response = await request.post();
-      var reflectedContentType = new MediaType.parse(
+      final response = await request.post();
+      final reflectedContentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(reflectedContentType.mimeType, equals(contentType.mimeType));
     });
 
     test('UTF8', () async {
-      Request request = new Request()
+      final request = new Request()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = UTF8
         ..body = 'dataç®å';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(UTF8.name));
       expect(response.body.asString(), equals('dataç®å'));
     });
 
     test('LATIN1', () async {
-      Request request = new Request()
+      final request = new Request()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = LATIN1
         ..body = 'dataç®å';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(LATIN1.name));
       expect(response.body.asString(), equals('dataç®å'));
     });
 
     test('ASCII', () async {
-      Request request = new Request()
+      final request = new Request()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = ASCII
         ..body = 'data';
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(ASCII.name));
       expect(response.body.asString(), equals('data'));
     });

--- a/test/integration/http/plain_text_request/vm_test.dart
+++ b/test/integration/http/plain_text_request/vm_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,13 +37,12 @@ void main() {
     runPlainTextRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      Request request = new Request()
-        ..uri = IntegrationPaths.reflectEndpointUri;
+      final request = new Request()..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpClientRequest ioRequest = request;
         ioRequest.headers.set('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/integration/http/streamed_request/browser_test.dart
+++ b/test/integration/http/streamed_request/browser_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,19 +37,19 @@ void main() {
     runStreamedRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpRequest xhr = request;
         xhr.setRequestHeader('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
 
     group('withCredentials', () {
       test('set to true (StreamedRequest)', () async {
-        StreamedRequest request = new StreamedRequest()
+        final request = new StreamedRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = true;
         request.configure((request) async {
@@ -60,7 +60,7 @@ void main() {
       });
 
       test('set to false (StreamedRequest)', () async {
-        StreamedRequest request = new StreamedRequest()
+        final request = new StreamedRequest()
           ..uri = IntegrationPaths.pingEndpointUri
           ..withCredentials = false;
         request.configure((request) async {

--- a/test/integration/http/streamed_request/mock_test.dart
+++ b/test/integration/http/streamed_request/mock_test.dart
@@ -24,7 +24,7 @@ import '../mock_endpoints/reflect.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicHttp;

--- a/test/integration/http/streamed_request/suite.dart
+++ b/test/integration/http/streamed_request/suite.dart
@@ -24,18 +24,18 @@ import '../../integration_paths.dart';
 void runStreamedRequestSuite() {
   group('StreamedRequest', () {
     test('contentLength should NOT be set automatically', () async {
-      StreamedRequest emptyRequest = new StreamedRequest()
+      final emptyRequest = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..contentLength = 0;
-      Response response =
+      final response =
           await emptyRequest.post(uri: IntegrationPaths.reflectEndpointUri);
-      var contentLength =
+      final contentLength =
           int.parse(response.body.asJson()['headers']['content-length']);
       expect(contentLength, equals(0),
           reason:
               'Empty streamed plain-text request\'s content-length should be 0.');
 
-      List<List<int>> chunks = [
+      final chunks = <List<int>>[
         UTF8.encode('chunk1'),
         UTF8.encode('chunk2'),
         UTF8.encode('chunk3')
@@ -44,68 +44,68 @@ void runStreamedRequestSuite() {
       chunks.forEach((chunk) {
         size += chunk.length;
       });
-      StreamedRequest nonEmptyRequest = new StreamedRequest()
+      final nonEmptyRequest = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = new Stream.fromIterable(chunks)
         ..contentLength = size;
-      response = await nonEmptyRequest.post();
-      contentLength =
-          int.parse(response.body.asJson()['headers']['content-length']);
-      expect(contentLength, equals(size),
+      final response2 = await nonEmptyRequest.post();
+      final contentLength2 =
+          int.parse(response2.body.asJson()['headers']['content-length']);
+      expect(contentLength2, equals(size),
           reason:
               'Non-empty streamed plain-text request\'s content-length should be greater than 0.');
     });
 
     test('content-type should be set automatically', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = new Stream.fromIterable([])
         ..contentLength = 0;
-      Response response = await request.post();
-      MediaType contentType = new MediaType.parse(
+      final response = await request.post();
+      final contentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(contentType.mimeType, equals('text/plain'));
     });
 
     test('content-type should be overridable', () async {
-      var contentType = new MediaType('application', 'x-custom');
-      StreamedRequest request = new StreamedRequest()
+      final contentType = new MediaType('application', 'x-custom');
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri
         ..body = new Stream.fromIterable([])
         ..contentLength = 0
         ..contentType = contentType;
-      Response response = await request.post();
-      var reflectedContentType = new MediaType.parse(
+      final response = await request.post();
+      final reflectedContentType = new MediaType.parse(
           response.body.asJson()['headers']['content-type']);
       expect(reflectedContentType.mimeType, equals(contentType.mimeType));
     });
 
     test('UTF8', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = UTF8
         ..body = new Stream.fromIterable([UTF8.encode('dataç®å')]);
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(UTF8.name));
       expect(response.body.asString(), equals('dataç®å'));
     });
 
     test('LATIN1', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = LATIN1
         ..body = new Stream.fromIterable([LATIN1.encode('dataç®å')]);
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(LATIN1.name));
       expect(response.body.asString(), equals('dataç®å'));
     });
 
     test('ASCII', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.echoEndpointUri
         ..encoding = ASCII
         ..body = new Stream.fromIterable([ASCII.encode('data')]);
-      Response response = await request.post();
+      final response = await request.post();
       expect(response.encoding.name, equals(ASCII.name));
       expect(response.body.asString(), equals('data'));
     });

--- a/test/integration/http/streamed_request/vm_test.dart
+++ b/test/integration/http/streamed_request/vm_test.dart
@@ -24,7 +24,7 @@ import '../../integration_paths.dart';
 import 'suite.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicHttp;
@@ -37,13 +37,13 @@ void main() {
     runStreamedRequestSuite();
 
     test('underlying HttpRequest configuration', () async {
-      StreamedRequest request = new StreamedRequest()
+      final request = new StreamedRequest()
         ..uri = IntegrationPaths.reflectEndpointUri;
       request.configure((request) async {
         HttpClientRequest ioRequest = request;
         ioRequest.headers.set('x-configured', 'true');
       });
-      Response response = await request.get();
+      final response = await request.get();
       expect(response.body.asJson()['headers']['x-configured'], equals('true'));
     });
   });

--- a/test/integration/platforms/browser_platform_test.dart
+++ b/test/integration/platforms/browser_platform_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/src/http/browser/requests.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicPlatformAdapter;

--- a/test/integration/platforms/mock_platform_test.dart
+++ b/test/integration/platforms/mock_platform_test.dart
@@ -24,7 +24,7 @@ import 'package:w_transport/src/web_socket/mock/w_socket.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicPlatformAdapter;
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('newWSocket()', () async {
-      Uri wsUri = Uri.parse('ws://test/ws');
+      final wsUri = Uri.parse('ws://test/ws');
       MockTransports.webSocket.expect(wsUri, connectTo: new MockWSocket());
       expect(await WSocket.connect(wsUri), new isInstanceOf<MockWSocket>());
     });

--- a/test/integration/platforms/platform_adapter_test.dart
+++ b/test/integration/platforms/platform_adapter_test.dart
@@ -20,7 +20,7 @@ import 'package:w_transport/src/platform_adapter.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeIntegration
     ..topic = topicPlatformAdapter;
 

--- a/test/integration/platforms/vm_platform_test.dart
+++ b/test/integration/platforms/vm_platform_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/src/http/vm/requests.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicPlatformAdapter;

--- a/test/integration/ws/browser_test.dart
+++ b/test/integration/ws/browser_test.dart
@@ -25,7 +25,7 @@ import '../integration_paths.dart';
 import 'common.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
@@ -38,28 +38,28 @@ void main() {
     runCommonWebSocketIntegrationTests();
 
     test('should support Blob', () async {
-      Blob blob = new Blob(['one', 'two']);
-      WSocket socket = await WSocket.connect(IntegrationPaths.echoUri);
+      final blob = new Blob(['one', 'two']);
+      final socket = await WSocket.connect(IntegrationPaths.echoUri);
       socket.add(blob);
       await socket.close();
     });
 
     test('should support String', () async {
-      String data = 'data';
-      WSocket socket = await WSocket.connect(IntegrationPaths.echoUri);
+      final data = 'data';
+      final socket = await WSocket.connect(IntegrationPaths.echoUri);
       socket.add(data);
       await socket.close();
     });
 
     test('should support TypedData', () async {
-      TypedData data = new Uint16List.fromList([1, 2, 3]);
-      WSocket socket = await WSocket.connect(IntegrationPaths.echoUri);
+      final data = new Uint16List.fromList([1, 2, 3]);
+      final socket = await WSocket.connect(IntegrationPaths.echoUri);
       socket.add(data);
       await socket.close();
     });
 
     test('should throw when attempting to send invalid data', () async {
-      WSocket socket = await WSocket.connect(IntegrationPaths.pingUri);
+      final socket = await WSocket.connect(IntegrationPaths.pingUri);
       expect(() {
         socket.add(true);
       }, throwsArgumentError);

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -24,10 +24,10 @@ void runCommonWebSocketIntegrationTests(
   if (connect == null) {
     connect = (uri) => WSocket.connect(uri);
   }
-  var closeUri = IntegrationPaths.closeUri;
-  var echoUri = IntegrationPaths.echoUri;
-  var fourOhFourUri = IntegrationPaths.fourOhFourUri;
-  var pingUri = IntegrationPaths.pingUri;
+  Uri closeUri = IntegrationPaths.closeUri;
+  Uri echoUri = IntegrationPaths.echoUri;
+  final fourOhFourUri = IntegrationPaths.fourOhFourUri;
+  Uri pingUri = IntegrationPaths.pingUri;
   if (port != null) {
     closeUri = closeUri.replace(port: port);
     echoUri = echoUri.replace(port: port);
@@ -40,8 +40,8 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('add() should send a message', () async {
-    var webSocket = await connect(echoUri);
-    var helper = new WSHelper(webSocket);
+    final webSocket = await connect(echoUri);
+    final helper = new WSHelper(webSocket);
 
     webSocket.add('message');
     await helper.messagesReceived(1);
@@ -50,8 +50,8 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('add() should support sending multiple messages', () async {
-    var webSocket = await connect(echoUri);
-    var helper = new WSHelper(webSocket);
+    final webSocket = await connect(echoUri);
+    final helper = new WSHelper(webSocket);
 
     webSocket.add('message1');
     webSocket.add('message2');
@@ -61,7 +61,7 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('add() should throw after sink has been closed', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     await webSocket.close();
     expect(() {
       webSocket.add('too late');
@@ -70,11 +70,11 @@ void runCommonWebSocketIntegrationTests(
 
   test('addError() should close the socket with an error that can be caught',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     webSocket.addError(
         new Exception('Exception should close the socket with an error.'));
 
-    var error;
+    Object error;
     try {
       await webSocket.done;
     } catch (e) {
@@ -86,10 +86,10 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('addStream() should send a Stream of data', () async {
-    var webSocket = await connect(echoUri);
-    var helper = new WSHelper(webSocket);
+    final webSocket = await connect(echoUri);
+    final helper = new WSHelper(webSocket);
 
-    var stream = new Stream.fromIterable(['message1', 'message2']);
+    final stream = new Stream.fromIterable(['message1', 'message2']);
     await webSocket.addStream(stream);
     await helper.messagesReceived(2);
     expect(helper.messages, unorderedEquals(['message1', 'message2']));
@@ -98,11 +98,11 @@ void runCommonWebSocketIntegrationTests(
 
   test('addStream() should support sending multiple Streams serially',
       () async {
-    var webSocket = await connect(echoUri);
-    var helper = new WSHelper(webSocket);
+    final webSocket = await connect(echoUri);
+    final helper = new WSHelper(webSocket);
 
-    var stream1 = new Stream.fromIterable(['message1a', 'message2a']);
-    var stream2 = new Stream.fromIterable(['message1b', 'message2b']);
+    final stream1 = new Stream.fromIterable(['message1a', 'message2a']);
+    final stream2 = new Stream.fromIterable(['message1b', 'message2b']);
     await webSocket.addStream(stream1);
     await webSocket.addStream(stream2);
     await helper.messagesReceived(4);
@@ -113,11 +113,11 @@ void runCommonWebSocketIntegrationTests(
 
   test('addStream() should throw if multiple Streams added concurrently',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
-    var stream = new Stream.fromIterable(['message1', 'message2']);
-    var firstFuture = webSocket.addStream(stream);
-    var lateFuture = webSocket.addStream(stream);
+    final stream = new Stream.fromIterable(['message1', 'message2']);
+    final firstFuture = webSocket.addStream(stream);
+    final lateFuture = webSocket.addStream(stream);
     expect(lateFuture, throwsStateError);
     await firstFuture;
     try {
@@ -129,15 +129,15 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('addStream() should throw after sink has been closed', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     await webSocket.close();
     expect(webSocket.addStream(new Stream.fromIterable(['too late'])),
         throwsStateError);
   });
 
   test('addStream() should cause socket to close if error is added', () async {
-    var webSocket = await connect(echoUri);
-    var controller = new StreamController();
+    final webSocket = await connect(echoUri);
+    final controller = new StreamController<dynamic>();
     controller.add('message1');
     controller.addError(new Exception('addStream error, should close socket'));
     await webSocket.addStream(controller.stream);
@@ -145,8 +145,8 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should support listening to incoming messages', () async {
-    var webSocket = await connect(pingUri);
-    var helper = new WSHelper(webSocket);
+    final webSocket = await connect(pingUri);
+    final helper = new WSHelper(webSocket);
 
     webSocket.add('ping2');
     await helper.messagesReceived(2);
@@ -156,7 +156,7 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should not allow multiple listeners by default', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     webSocket.listen((_) {});
     expect(() {
       webSocket.listen((_) {});
@@ -165,12 +165,12 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should lose messages if a listener is registered late', () async {
-    var webSocket = await connect(pingUri);
+    final webSocket = await connect(pingUri);
     // First two pings should be lost because no listener has been registered.
     webSocket.add('ping2');
 
     await new Future.delayed(new Duration(milliseconds: 200));
-    var helper = new WSHelper(webSocket);
+    final helper = new WSHelper(webSocket);
 
     // Next round of pings should now be received.
     webSocket.add('ping3');
@@ -182,9 +182,9 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should call onDone() when socket closes', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
-    Completer c = new Completer();
+    final c = new Completer<Null>();
     webSocket.listen((_) {}, onDone: () {
       c.complete();
     });
@@ -197,9 +197,9 @@ void runCommonWebSocketIntegrationTests(
 
   test('should have the close code and reason available in onDone() callback',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
-    Completer c = new Completer();
+    final c = new Completer<Null>();
     webSocket.listen((_) {}, onDone: () {
       expect(webSocket.closeCode, equals(4001));
       expect(webSocket.closeReason, equals('Closed.'));
@@ -217,11 +217,11 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should work as a broadcast stream', () async {
-    var webSocket = await connect(pingUri);
-    Stream stream = webSocket.asBroadcastStream();
+    final webSocket = await connect(pingUri);
+    final stream = webSocket.asBroadcastStream();
 
-    Completer c1 = new Completer();
-    Completer c2 = new Completer();
+    final c1 = new Completer<Null>();
+    final c2 = new Completer<Null>();
 
     stream.listen((_) {
       c1.complete();
@@ -238,7 +238,7 @@ void runCommonWebSocketIntegrationTests(
 
   test('should have the close code and reason available after closing',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     await webSocket.close(4001, 'Closed.');
     expect(webSocket.closeCode, equals(4001));
     expect(webSocket.closeReason, equals('Closed.'));
@@ -247,12 +247,12 @@ void runCommonWebSocketIntegrationTests(
   test(
       'should close and properly drain stream even if no listeners were registered',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     await webSocket.close();
   });
 
   test('should handle the server closing the connection', () async {
-    var webSocket = await connect(closeUri);
+    final webSocket = await connect(closeUri);
     webSocket.add(_closeRequest());
     await webSocket.done;
   });
@@ -260,7 +260,7 @@ void runCommonWebSocketIntegrationTests(
   test(
       'should ignore close() being called after the server closes the connection',
       () async {
-    var webSocket = await connect(closeUri);
+    final webSocket = await connect(closeUri);
     webSocket.add(_closeRequest(4001, 'Closed by server.'));
     await webSocket.done;
     await webSocket.close(4002, 'Late close.');
@@ -269,7 +269,7 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should ignore close() calls after the first', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
     await webSocket.close(4001, 'Custom close.');
     await webSocket.close(4002, 'Late close.');
     expect(webSocket.closeCode, equals(4001));
@@ -279,7 +279,7 @@ void runCommonWebSocketIntegrationTests(
   test(
       'should report the close code and reason that the server used when closing the connection',
       () async {
-    var socket = await connect(closeUri);
+    final socket = await connect(closeUri);
     socket.add(_closeRequest(4001, 'Closed by server.'));
     await socket.done;
     expect(socket.closeCode, equals(4001));
@@ -287,13 +287,13 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('message events should be discarded prior to a subscription', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
     webSocket.add('1');
     webSocket.add('2');
     await new Future.delayed(new Duration(milliseconds: 200));
 
-    var messages = [];
+    final messages = <String>[];
     webSocket.listen((data) {
       messages.add(data);
     });
@@ -309,9 +309,9 @@ void runCommonWebSocketIntegrationTests(
   test(
       'the first event should be received if a subscription is made immediately',
       () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
-    var c = new Completer();
+    final c = new Completer<String>();
     webSocket.listen((data) {
       c.complete(data);
     });
@@ -323,15 +323,15 @@ void runCommonWebSocketIntegrationTests(
 
   test('all event streams should respect pause() and resume() signals',
       () async {
-    var webSocket = await connect(echoUri);
-    var messages = [];
+    final webSocket = await connect(echoUri);
+    final messages = <String>[];
 
     // no subscription yet, messages should be discarded
     webSocket.add('1');
     await new Future.delayed(new Duration(milliseconds: 200));
 
     // setup a subscription, messages should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       messages.add(data);
     });
     webSocket.add('2');
@@ -354,11 +354,11 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should support calling pause() with a resume signal', () async {
-    var webSocket = await connect(echoUri);
-    var messages = [];
+    final webSocket = await connect(echoUri);
+    final messages = <String>[];
 
     // setup a subscription, messages should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       messages.add(data);
     });
     webSocket.add('1');
@@ -366,7 +366,7 @@ void runCommonWebSocketIntegrationTests(
 
     // pause the subscription, messages should be discarded until the resume
     // signal future resolves.
-    var c = new Completer();
+    final c = new Completer<Null>();
     sub.pause(c.future);
     await new Future.delayed(new Duration(milliseconds: 200));
     webSocket.add('2');
@@ -385,11 +385,11 @@ void runCommonWebSocketIntegrationTests(
   test(
       'should support calling pause() with a resume signal even if it resolves with an error',
       () async {
-    var webSocket = await connect(echoUri);
-    var messages = [];
+    final webSocket = await connect(echoUri);
+    final messages = <String>[];
 
     // setup a subscription, messages should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       messages.add(data);
     });
     webSocket.add('1');
@@ -397,7 +397,7 @@ void runCommonWebSocketIntegrationTests(
 
     // pause the subscription, messages should be discarded until the resume
     // signal future resolves.
-    var c = new Completer();
+    final c = new Completer<Null>();
     sub.pause(c.future);
     await new Future.delayed(new Duration(milliseconds: 200));
     webSocket.add('2');
@@ -414,11 +414,11 @@ void runCommonWebSocketIntegrationTests(
   }, skip: 'Can\'t test without the exception causing the test to fail.');
 
   test('should handle calling pause() multiple times', () async {
-    var webSocket = await connect(echoUri);
-    var messages = [];
+    final webSocket = await connect(echoUri);
+    final messages = <String>[];
 
     // setup a subscription, messages should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       messages.add(data);
     });
     webSocket.add('1');
@@ -448,28 +448,28 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should support converting StreamSubscription to a Future', () async {
-    var webSocket = await connect(pingUri);
-    var sub = webSocket.listen((_) {});
-    var future = sub.asFuture('futureValue');
+    final webSocket = await connect(pingUri);
+    final sub = webSocket.listen((_) {});
+    final future = sub.asFuture('futureValue');
     // ignore: unawaited_futures
     webSocket.close();
     expect(await future, equals('futureValue'));
   });
 
   test('should support reassigning the onData() handler', () async {
-    var webSocket = await connect(echoUri);
+    final webSocket = await connect(echoUri);
 
-    var origMessages = [];
-    var origOnData = (data) {
+    final origMessages = <String>[];
+    final origOnData = (data) {
       origMessages.add(data);
     };
 
-    var newMessages = [];
-    var newOnData = (data) {
+    final newMessages = <String>[];
+    final newOnData = (data) {
       newMessages.add(data);
     };
 
-    var subscription = webSocket.listen(origOnData);
+    final subscription = webSocket.listen(origOnData);
     webSocket.add('1');
     webSocket.add('2');
     // SockJS requires a delay longer than 1 tick for the echos to be received.
@@ -487,9 +487,9 @@ void runCommonWebSocketIntegrationTests(
   });
 
   test('should support reassigning the onDone() handler', () async {
-    var webSocket = await connect(closeUri);
-    var c = new Completer();
-    var subscription = webSocket.listen((_) {}, onDone: () {});
+    final webSocket = await connect(closeUri);
+    final c = new Completer<Null>();
+    final subscription = webSocket.listen((_) {}, onDone: () {});
     subscription.onDone(() {
       c.complete();
     });
@@ -499,7 +499,7 @@ void runCommonWebSocketIntegrationTests(
 }
 
 String _closeRequest([int closeCode, String closeReason]) {
-  var c = 'close';
+  String c = 'close';
   if (closeCode != null) {
     c = '$c:$closeCode';
     if (closeReason != null) {
@@ -511,7 +511,7 @@ String _closeRequest([int closeCode, String closeReason]) {
 
 class WSHelper {
   WSocket socket;
-  Map<int, Completer> _completers = {};
+  Map<int, Completer<Null>> _completers = {};
   List<String> _messages = [];
 
   WSHelper(this.socket) {
@@ -527,10 +527,10 @@ class WSHelper {
 
   Iterable<String> get messages => _messages;
 
-  Future messagesReceived(int numMessages) async {
+  Future<Null> messagesReceived(int numMessages) async {
     if (_messages.length >= numMessages) return;
 
-    Completer c = new Completer();
+    final c = new Completer<Null>();
     _completers[numMessages] = c;
     await c.future;
   }

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -23,7 +23,7 @@ import '../integration_paths.dart';
 import 'common.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformMock
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
@@ -39,13 +39,13 @@ void main() {
 
       MockTransports.webSocket.when(IntegrationPaths.closeUri,
           handler: (Uri uri, {protocols, headers}) async {
-        MockWSocket webSocket = new MockWSocket();
+        final webSocket = new MockWSocket();
 
         webSocket.onOutgoing((data) {
           if (data.startsWith('close')) {
-            var parts = data.split(':');
-            var closeCode;
-            var closeReason;
+            final parts = data.split(':');
+            int closeCode;
+            String closeReason;
             if (parts.length >= 2) {
               closeCode = int.parse(parts[1]);
             }
@@ -61,18 +61,18 @@ void main() {
 
       MockTransports.webSocket.when(IntegrationPaths.echoUri,
           handler: (Uri uri, {protocols, headers}) async {
-        MockWSocket webSocket = new MockWSocket();
+        final webSocket = new MockWSocket();
         webSocket.onOutgoing(webSocket.addIncoming);
         return webSocket;
       });
 
       MockTransports.webSocket.when(IntegrationPaths.pingUri,
           handler: (Uri uri, {protocols, headers}) async {
-        MockWSocket webSocket = new MockWSocket();
+        final webSocket = new MockWSocket();
 
         webSocket.onOutgoing((data) async {
           data = data.replaceAll('ping', '');
-          var numPongs = 1;
+          int numPongs = 1;
           try {
             numPongs = int.parse(data);
           } catch (_) {}

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -28,22 +28,22 @@ import 'common.dart';
 const int sockjsPort = 8026;
 
 void main() {
-  Naming wsNaming = new Naming()
+  final wsNaming = new Naming()
     ..platform = platformBrowserSockjsWS
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
 
-  Naming xhrNaming = new Naming()
+  final xhrNaming = new Naming()
     ..platform = platformBrowserSockjsXhr
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
 
-  Naming wsDeprecatedNaming = new Naming()
+  final wsDeprecatedNaming = new Naming()
     ..platform = platformBrowserSockjsWSDeprecated
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
 
-  Naming xhrDeprecatedNaming = new Naming()
+  final xhrDeprecatedNaming = new Naming()
     ..platform = platformBrowserSockjsXhrDeprecated
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
@@ -96,12 +96,12 @@ void main() {
 void sockJSSuite(Future<WSocket> connect(Uri uri)) {
   runCommonWebSocketIntegrationTests(connect: connect, port: sockjsPort);
 
-  var echoUri = IntegrationPaths.echoUri.replace(port: sockjsPort);
-  var pingUri = IntegrationPaths.pingUri.replace(port: sockjsPort);
+  final echoUri = IntegrationPaths.echoUri.replace(port: sockjsPort);
+  final pingUri = IntegrationPaths.pingUri.replace(port: sockjsPort);
 
   test('should not support Blob', () async {
-    Blob blob = new Blob(['one', 'two']);
-    WSocket socket = await connect(pingUri);
+    final blob = new Blob(['one', 'two']);
+    final socket = await connect(pingUri);
     expect(() {
       socket.add(blob);
     }, throwsArgumentError);
@@ -109,15 +109,15 @@ void sockJSSuite(Future<WSocket> connect(Uri uri)) {
   });
 
   test('should support String', () async {
-    String data = 'data';
-    WSocket socket = await connect(echoUri);
+    final data = 'data';
+    final socket = await connect(echoUri);
     socket.add(data);
     await socket.close();
   });
 
   test('should not support TypedData', () async {
-    TypedData data = new Uint16List.fromList([1, 2, 3]);
-    WSocket socket = await connect(echoUri);
+    final data = new Uint16List.fromList([1, 2, 3]);
+    final socket = await connect(echoUri);
     expect(() {
       socket.add(data);
     }, throwsArgumentError);
@@ -125,7 +125,7 @@ void sockJSSuite(Future<WSocket> connect(Uri uri)) {
   });
 
   test('should throw when attempting to send invalid data', () async {
-    WSocket socket = await connect(pingUri);
+    final socket = await connect(pingUri);
     expect(() {
       socket.add(true);
     }, throwsArgumentError);

--- a/test/integration/ws/vm_test.dart
+++ b/test/integration/ws/vm_test.dart
@@ -22,7 +22,7 @@ import '../integration_paths.dart';
 import 'common.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformVM
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
@@ -35,21 +35,21 @@ void main() {
     runCommonWebSocketIntegrationTests();
 
     test('should support List<int>', () async {
-      List<int> data = [1, 2, 3];
-      WSocket socket = await WSocket.connect(IntegrationPaths.echoUri);
+      final data = <int>[1, 2, 3];
+      final socket = await WSocket.connect(IntegrationPaths.echoUri);
       socket.add(data);
       await socket.close();
     });
 
     test('should support String', () async {
-      String data = 'data';
-      WSocket socket = await WSocket.connect(IntegrationPaths.echoUri);
+      final data = 'data';
+      final socket = await WSocket.connect(IntegrationPaths.echoUri);
       socket.add(data);
       await socket.close();
     });
 
     test('should throw when attempting to send invalid data', () async {
-      WSocket socket = await WSocket.connect(IntegrationPaths.pingUri);
+      final socket = await WSocket.connect(IntegrationPaths.pingUri);
       expect(() {
         socket.add(true);
       }, throwsArgumentError);

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -41,7 +41,7 @@ class Naming {
 
   @override
   String toString() {
-    var s = '$topic [$testType]';
+    String s = '$topic [$testType]';
     if (platform != null) {
       s += ' [$platform]';
     }

--- a/test/unit/http/backoff_test.dart
+++ b/test/unit/http/backoff_test.dart
@@ -27,7 +27,7 @@ import '../../naming.dart';
 void main() {
   configureWTransportForTest();
 
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeUnit
     ..topic = topicBackoff;
@@ -35,21 +35,21 @@ void main() {
   group(naming.toString(), () {
     group('ExponentialBackOff : ', () {
       test('deprecated `duration` should be forwarded to `interval`', () {
-        var interval = new Duration(seconds: 10);
-        var backOff = new RetryBackOff.exponential(interval);
+        final interval = new Duration(seconds: 10);
+        final backOff = new RetryBackOff.exponential(interval);
         expect(backOff.duration, equals(interval));
         expect(backOff.duration, equals(backOff.interval));
       });
 
       test('no jitter, maxInterval not exceeded', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        Duration maxInterval = new Duration(milliseconds: 400);
-        bool withJitter = false;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final maxInterval = new Duration(milliseconds: 400);
+        final withJitter = false;
         request.autoRetry.backOff = new RetryBackOff.exponential(interval,
             withJitter: withJitter, maxInterval: maxInterval);
 
-        for (var i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
           request.autoRetry.numAttempts = i;
 
           if (i == 0) {
@@ -65,14 +65,14 @@ void main() {
       });
 
       test('with jitter, maxInterval not exceeded', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        Duration maxInterval = new Duration(milliseconds: 400);
-        bool withJitter = true;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final maxInterval = new Duration(milliseconds: 400);
+        final withJitter = true;
         request.autoRetry.backOff = new RetryBackOff.exponential(interval,
             withJitter: withJitter, maxInterval: maxInterval);
 
-        for (var i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
           request.autoRetry.numAttempts = i;
 
           if (i == 0) {
@@ -88,14 +88,14 @@ void main() {
       });
 
       test('no jitter, maxInterval is exceeded', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        Duration maxInterval = new Duration(milliseconds: 20);
-        bool withJitter = false;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final maxInterval = new Duration(milliseconds: 20);
+        final withJitter = false;
         request.autoRetry.backOff = new RetryBackOff.exponential(interval,
             withJitter: withJitter, maxInterval: maxInterval);
 
-        for (var i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
           request.autoRetry.numAttempts = i;
 
           if (i == 0) {
@@ -112,14 +112,14 @@ void main() {
       });
 
       test('with jitter, maxInterval is exceeded', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        Duration maxInterval = new Duration(milliseconds: 20);
-        bool withJitter = true;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final maxInterval = new Duration(milliseconds: 20);
+        final withJitter = true;
         request.autoRetry.backOff = new RetryBackOff.exponential(interval,
             withJitter: withJitter, maxInterval: maxInterval);
 
-        for (var i = 0; i < 50; i++) {
+        for (int i = 0; i < 50; i++) {
           request.autoRetry.numAttempts = i;
 
           if (i == 0) {
@@ -142,20 +142,20 @@ void main() {
 
     group('FixedBackOff : ', () {
       test('deprecated `duration` should be forwarded to `interval`', () {
-        var interval = new Duration(seconds: 10);
-        var backOff = new RetryBackOff.fixed(interval);
+        final interval = new Duration(seconds: 10);
+        final backOff = new RetryBackOff.fixed(interval);
         expect(backOff.duration, equals(interval));
         expect(backOff.duration, equals(backOff.interval));
       });
 
       test('no jitter', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        bool withJitter = false;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final withJitter = false;
         request.autoRetry.backOff =
             new RetryBackOff.fixed(interval, withJitter: withJitter);
 
-        for (var i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
           request.autoRetry.numAttempts = i;
 
           if (i == 0) {
@@ -166,14 +166,14 @@ void main() {
       });
 
       test('with jitter', () async {
-        var request = new Request();
-        Duration interval = new Duration(milliseconds: 5);
-        bool withJitter = true;
+        final request = new Request();
+        final interval = new Duration(milliseconds: 5);
+        final withJitter = true;
         request.autoRetry.backOff =
             new RetryBackOff.fixed(interval, withJitter: withJitter);
 
-        for (var i = 0; i < 5; i++) {
-          int backoff =
+        for (int i = 0; i < 5; i++) {
+          final backoff =
               Backoff.calculateBackOff(request.autoRetry).inMilliseconds;
           expect(backoff, lessThanOrEqualTo(interval.inMilliseconds * 1.5));
           expect(backoff, greaterThanOrEqualTo(interval.inMilliseconds ~/ 2));
@@ -183,7 +183,7 @@ void main() {
 
     group('No Backoff', () {
       test('deprecated `duration` should be forwarded to `interval`', () {
-        var backOff = new RetryBackOff.none();
+        final backOff = new RetryBackOff.none();
         expect(backOff.duration, isNull);
         expect(backOff.duration, equals(backOff.interval));
       });

--- a/test/unit/http/browser_utils_test.dart
+++ b/test/unit/http/browser_utils_test.dart
@@ -25,7 +25,7 @@ import 'package:w_transport/src/http/browser/utils.dart'
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..platform = platformBrowser
     ..testType = testTypeUnit
     ..topic = topicHttp;
@@ -35,16 +35,16 @@ void main() {
       test(
           'should convert computable ProgressEvents to WProgress instances with correct values',
           () async {
-        var eventStream = new Stream<ProgressEvent>.fromIterable([
+        final eventStream = new Stream<ProgressEvent>.fromIterable([
           new MockProgressEvent.computable(0, 100),
           new MockProgressEvent.computable(10, 100),
           new MockProgressEvent.computable(50, 100),
           new MockProgressEvent.computable(73, 100),
           new MockProgressEvent.computable(100, 100),
         ]);
-        Stream<RequestProgress> requestProgressStream =
+        final requestProgressStream =
             eventStream.transform(transformProgressEvents);
-        List<RequestProgress> wEvents = await requestProgressStream.toList();
+        final wEvents = await requestProgressStream.toList();
         expect(wEvents[0].percent, equals(0.0));
         expect(wEvents[1].percent, equals(10.0));
         expect(wEvents[2].percent, equals(50.0));
@@ -55,24 +55,22 @@ void main() {
       test(
           'should convert non-computable ProgressEvents to WProgress instances with 0% values',
           () async {
-        var events = new Stream<ProgressEvent>.fromIterable([
+        final events = new Stream<ProgressEvent>.fromIterable([
           new MockProgressEvent.nonComputable(),
           new MockProgressEvent.nonComputable(),
         ]);
-        Stream<RequestProgress> wEventStream =
-            events.transform(transformProgressEvents);
-        List<RequestProgress> wEvents = await wEventStream.toList();
+        final wEventStream = events.transform(transformProgressEvents);
+        final wEvents = await wEventStream.toList();
         expect(wEvents[0].percent, equals(0.0));
         expect(wEvents[1].percent, equals(0.0));
       });
 
       test('should support pausing and resuming a subscription', () async {
-        StreamController<ProgressEvent> eventController =
-            new StreamController();
-        Stream<RequestProgress> wEventStream =
+        final eventController = new StreamController<ProgressEvent>();
+        final wEventStream =
             eventController.stream.transform(transformProgressEvents);
 
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         int eventCount = 0;
         StreamSubscription subscription = wEventStream.listen((_) {
           eventCount++;

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -32,7 +32,7 @@ abstract class ReqIntMixin implements HttpInterceptor {
 abstract class RespIntMixin implements HttpInterceptor {
   @override
   Future<ResponsePayload> interceptResponse(ResponsePayload payload) async {
-    var newHeaders = new Map<String, String>.from(payload.response.headers);
+    final newHeaders = new Map<String, String>.from(payload.response.headers);
     newHeaders['x-intercepted'] = 'true';
     Response response = payload.response;
     payload.response = new Response.fromString(payload.response.status,
@@ -58,7 +58,7 @@ class AsyncInt extends HttpInterceptor {
   @override
   Future<ResponsePayload> interceptResponse(ResponsePayload payload) async {
     await new Future.delayed(new Duration(milliseconds: 500));
-    var headers = new Map<String, String>.from(payload.response.headers);
+    final headers = new Map<String, String>.from(payload.response.headers);
     Response response = payload.response;
     headers['x-interceptor'] =
         payload.request.uri.queryParameters['interceptor'];
@@ -69,7 +69,7 @@ class AsyncInt extends HttpInterceptor {
 }
 
 Iterable<BaseRequest> createAllRequestTypes(Client client) {
-  return [
+  return <BaseRequest>[
     client.newFormRequest(),
     client.newJsonRequest(),
     client.newMultipartRequest(),
@@ -79,7 +79,7 @@ Iterable<BaseRequest> createAllRequestTypes(Client client) {
 }
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -152,25 +152,28 @@ void _runHttpClientSuite(Client getClient()) {
   });
 
   test('complete request', () async {
-    Uri uri = Uri.parse('/test');
+    final uri = Uri.parse('/test');
     MockTransports.http.expect('GET', uri);
     await client.newRequest().get(uri: uri);
   });
 
   test('baseUri should be inherited by all requests', () async {
-    var baseUri = Uri.parse('https://example.com/base/path');
+    final baseUri = Uri.parse('https://example.com/base/path');
     client.baseUri = baseUri;
-    for (var request in createAllRequestTypes(client)) {
+    for (final request in createAllRequestTypes(client)) {
       expect(request.uri, equals(baseUri));
     }
   });
 
   test('headers should be inherited by all requests', () async {
-    var headers = {'x-custom1': 'value', 'x-custom2': 'value2'};
+    final headers = <String, String>{
+      'x-custom1': 'value',
+      'x-custom2': 'value2'
+    };
     client.headers = headers;
     expect(client.headers, equals(headers));
-    for (var request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
       MockTransports.http.expect('GET', uri, headers: headers);
       if (request is MultipartRequest) {
         request.fields['f'] = 'v';
@@ -180,10 +183,10 @@ void _runHttpClientSuite(Client getClient()) {
   });
 
   test('timeoutThreshold should be inherited by all requests', () async {
-    Duration tt = new Duration(seconds: 1);
+    final tt = new Duration(seconds: 1);
     client.timeoutThreshold = tt;
     expect(client.timeoutThreshold, equals(tt));
-    for (var request in createAllRequestTypes(client)) {
+    for (final request in createAllRequestTypes(client)) {
       expect(request.timeoutThreshold, equals(tt));
     }
   });
@@ -191,9 +194,9 @@ void _runHttpClientSuite(Client getClient()) {
   test('withCredentials should be inherited by all requests', () async {
     client.withCredentials = true;
     expect(client.withCredentials, isTrue);
-    for (var request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
-      Completer c = new Completer();
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
+      final c = new Completer<Null>();
       MockTransports.http.when(uri, (FinalizedRequest request) async {
         request.withCredentials
             ? c.complete()
@@ -218,7 +221,7 @@ void _runHttpClientSuite(Client getClient()) {
       ..maxRetries = 4
       ..test = (request, response, willRetry) async => true;
 
-    for (var request in createAllRequestTypes(client)) {
+    for (final request in createAllRequestTypes(client)) {
       expect(request.autoRetry.backOff.interval,
           equals(client.autoRetry.backOff.interval));
       expect(request.autoRetry.backOff.method,
@@ -237,8 +240,8 @@ void _runHttpClientSuite(Client getClient()) {
 
   test('addInterceptor() single interceptor (request only)', () async {
     client.addInterceptor(new ReqInt());
-    for (BaseRequest request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
       MockTransports.http
           .expect('GET', uri, headers: {'x-intercepted': 'true'});
       if (request is MultipartRequest) {
@@ -250,50 +253,50 @@ void _runHttpClientSuite(Client getClient()) {
 
   test('addInterceptor() single interceptor (response only)', () async {
     client.addInterceptor(new RespInt());
-    for (BaseRequest request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
       MockTransports.http.expect('GET', uri);
       if (request is MultipartRequest) {
         request.fields['f'] = 'v';
       }
-      Response response = await request.get(uri: uri);
+      final response = await request.get(uri: uri);
       expect(response.headers, containsPair('x-intercepted', 'true'));
     }
   });
 
   test('addInterceptor() single interceptor', () async {
     client.addInterceptor(new ReqRespInt());
-    for (BaseRequest request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
       MockTransports.http
           .expect('GET', uri, headers: {'x-intercepted': 'true'});
       if (request is MultipartRequest) {
         request.fields['f'] = 'v';
       }
-      Response response = await request.get(uri: uri);
+      final response = await request.get(uri: uri);
       expect(response.headers, containsPair('x-intercepted', 'true'));
     }
   });
 
   test('addInterceptor() multiple interceptors', () async {
     client..addInterceptor(new ReqRespInt())..addInterceptor(new AsyncInt());
-    for (BaseRequest request in createAllRequestTypes(client)) {
-      Uri uri = Uri.parse('/test');
-      Uri augmentedUri =
+    for (final request in createAllRequestTypes(client)) {
+      final uri = Uri.parse('/test');
+      final augmentedUri =
           uri.replace(queryParameters: {'interceptor': 'asyncint'});
       MockTransports.http
           .expect('GET', augmentedUri, headers: {'x-intercepted': 'true'});
       if (request is MultipartRequest) {
         request.fields['f'] = 'v';
       }
-      Response response = await request.get(uri: uri);
+      final response = await request.get(uri: uri);
       expect(response.headers, containsPair('x-intercepted', 'true'));
       expect(response.headers, containsPair('x-interceptor', 'asyncint'));
     }
   });
 
   test('close()', () async {
-    Future future = client.newRequest().get(uri: Uri.parse('/test'));
+    final future = client.newRequest().get(uri: Uri.parse('/test'));
     client.close();
     expect(future, throws);
   });

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -34,17 +34,17 @@ void main() {
       });
 
       test('setting fields defaults to empty map if null', () {
-        FormRequest request = new FormRequest()..fields = null;
+        final request = new FormRequest()..fields = null;
         expect(request.fields, equals({}));
       });
 
       test('setting entire fields map', () {
-        FormRequest request = new FormRequest()..fields = {'field': 'value'};
+        final request = new FormRequest()..fields = {'field': 'value'};
         expect(request.fields, equals({'field': 'value'}));
       });
 
       test('setting fields incrementally', () {
-        FormRequest request = new FormRequest()
+        final request = new FormRequest()
           ..fields['field1'] = 'value1'
           ..fields['field2'] = 'value2';
         expect(
@@ -52,32 +52,32 @@ void main() {
       });
 
       test('setting body in request dispatcher is supported', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
           return new MockResponse.ok();
         });
 
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         await request.post(uri: uri, body: {'field': 'value'});
         expect(await c.future, equals('field=value'));
       });
 
       test('setting body in request dispatcher should throw if invalid',
           () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         expect(request.post(uri: uri, body: 'invalid'), throws);
       });
 
       test('body should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         await request.post(uri: uri);
         expect(() {
           request.fields['too'] = 'late';
@@ -88,21 +88,21 @@ void main() {
       });
 
       test('content-length cannot be set manually', () {
-        Request request = new Request();
+        final request = new Request();
         expect(() {
           request.contentLength = 10;
         }, throwsUnsupportedError);
       });
 
       test('setting encoding to null should throw', () {
-        var request = new FormRequest();
+        final request = new FormRequest();
         expect(() {
           request.encoding = null;
         }, throwsArgumentError);
       });
 
       test('setting encoding should update content-type', () {
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         request.encoding = LATIN1;
@@ -115,7 +115,7 @@ void main() {
       test(
           'setting encoding should not update content-type if content-type has been set manually',
           () {
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         // Manually override content-type.
@@ -130,9 +130,9 @@ void main() {
       });
 
       test('setting content-type should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         await request.get(uri: uri);
         expect(() {
           request.contentType = new MediaType('application', 'x-custom');
@@ -140,9 +140,9 @@ void main() {
       });
 
       test('setting encoding should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        FormRequest request = new FormRequest();
+        final request = new FormRequest();
         await request.get(uri: uri);
         expect(() {
           request.encoding = LATIN1;
@@ -150,18 +150,18 @@ void main() {
       });
 
       test('custom content-type without inferrable encoding', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        var request = new FormRequest()
+        final request = new FormRequest()
           ..contentType = new MediaType('application', 'x-custom')
           ..fields['foo'] = 'bar';
         await request.post(uri: uri);
       });
 
       test('clone()', () {
-        var fields = {'f1': 'v1', 'f2': 'v2'};
-        FormRequest orig = new FormRequest()..fields = fields;
-        FormRequest clone = orig.clone();
+        final fields = <String, String>{'f1': 'v1', 'f2': 'v2'};
+        final orig = new FormRequest()..fields = fields;
+        final clone = orig.clone();
         expect(clone.fields, equals(fields));
       });
     });

--- a/test/unit/http/http_body_test.dart
+++ b/test/unit/http/http_body_test.dart
@@ -22,158 +22,159 @@ import 'package:w_transport/w_transport.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('HttpBody', () {
       test('.fromBytes() ctor should default to empty list', () {
-        MediaType contentType = new MediaType('text', 'plain');
-        HttpBody body = new HttpBody.fromBytes(contentType, null);
+        final contentType = new MediaType('text', 'plain');
+        final body = new HttpBody.fromBytes(contentType, null);
         expect(body.asBytes(), isEmpty);
       });
 
       test('should use encoding if one is explicitly given', () {
-        var contentType = new MediaType('text', 'plain');
+        final contentType = new MediaType('text', 'plain');
 
-        var stringBody =
+        final stringBody =
             new HttpBody.fromString(contentType, 'body', encoding: ASCII);
         expect(stringBody.encoding, equals(ASCII));
 
-        var bytesBody = new HttpBody.fromBytes(contentType, UTF8.encode('body'),
+        final bytesBody = new HttpBody.fromBytes(
+            contentType, UTF8.encode('body'),
             encoding: ASCII);
         expect(bytesBody.encoding, equals(ASCII));
       });
 
       test('should parse encoding from content-type', () {
-        var contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': ASCII.name});
 
-        var stringBody = new HttpBody.fromString(contentType, 'body');
+        final stringBody = new HttpBody.fromString(contentType, 'body');
         expect(stringBody.encoding, equals(ASCII));
 
-        var bytesBody =
+        final bytesBody =
             new HttpBody.fromBytes(contentType, UTF8.encode('body'));
         expect(bytesBody.encoding, equals(ASCII));
       });
 
       test('should allow a fallback encoding', () {
-        var contentType = new MediaType('text', 'plain');
+        final contentType = new MediaType('text', 'plain');
 
-        var stringBody = new HttpBody.fromString(contentType, 'body',
+        final stringBody = new HttpBody.fromString(contentType, 'body',
             fallbackEncoding: ASCII);
         expect(stringBody.encoding, equals(ASCII));
 
-        var bytesBody = new HttpBody.fromBytes(contentType, UTF8.encode('body'),
+        final bytesBody = new HttpBody.fromBytes(
+            contentType, UTF8.encode('body'),
             fallbackEncoding: ASCII);
         expect(bytesBody.encoding, equals(ASCII));
       });
 
       test('should use UTF8 by default', () {
-        var contentType = new MediaType('text', 'plain');
+        final contentType = new MediaType('text', 'plain');
 
-        var stringBody = new HttpBody.fromString(contentType, 'body');
+        final stringBody = new HttpBody.fromString(contentType, 'body');
         expect(stringBody.encoding, equals(UTF8));
 
-        var bytesBody =
+        final bytesBody =
             new HttpBody.fromBytes(contentType, UTF8.encode('body'));
         expect(bytesBody.encoding, equals(UTF8));
       });
 
       test('content-length should be calculated automaticlaly', () {
-        MediaType contentType = new MediaType('text', 'plain');
-        HttpBody body = new HttpBody.fromBytes(contentType, [1, 2, 3, 4]);
+        final contentType = new MediaType('text', 'plain');
+        final body = new HttpBody.fromBytes(contentType, [1, 2, 3, 4]);
         expect(body.contentLength, equals(4));
       });
 
       test('asBytes() UTF8', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': UTF8.name});
-        HttpBody body = new HttpBody.fromString(contentType, 'bodyçå®');
-        Uint8List encoded = new Uint8List.fromList(UTF8.encode('bodyçå®'));
+        final body = new HttpBody.fromString(contentType, 'bodyçå®');
+        final encoded = new Uint8List.fromList(UTF8.encode('bodyçå®'));
         expect(body.asBytes(), equals(encoded));
       });
 
       test('asBytes() LATIN1', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': LATIN1.name});
-        HttpBody body = new HttpBody.fromString(contentType, 'bodyçå®');
-        Uint8List encoded = new Uint8List.fromList(LATIN1.encode('bodyçå®'));
+        final body = new HttpBody.fromString(contentType, 'bodyçå®');
+        final encoded = new Uint8List.fromList(LATIN1.encode('bodyçå®'));
         expect(body.asBytes(), equals(encoded));
       });
 
       test('asBytes() ASCII', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': ASCII.name});
-        HttpBody body = new HttpBody.fromString(contentType, 'body');
-        Uint8List encoded = new Uint8List.fromList(ASCII.encode('body'));
+        final body = new HttpBody.fromString(contentType, 'body');
+        final encoded = new Uint8List.fromList(ASCII.encode('body'));
         expect(body.asBytes(), equals(encoded));
       });
 
       test('asJson() UTF8', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': UTF8.name});
-        var bodyJson = [
+        final bodyJson = <Map<String, String>>[
           {'foo': 'bar', 'baz': 'çå®"'}
         ];
-        HttpBody body = new HttpBody.fromBytes(
+        final body = new HttpBody.fromBytes(
             contentType, UTF8.encode(JSON.encode(bodyJson)));
         expect(body.asJson(), equals(bodyJson));
       });
 
       test('asJson() LATIN1', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': LATIN1.name});
-        var bodyJson = [
+        final bodyJson = <Map<String, String>>[
           {'foo': 'bar', 'baz': 'çå®"'}
         ];
-        HttpBody body = new HttpBody.fromBytes(
+        final body = new HttpBody.fromBytes(
             contentType, LATIN1.encode(JSON.encode(bodyJson)));
         expect(body.asJson(), equals(bodyJson));
       });
 
       test('asJson() ASCII', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        var bodyJson = [
+        final bodyJson = <Map<String, String>>[
           {'foo': 'bar', 'bar': 'baz'}
         ];
-        HttpBody body = new HttpBody.fromBytes(
+        final body = new HttpBody.fromBytes(
             contentType, ASCII.encode(JSON.encode(bodyJson)));
         expect(body.asJson(), equals(bodyJson));
       });
 
       test('asString() UTF8', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': UTF8.name});
-        HttpBody body =
+        final body =
             new HttpBody.fromBytes(contentType, UTF8.encode('bodyçå®'));
         expect(body.asString(), equals('bodyçå®'));
       });
 
       test('asString() LATIN1', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': LATIN1.name});
-        HttpBody body =
+        final body =
             new HttpBody.fromBytes(contentType, LATIN1.encode('bodyçå®'));
         expect(body.asString(), equals('bodyçå®'));
       });
 
       test('asString() ASCII', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        HttpBody body =
-            new HttpBody.fromBytes(contentType, ASCII.encode('body'));
+        final body = new HttpBody.fromBytes(contentType, ASCII.encode('body'));
         expect(body.asString(), equals('body'));
       });
 
       test('should throw ResponseFormatException if body cannot be encoded',
           () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        HttpBody body = new HttpBody.fromString(contentType, 'bodyçå®');
-        var exception;
+        final body = new HttpBody.fromString(contentType, 'bodyçå®');
+        Object exception;
         try {
           body.asBytes();
         } catch (e) {
@@ -192,11 +193,11 @@ void main() {
 
       test('should throw ResponseFormatException if bytes cannot be decoded',
           () {
-        MediaType contentType =
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        HttpBody body =
+        final body =
             new HttpBody.fromBytes(contentType, UTF8.encode('bodyçå®'));
-        var exception;
+        Object exception;
         try {
           body.asString();
         } catch (e) {
@@ -217,25 +218,25 @@ void main() {
 
     group('StreamedHttpBody', () {
       test('should parse encoding from content-type', () {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': ASCII.name});
-        StreamedHttpBody body = new StreamedHttpBody.fromByteStream(
+        final body = new StreamedHttpBody.fromByteStream(
             contentType, new Stream.fromIterable([]));
         expect(body.encoding.name, equals(ASCII.name));
       });
 
       test('should allow a fallback encoding', () {
-        MediaType contentType = new MediaType('text', 'plain');
-        StreamedHttpBody body = new StreamedHttpBody.fromByteStream(
+        final contentType = new MediaType('text', 'plain');
+        final body = new StreamedHttpBody.fromByteStream(
             contentType, new Stream.fromIterable([]),
             fallbackEncoding: LATIN1);
         expect(body.encoding.name, equals(LATIN1.name));
       });
 
       test('toBytes()', () async {
-        MediaType contentType =
+        final contentType =
             new MediaType('text', 'plain', {'charset': UTF8.name});
-        StreamedHttpBody body = new StreamedHttpBody.fromByteStream(
+        final body = new StreamedHttpBody.fromByteStream(
             contentType,
             new Stream.fromIterable([
               [1, 2],

--- a/test/unit/http/http_interceptor_test.dart
+++ b/test/unit/http/http_interceptor_test.dart
@@ -20,7 +20,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -32,16 +32,16 @@ void main() {
       });
 
       test('default implementations should not modify the payloads', () async {
-        var req = new Request()..uri = Uri.parse('/test');
-        var body =
+        final req = new Request()..uri = Uri.parse('/test');
+        final body =
             new HttpBody.fromString(new MediaType('text', 'plain'), 'body');
-        var finalizedReq =
+        final finalizedReq =
             new FinalizedRequest('GET', req.uri, {}, body, false);
-        var resp = new MockResponse.ok();
-        var reqPayload = new RequestPayload(new Request());
-        var respPayload = new ResponsePayload(finalizedReq, resp);
+        final resp = new MockResponse.ok();
+        final reqPayload = new RequestPayload(new Request());
+        final respPayload = new ResponsePayload(finalizedReq, resp);
 
-        var interceptor = new HttpInterceptor();
+        final interceptor = new HttpInterceptor();
         expect(
             identical(
                 reqPayload, await interceptor.interceptRequest(reqPayload)),

--- a/test/unit/http/http_static_test.dart
+++ b/test/unit/http/http_static_test.dart
@@ -23,7 +23,7 @@ import '../../naming.dart';
 
 // TODO: tests with headers
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -46,7 +46,7 @@ void main() {
       });
 
       test('DELETE withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -65,7 +65,7 @@ void main() {
       });
 
       test('GET withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -84,7 +84,7 @@ void main() {
       });
 
       test('HEAD withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -103,7 +103,7 @@ void main() {
       });
 
       test('OPTIONS withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -122,7 +122,7 @@ void main() {
       });
 
       test('PATCH with body', () async {
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
@@ -134,7 +134,7 @@ void main() {
       });
 
       test('PATCH withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -153,7 +153,7 @@ void main() {
       });
 
       test('POST with body', () async {
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
@@ -165,7 +165,7 @@ void main() {
       });
 
       test('POST withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -184,7 +184,7 @@ void main() {
       });
 
       test('PUT with body', () async {
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
@@ -196,7 +196,7 @@ void main() {
       });
 
       test('PUT withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();
@@ -215,7 +215,7 @@ void main() {
       });
 
       test('custom method with body', () async {
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
@@ -227,7 +227,7 @@ void main() {
       });
 
       test('custom method withCredentials', () async {
-        Completer c = new Completer();
+        final c = new Completer<Null>();
         MockTransports.http.when(requestUri, (FinalizedRequest request) async {
           if (request.withCredentials) {
             c.complete();

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -34,28 +34,28 @@ void main() {
       });
 
       test('setting entire body (Map)', () {
-        Map json = {'field': 'value'};
-        JsonRequest request = new JsonRequest()..body = json;
+        final json = <String, String>{'field': 'value'};
+        final request = new JsonRequest()..body = json;
         expect(request.body, equals(json));
       });
 
       test('setting entire body (List)', () {
-        List json = [
+        final json = <Map<String, String>>[
           {'field': 'value'}
         ];
-        JsonRequest request = new JsonRequest()..body = json;
+        final request = new JsonRequest()..body = json;
         expect(request.body, equals(json));
       });
 
       test('setting entire body (invalid JSON)', () {
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         expect(() {
           request.body = new Stream.fromIterable([]);
         }, throws);
       });
 
       test('setting fields incrementally', () {
-        FormRequest request = new FormRequest()
+        final request = new FormRequest()
           ..fields['field1'] = 'value1'
           ..fields['field2'] = 'value2';
         expect(
@@ -63,33 +63,33 @@ void main() {
       });
 
       test('setting body in request dispatcher is supported (Map)', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
           return new MockResponse.ok();
         });
 
-        JsonRequest request = new JsonRequest();
-        Map json = {'field': 'value'};
+        final request = new JsonRequest();
+        final json = <String, String>{'field': 'value'};
         await request.post(uri: uri, body: json);
         expect(await c.future, equals(JSON.encode(json)));
       });
 
       test('setting body in request dispatcher is supported (List)', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
           return new MockResponse.ok();
         });
 
-        JsonRequest request = new JsonRequest();
-        List json = [
+        final request = new JsonRequest();
+        final json = <Map<String, String>>[
           {'field': 'value'}
         ];
         await request.post(uri: uri, body: json);
@@ -98,16 +98,16 @@ void main() {
 
       test('setting body in request dispatcher should throw if invalid',
           () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         expect(request.post(uri: uri, body: UTF8), throws);
       });
 
       test('body should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         await request.post(uri: uri);
         expect(() {
           request.body = {'too': 'late'};
@@ -115,21 +115,21 @@ void main() {
       });
 
       test('content-length cannot be set manually', () {
-        Request request = new Request();
+        final request = new Request();
         expect(() {
           request.contentLength = 10;
         }, throwsUnsupportedError);
       });
 
       test('setting encoding to null should throw', () {
-        var request = new JsonRequest();
+        final request = new JsonRequest();
         expect(() {
           request.encoding = null;
         }, throwsArgumentError);
       });
 
       test('setting encoding should update content-type', () {
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         request.encoding = LATIN1;
@@ -142,7 +142,7 @@ void main() {
       test(
           'setting encoding should not update content-type if content-type has been set manually',
           () {
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         // Manually override content-type.
@@ -157,9 +157,9 @@ void main() {
       });
 
       test('setting content-type should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         await request.get(uri: uri);
         expect(() {
           request.contentType = new MediaType('application', 'x-custom');
@@ -167,9 +167,9 @@ void main() {
       });
 
       test('setting encoding should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        JsonRequest request = new JsonRequest();
+        final request = new JsonRequest();
         await request.get(uri: uri);
         expect(() {
           request.encoding = LATIN1;
@@ -177,20 +177,20 @@ void main() {
       });
 
       test('custom content-type without inferrable encoding', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        var request = new JsonRequest()
+        final request = new JsonRequest()
           ..contentType = new MediaType('application', 'x-custom')
           ..body = {'foo': 'bar'};
         await request.post(uri: uri);
       });
 
       test('clone()', () {
-        var body = [
+        final body = <Map<String, String>>[
           {'f1': 'v1', 'f2': 'v2'}
         ];
-        JsonRequest orig = new JsonRequest()..body = body;
-        JsonRequest clone = orig.clone();
+        final orig = new JsonRequest()..body = body;
+        final clone = orig.clone();
         expect(clone.body, equals(body));
       });
     });

--- a/test/unit/http/multipart_file_test.dart
+++ b/test/unit/http/multipart_file_test.dart
@@ -21,41 +21,38 @@ import 'package:w_transport/w_transport.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('MultipartFile', () {
       test('content-type set explicitly', () {
-        MediaType contentType = new MediaType('application', 'json');
-        MultipartFile file = new MultipartFile(new Stream.fromIterable([]), 0,
+        final contentType = new MediaType('application', 'json');
+        final file = new MultipartFile(new Stream.fromIterable([]), 0,
             contentType: contentType, filename: 'page.html');
         expect(file.contentType.mimeType, 'application/json');
       });
 
       test('content-type should be based on a mimetype lookup', () {
-        var stream = new Stream<List<int>>.fromIterable([]);
+        final stream = new Stream<List<int>>.fromIterable([]);
 
-        MultipartFile jsonFile =
-            new MultipartFile(stream, 0, filename: 'data.json');
+        final jsonFile = new MultipartFile(stream, 0, filename: 'data.json');
         expect(jsonFile.contentType.mimeType, equals('application/json'));
 
-        MultipartFile zipFile =
+        final zipFile =
             new MultipartFile(stream, 0, filename: 'compressed.zip');
         expect(zipFile.contentType.mimeType, equals('application/zip'));
 
-        MultipartFile imgFile =
-            new MultipartFile(stream, 0, filename: 'img.png');
+        final imgFile = new MultipartFile(stream, 0, filename: 'img.png');
         expect(imgFile.contentType.mimeType, equals('image/png'));
 
-        MultipartFile htmlFile =
-            new MultipartFile(stream, 0, filename: 'page.html');
+        final htmlFile = new MultipartFile(stream, 0, filename: 'page.html');
         expect(htmlFile.contentType.mimeType, equals('text/html'));
       });
 
       test('content-type default to application/octet-stream', () {
-        MultipartFile file = new MultipartFile(new Stream.fromIterable([]), 0);
+        final file = new MultipartFile(new Stream.fromIterable([]), 0);
         expect(file.contentType.mimeType, equals('application/octet-stream'));
       });
     });

--- a/test/unit/http/multipart_request_test.dart
+++ b/test/unit/http/multipart_request_test.dart
@@ -22,7 +22,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -33,30 +33,30 @@ void main() {
       });
 
       test('content-type cannot be set manually', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         expect(() => request.contentType = null, throwsUnsupportedError);
       });
 
       test('content-length cannot be set manually', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         expect(() {
           request.contentLength = 10;
         }, throwsUnsupportedError);
       });
 
       test('setting body in request dispatcher is unsupported', () async {
-        Uri uri = Uri.parse('/test');
-        MultipartRequest request = new MultipartRequest();
+        final uri = Uri.parse('/test');
+        final request = new MultipartRequest();
         expect(request.post(uri: uri, body: 'body'), throwsUnsupportedError);
       });
 
       test('body cannot be empty', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         expect(request.post(uri: Uri.parse('/test')), throwsUnsupportedError);
       });
 
       test('body can be set incrementally or all at once', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         request.fields = {'field1': 'v1'};
         expect(request.fields, containsPair('field1', 'v1'));
         request.files = {'file1': 'f1'};
@@ -68,10 +68,9 @@ void main() {
       });
 
       test('body should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        MultipartRequest request = new MultipartRequest()
-          ..fields['field1'] = 'value1';
+        final request = new MultipartRequest()..fields['field1'] = 'value1';
         await request.post(uri: uri);
         expect(() {
           request.fields['too'] = 'late';
@@ -88,21 +87,21 @@ void main() {
       });
 
       test('setting encoding should be unsupported', () {
-        MultipartRequest request = new MultipartRequest();
+        final request = new MultipartRequest();
         expect(() {
           request.encoding = UTF8;
         }, throwsUnsupportedError);
       });
 
       test('clone()', () {
-        var fields = {'f1': 'v1', 'f2': 'v2'};
-        MultipartRequest orig = new MultipartRequest()..fields = fields;
-        MultipartRequest clone = orig.clone();
+        final fields = <String, String>{'f1': 'v1', 'f2': 'v2'};
+        final orig = new MultipartRequest()..fields = fields;
+        final clone = orig.clone();
         expect(clone.fields, equals(fields));
       });
 
       test('autoRetry with files not supported', () {
-        MultipartRequest request = new MultipartRequest()..files['k'] = 'f';
+        final request = new MultipartRequest()..files['k'] = 'f';
         expect(request.autoRetry.supported, isFalse);
       });
     });

--- a/test/unit/http/plain_text_request_test.dart
+++ b/test/unit/http/plain_text_request_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -34,7 +34,7 @@ void main() {
       });
 
       test('setting body (string)', () {
-        Request request = new Request();
+        final request = new Request();
 
         request.body = 'body';
         expect(request.body, equals('body'));
@@ -46,7 +46,7 @@ void main() {
       });
 
       test('setting body (bytes)', () {
-        Request request = new Request();
+        final request = new Request();
 
         request.bodyBytes = UTF8.encode('body');
         expect(request.bodyBytes, equals(UTF8.encode('body')));
@@ -59,48 +59,48 @@ void main() {
 
       test('setting body in request dispatcher is supported (string)',
           () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
           return new MockResponse.ok();
         });
 
-        Request request = new Request();
+        final request = new Request();
         await request.post(uri: uri, body: 'body');
         expect(await c.future, equals('body'));
       });
 
       test('setting body in request dispatcher is supported (bytes)', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           HttpBody body = request.body;
           c.complete(body.asString());
           return new MockResponse.ok();
         });
 
-        Request request = new Request();
+        final request = new Request();
         await request.post(uri: uri, body: UTF8.encode('body'));
         expect(await c.future, equals('body'));
       });
 
       test('setting body in request dispatcher should throw if invalid',
           () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Request request = new Request();
+        final request = new Request();
         expect(request.post(uri: uri, body: {'invalid': 'map'}),
             throwsArgumentError);
       });
 
       test('body should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        Request request = new Request();
+        final request = new Request();
         await request.post(uri: uri);
         expect(() {
           request.body = 'too late';
@@ -111,21 +111,21 @@ void main() {
       });
 
       test('content-length cannot be set manually', () {
-        Request request = new Request();
+        final request = new Request();
         expect(() {
           request.contentLength = 10;
         }, throwsUnsupportedError);
       });
 
       test('setting encoding to null should throw', () {
-        var request = new Request();
+        final request = new Request();
         expect(() {
           request.encoding = null;
         }, throwsArgumentError);
       });
 
       test('setting encoding should update content-type', () {
-        Request request = new Request();
+        final request = new Request();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         request.encoding = LATIN1;
@@ -138,7 +138,7 @@ void main() {
       test(
           'setting encoding should not update content-type if content-type has been set manually',
           () {
-        Request request = new Request();
+        final request = new Request();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         // Manually override content-type.
@@ -153,9 +153,9 @@ void main() {
       });
 
       test('setting content-type should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        Request request = new Request();
+        final request = new Request();
         await request.get(uri: uri);
         expect(() {
           request.contentType = new MediaType('application', 'x-custom');
@@ -163,9 +163,9 @@ void main() {
       });
 
       test('setting encoding should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        Request request = new Request();
+        final request = new Request();
         await request.get(uri: uri);
         expect(() {
           request.encoding = LATIN1;
@@ -173,23 +173,23 @@ void main() {
       });
 
       test('custom content-type without inferrable encoding', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        var request = new Request()
+        final request = new Request()
           ..contentType = new MediaType('application', 'x-custom')
           ..body = 'body';
         await request.post(uri: uri);
       });
 
       test('clone()', () {
-        var body = 'body';
-        Request orig = new Request()..body = body;
-        Request clone = orig.clone();
+        final body = 'body';
+        final orig = new Request()..body = body;
+        final clone = orig.clone();
         expect(clone.body, equals(body));
 
-        var bodyBytes = UTF8.encode('bytes');
-        Request orig2 = new Request()..bodyBytes = bodyBytes;
-        Request clone2 = orig2.clone();
+        final bodyBytes = UTF8.encode('bytes');
+        final orig2 = new Request()..bodyBytes = bodyBytes;
+        final clone2 = orig2.clone();
         expect(clone2.bodyBytes, equals(bodyBytes));
       });
     });

--- a/test/unit/http/request_exception_test.dart
+++ b/test/unit/http/request_exception_test.dart
@@ -20,28 +20,27 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('RequestException', () {
       test('should include the method and URI if given', () {
-        RequestException exception =
+        final exception =
             new RequestException('POST', Uri.parse('/path'), null, null);
         expect(exception.toString(), contains('POST'));
         expect(exception.toString(), contains('/path'));
       });
 
       test('should include the response status and text if given', () {
-        Response response = new MockResponse.ok();
-        RequestException exception =
-            new RequestException('GET', null, null, response);
+        final response = new MockResponse.ok();
+        final exception = new RequestException('GET', null, null, response);
         expect(exception.toString(), contains('200 OK'));
       });
 
       test('should include the original error if given', () {
-        RequestException exception = new RequestException(
+        final exception = new RequestException(
             'GET', null, null, null, new Exception('original'));
         expect(exception.toString(), contains('original'));
       });

--- a/test/unit/http/request_progress_test.dart
+++ b/test/unit/http/request_progress_test.dart
@@ -18,29 +18,29 @@ import 'package:w_transport/w_transport.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('RequestProgress', () {
       test('lengthComputable should be true if total is known', () {
-        RequestProgress prog = new RequestProgress(10, 100);
+        final prog = new RequestProgress(10, 100);
         expect(prog.lengthComputable, isTrue);
       });
 
       test('lengthComputable should be false if total is unknown', () {
-        RequestProgress prog = new RequestProgress(10);
+        final prog = new RequestProgress(10);
         expect(prog.lengthComputable, isFalse);
       });
 
       test('percent should be calculcated', () {
-        RequestProgress prog = new RequestProgress(10, 100);
+        final prog = new RequestProgress(10, 100);
         expect(prog.percent, equals(10.0));
       });
 
       test('percent should be 0.0 if length is not computable', () {
-        RequestProgress prog = new RequestProgress(10);
+        final prog = new RequestProgress(10);
         expect(prog.percent, equals(0.0));
       });
     });

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -70,22 +70,22 @@ void main() {
     _runAutoRetryTestSuiteFor('Request', reqFactory);
 
     test('clone() of request from client', () async {
-      Uri requestUri = Uri.parse('/mock/request');
+      final requestUri = Uri.parse('/mock/request');
 
       // Hold the requests long enough to let the client cancel them on close
       MockTransports.http.when(requestUri, (request) async {
         await new Future.delayed(new Duration(seconds: 10));
       }, method: 'GET');
 
-      var client = new HttpClient();
-      var clientReqs = [
+      final client = new HttpClient();
+      final clientReqs = <BaseRequest>[
         client.newFormRequest(),
         client.newJsonRequest(),
         client.newMultipartRequest()..fields['f1'] = 'v1',
         client.newRequest()
       ];
-      for (BaseRequest orig in clientReqs) {
-        BaseRequest clone = orig.clone()..uri = requestUri;
+      for (final orig in clientReqs) {
+        final clone = orig.clone()..uri = requestUri;
         expect(clone.get(), throwsA(predicate((exception) {
           return exception is RequestException &&
               exception.toString().contains('client was closed');
@@ -99,8 +99,8 @@ void main() {
 void _runCommonRequestSuiteFor(
     String name, BaseRequest requestFactory({bool withBody})) {
   group(name, () {
-    var requestUri = Uri.parse('/mock/request');
-    var requestHeaders = <String, String>{'x-custom': 'header'};
+    final requestUri = Uri.parse('/mock/request');
+    final requestHeaders = <String, String>{'x-custom': 'header'};
 
     setUp(() {
       MockTransports.reset();
@@ -240,7 +240,7 @@ void _runCommonRequestSuiteFor(
     test(
         'URI and data should be accepted as parameters to a request dispatch method',
         () async {
-      Completer dataCompleter = new Completer();
+      final dataCompleter = new Completer<String>();
       MockTransports.http.when(requestUri, (FinalizedRequest request) async {
         if (request.body is HttpBody) {
           HttpBody body = request.body;
@@ -260,7 +260,7 @@ void _runCommonRequestSuiteFor(
         () async {
       MockTransports.http.expect('GET', requestUri,
           headers: {'x-one': '1', 'x-two': '2', 'x-three': '3'});
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..headers = {'x-one': '1', 'x-two': '0'}
         ..uri = requestUri;
       await request.get(headers: {'x-two': '2', 'x-three': '3'});
@@ -268,7 +268,7 @@ void _runCommonRequestSuiteFor(
 
     test('request cancellation prior to dispatch should cancel request',
         () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.abort();
       expect(request.get(uri: requestUri),
           throwsA(new isInstanceOf<RequestException>()));
@@ -277,8 +277,8 @@ void _runCommonRequestSuiteFor(
     test(
         'request cancellation after dispatch but prior to resolution should cancel request',
         () async {
-      BaseRequest request = requestFactory();
-      Future future = request.get(uri: requestUri);
+      final request = requestFactory();
+      final future = request.get(uri: requestUri);
       await new Future.delayed(new Duration(milliseconds: 500));
       request.abort();
       expect(future, throwsA(new isInstanceOf<RequestException>()));
@@ -287,7 +287,7 @@ void _runCommonRequestSuiteFor(
     test('request cancellation after request has succeeded should do nothing',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       request.abort();
     });
@@ -295,8 +295,8 @@ void _runCommonRequestSuiteFor(
     test('request cancellation after request has failed should do nothing',
         () async {
       MockTransports.http.expect('GET', requestUri, failWith: new Exception());
-      BaseRequest request = requestFactory();
-      Future future = request.get(uri: requestUri);
+      final request = requestFactory();
+      final future = request.get(uri: requestUri);
       expect(future, throwsA(new isInstanceOf<RequestException>()));
       try {
         await future;
@@ -305,7 +305,7 @@ void _runCommonRequestSuiteFor(
     });
 
     test('request cancellation should accept a custom error', () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.abort(new Exception('custom error'));
       expect(request.get(uri: requestUri), throwsA(predicate((error) {
         return error is RequestException &&
@@ -314,7 +314,7 @@ void _runCommonRequestSuiteFor(
     });
 
     test('should wrap an unexpected exception in RequestException', () async {
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       MockTransports.http.causeFailureOnOpen(request);
       expect(request.get(uri: requestUri),
           throwsA(new isInstanceOf<RequestException>()));
@@ -323,14 +323,14 @@ void _runCommonRequestSuiteFor(
     test('should throw if status code is non-200', () async {
       MockTransports.http.expect('GET', requestUri,
           respondWith: new MockResponse.internalServerError());
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       expect(request.get(uri: requestUri),
           throwsA(new isInstanceOf<RequestException>()));
     });
 
     test('headers should be unmodifiable once sent', () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..uri = requestUri
         ..headers = {'x-custom': 'value'};
       await request.get();
@@ -344,7 +344,7 @@ void _runCommonRequestSuiteFor(
 
     test('withCredentials flag should be unmodifiable once sent', () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       expect(() {
         request.withCredentials = true;
@@ -353,8 +353,8 @@ void _runCommonRequestSuiteFor(
 
     test('request can only be sent once', () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
-      Future first = request.get(uri: requestUri);
+      final request = requestFactory();
+      final first = request.get(uri: requestUri);
       expect(request.get(uri: requestUri), throwsStateError);
       await first;
     });
@@ -362,7 +362,7 @@ void _runCommonRequestSuiteFor(
     test('requestInterceptor allows async modification of request', () async {
       MockTransports.http
           .expect('GET', requestUri, headers: {'x-intercepted': 'true'});
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.requestInterceptor = (BaseRequest request) async {
         request.headers['x-intercepted'] = 'true';
       };
@@ -372,8 +372,8 @@ void _runCommonRequestSuiteFor(
     test(
         'if requestInterceptor throws, the request should fail with that exception',
         () async {
-      BaseRequest request = requestFactory();
-      var exception = new Exception('interceptor failure');
+      final request = requestFactory();
+      final exception = new Exception('interceptor failure');
 
       request.requestInterceptor = (BaseRequest request) async {
         throw exception;
@@ -384,7 +384,7 @@ void _runCommonRequestSuiteFor(
     test('setting requestInterceptor throws if request has been sent',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       expect(() {
         request.requestInterceptor = (request) async {};
@@ -393,7 +393,7 @@ void _runCommonRequestSuiteFor(
 
     test('responseInterceptor gets FinalizedRequest', () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor =
           (FinalizedRequest request, response, [exception]) async {
         expect(request.method, equals('GET'));
@@ -403,9 +403,9 @@ void _runCommonRequestSuiteFor(
     });
 
     test('responseInterceptor gets BaseResponse', () async {
-      MockResponse mockResponse = new MockResponse.ok(body: 'original');
+      final mockResponse = new MockResponse.ok(body: 'original');
       MockTransports.http.expect('GET', requestUri, respondWith: mockResponse);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor =
           (request, BaseResponse response, [exception]) async {
         expect(response, new isInstanceOf<Response>());
@@ -418,7 +418,7 @@ void _runCommonRequestSuiteFor(
     test('responseInterceptor gets no RequestException on successful request',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor = (request, response, [exception]) async {
         expect(exception, isNull);
       };
@@ -429,7 +429,7 @@ void _runCommonRequestSuiteFor(
         () async {
       MockTransports.http
           .expect('GET', requestUri, failWith: new Exception('mock failure'));
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor =
           (request, response, [RequestException exception]) async {
         expect(exception, isNotNull);
@@ -439,15 +439,15 @@ void _runCommonRequestSuiteFor(
     });
 
     test('responseInterceptor allows replacement of BaseResponse', () async {
-      MockResponse mockResponse = new MockResponse.ok(body: 'original');
+      final mockResponse = new MockResponse.ok(body: 'original');
       MockTransports.http.expect('GET', requestUri, respondWith: mockResponse);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor =
           (request, BaseResponse response, [exception]) async {
         return new Response.fromString(
             response.status, response.statusText, response.headers, 'modified');
       };
-      Response response = await request.get(uri: requestUri);
+      final response = await request.get(uri: requestUri);
       expect(response.body.asString(), equals('modified'));
     });
 
@@ -455,7 +455,7 @@ void _runCommonRequestSuiteFor(
         'if responseInterceptor throws, the error should be wrapped in a RequestException',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor = (request, response, [exception]) async {
         throw new Exception('interceptor failure');
       };
@@ -468,7 +468,7 @@ void _runCommonRequestSuiteFor(
     test('setting responseInterceptor throws if request has been sent',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       expect(() {
         request.responseInterceptor = (request, response, [exception]) async {};
@@ -478,9 +478,9 @@ void _runCommonRequestSuiteFor(
     test(
         'should not double-wrap exception when applying responseInterceptor after failure',
         () async {
-      var error = new Error();
+      final error = new Error();
       MockTransports.http.expect('GET', requestUri, failWith: error);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       request.responseInterceptor =
           (request, response, [exception]) async => response;
       expect(request.get(uri: requestUri), throwsA(predicate((exception) {
@@ -490,8 +490,8 @@ void _runCommonRequestSuiteFor(
     });
 
     test('timeoutThreshold is not enforced if not set', () async {
-      BaseRequest request = requestFactory();
-      Future future = request.get(uri: requestUri);
+      final request = requestFactory();
+      final future = request.get(uri: requestUri);
       await new Future.delayed(new Duration(milliseconds: 250));
       MockTransports.http.completeRequest(request);
       await future;
@@ -499,16 +499,16 @@ void _runCommonRequestSuiteFor(
 
     test('timeoutThreshold does nothing if request completes in time',
         () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..timeoutThreshold = new Duration(milliseconds: 500);
-      Future future = request.get(uri: requestUri);
+      final future = request.get(uri: requestUri);
       await new Future.delayed(new Duration(milliseconds: 250));
       MockTransports.http.completeRequest(request);
       await future;
     });
 
     test('timeoutThreshold cancels the request if exceeded', () async {
-      BaseRequest request = requestFactory()
+      final request = requestFactory()
         ..timeoutThreshold = new Duration(milliseconds: 500);
       expect(request.get(uri: requestUri), throwsA(predicate((error) {
         return error is RequestException && error.error is TimeoutException;
@@ -518,7 +518,7 @@ void _runCommonRequestSuiteFor(
     test('configure() should throw if called after request has been sent',
         () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       expect(() {
         request.configure((_) {});
@@ -527,7 +527,7 @@ void _runCommonRequestSuiteFor(
 
     test('toString()', () async {
       MockTransports.http.expect('GET', requestUri);
-      BaseRequest request = requestFactory();
+      final request = requestFactory();
       await request.get(uri: requestUri);
       expect(request.toString(), contains('GET'));
       expect(request.toString(), contains(requestUri.toString()));
@@ -539,7 +539,7 @@ void _runCommonRequestSuiteFor(
 void _runAutoRetryTestSuiteFor(
     String name, BaseRequest requestFactory({bool withBody})) {
   group(name, () {
-    Uri requestUri = Uri.parse('/mock/request');
+    final requestUri = Uri.parse('/mock/request');
 
     setUp(() {
       MockTransports.reset();
@@ -557,11 +557,11 @@ void _runAutoRetryTestSuiteFor(
               [RequestException exception]) async =>
           response;
 
-      var headers = {'x-custom': 'header'};
-      var tt = new Duration(seconds: 10);
-      var encoding = LATIN1;
+      final headers = <String, String>{'x-custom': 'header'};
+      const tt = const Duration(seconds: 10);
+      final encoding = LATIN1;
 
-      BaseRequest orig = requestFactory()
+      final orig = requestFactory()
         ..autoRetry.enabled = true
         ..headers = headers
         ..requestInterceptor = reqInt
@@ -573,7 +573,7 @@ void _runAutoRetryTestSuiteFor(
         orig.encoding = encoding;
       }
 
-      BaseRequest clone = orig.clone();
+      final clone = orig.clone();
       expect(identical(clone.autoRetry, orig.autoRetry), isTrue);
       expect(clone.headers, equals(headers));
       expect(clone.requestInterceptor, equals(reqInt));
@@ -589,7 +589,7 @@ void _runAutoRetryTestSuiteFor(
       test('disabled', () async {
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.internalServerError());
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         expect(request.get(uri: requestUri),
             throwsA(new isInstanceOf<RequestException>()));
         await request.done;
@@ -600,7 +600,7 @@ void _runAutoRetryTestSuiteFor(
       test('no retries', () async {
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -616,7 +616,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -634,7 +634,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -653,7 +653,7 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.internalServerError());
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -672,7 +672,7 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.notFound());
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -688,7 +688,7 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('POST', requestUri,
             respondWith: new MockResponse.internalServerError());
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -705,7 +705,7 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.notFound());
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
@@ -722,7 +722,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError(
                 headers: {'x-retry': 'no'}));
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2
@@ -736,8 +736,9 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('retries only 500, 502, 503, 504 by default', () async {
-        Future expectNumRetries(int num, {bool shouldSucceed: true}) async {
-          BaseRequest request = requestFactory();
+        Future<Null> expectNumRetries(int num,
+            {bool shouldSucceed: true}) async {
+          final request = requestFactory();
           request.autoRetry
             ..enabled = true
             ..maxRetries = num;
@@ -777,9 +778,9 @@ void _runAutoRetryTestSuiteFor(
       });
 
       test('retries only GET, HEAD, OPTIONS by default', () async {
-        Future expectNumRetries(String method, int num,
+        Future<Null> expectNumRetries(String method, int num,
             {bool shouldSucceed: true}) async {
-          BaseRequest request = requestFactory();
+          final request = requestFactory();
           request.autoRetry
             ..enabled = true
             ..maxRetries = num;
@@ -832,7 +833,7 @@ void _runAutoRetryTestSuiteFor(
             .expect('GET', requestUri, respondWith: new MockResponse(408));
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2
@@ -849,7 +850,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('DELETE', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2
@@ -866,7 +867,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2
@@ -883,7 +884,7 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.notFound());
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2
@@ -909,12 +910,12 @@ void _runAutoRetryTestSuiteFor(
           }
         }, method: 'GET');
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 2;
 
-        Future future = request.get(uri: requestUri);
+        final future = request.get(uri: requestUri);
         await new Future.delayed(new Duration(milliseconds: 500));
         request.abort();
         expect(future, throwsA(predicate((exception) {
@@ -934,7 +935,7 @@ void _runAutoRetryTestSuiteFor(
           }
         }, method: 'GET');
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.timeoutThreshold = new Duration(milliseconds: 250);
         request.autoRetry
           ..enabled = true
@@ -950,14 +951,14 @@ void _runAutoRetryTestSuiteFor(
           await new Future.delayed(new Duration(seconds: 1));
         }, method: 'GET');
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.timeoutThreshold = new Duration(milliseconds: 250);
         request.autoRetry
           ..enabled = true
           ..forTimeouts = false
           ..maxRetries = 2;
 
-        var future = request.get(uri: requestUri);
+        final future = request.get(uri: requestUri);
         expect(future, throwsA(new isInstanceOf<RequestException>()));
         await future.catchError((_) {});
         expect(request.autoRetry.numAttempts, equals(1));
@@ -972,7 +973,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 3;
@@ -995,7 +996,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 3
@@ -1028,7 +1029,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 3
@@ -1062,7 +1063,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 3
@@ -1090,7 +1091,7 @@ void _runAutoRetryTestSuiteFor(
             respondWith: new MockResponse.internalServerError());
         MockTransports.http.expect('GET', requestUri);
 
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         request.autoRetry
           ..enabled = true
           ..maxRetries = 3
@@ -1127,7 +1128,7 @@ void _runAutoRetryTestSuiteFor(
           }
         });
 
-        BaseRequest request = requestFactory()
+        final request = requestFactory()
           ..timeoutThreshold = new Duration(milliseconds: 100);
         request.autoRetry
           ..enabled = true
@@ -1154,20 +1155,20 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.badRequest());
         MockTransports.http.expect('GET', requestUri);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         await request.get(uri: requestUri).catchError((_) {});
         await request.retry();
       });
 
       test('manual retry() throws if not yet sent', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         expect(request.retry, throwsStateError);
       });
 
       test('manual retry() throws if not yet complete', () async {
         MockTransports.http.when(
             requestUri, (request) => new Completer<BaseResponse>().future);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         // ignore: unawaited_futures
         request.get(uri: requestUri);
         await new Future.delayed(new Duration(milliseconds: 10));
@@ -1176,7 +1177,7 @@ void _runAutoRetryTestSuiteFor(
 
       test('manual retry() throws if did not fail', () async {
         MockTransports.http.expect('GET', requestUri);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         await request.get(uri: requestUri);
         expect(request.retry, throwsStateError);
       });
@@ -1185,20 +1186,20 @@ void _runAutoRetryTestSuiteFor(
         MockTransports.http.expect('GET', requestUri,
             respondWith: new MockResponse.badRequest());
         MockTransports.http.expect('GET', requestUri);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         await request.get(uri: requestUri).catchError((_) {});
         await request.streamRetry();
       });
 
       test('manual streamRetry() throws if not yet sent', () async {
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         expect(request.streamRetry, throwsStateError);
       });
 
       test('manual streamRetry() throws if not yet complete', () async {
         MockTransports.http.when(
             requestUri, (request) => new Completer<BaseResponse>().future);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         // ignore: unawaited_futures
         request.get(uri: requestUri);
         await new Future.delayed(new Duration(milliseconds: 10));
@@ -1207,7 +1208,7 @@ void _runAutoRetryTestSuiteFor(
 
       test('manual streamRetry() throws if did not fail', () async {
         MockTransports.http.expect('GET', requestUri);
-        BaseRequest request = requestFactory();
+        final request = requestFactory();
         await request.get(uri: requestUri);
         expect(request.streamRetry, throwsStateError);
       });

--- a/test/unit/http/response_format_exception_test.dart
+++ b/test/unit/http/response_format_exception_test.dart
@@ -22,17 +22,17 @@ import 'package:w_transport/src/http/response_format_exception.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('ResponseFormatException', () {
       test('should detail why bytes could not be decoded', () {
-        var bytes = UTF8.encode('bodyçå®');
-        var contentType =
+        final bytes = UTF8.encode('bodyçå®');
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        var exception =
+        final exception =
             new ResponseFormatException(contentType, ASCII, bytes: bytes);
         expect(exception.toString(), contains('Bytes could not be decoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
@@ -42,10 +42,10 @@ void main() {
       });
 
       test('should detail why string could not be encoded', () {
-        var body = 'bodyçå®';
-        var contentType =
+        final body = 'bodyçå®';
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        var exception =
+        final exception =
             new ResponseFormatException(contentType, ASCII, body: body);
         expect(exception.toString(), contains('Body could not be encoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
@@ -54,10 +54,10 @@ void main() {
       });
 
       test('should warn if encoding is null', () {
-        var body = 'bodyçå®';
-        var contentType =
+        final body = 'bodyçå®';
+        final contentType =
             new MediaType('application', 'json', {'charset': ASCII.name});
-        var exception =
+        final exception =
             new ResponseFormatException(contentType, null, body: body);
         expect(exception.toString(), contains('Body could not be encoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));

--- a/test/unit/http/response_test.dart
+++ b/test/unit/http/response_test.dart
@@ -20,50 +20,50 @@ import 'package:w_transport/w_transport.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
   group(naming.toString(), () {
     group('Response', () {
       test('content-length should be set automatically', () {
-        List<int> bytes = [10, 390];
-        Response response = new Response.fromBytes(200, 'OK', {}, bytes);
+        final bytes = <int>[10, 390];
+        final response = new Response.fromBytes(200, 'OK', {}, bytes);
         expect(response.contentLength, equals(bytes.length));
       });
 
       test('body', () {
-        Response response = new Response.fromString(200, 'OK', {}, 'body');
+        final response = new Response.fromString(200, 'OK', {}, 'body');
         expect(response.body.asString(), equals('body'));
       });
 
       test('replace', () {
-        Response response = new Response.fromString(200, 'OK', {}, 'body');
-        Response response2 = response.replace(status: 301);
+        final response = new Response.fromString(200, 'OK', {}, 'body');
+        final response2 = response.replace(status: 301);
         expect(response2.status, equals(301));
         expect(response2.statusText, equals('OK'));
         expect(response2.headers, equals({}));
         expect(response2.body.asString(), equals('body'));
 
-        Response response3 = response.replace(statusText: 'Not OK');
+        final response3 = response.replace(statusText: 'Not OK');
         expect(response3.status, equals(200));
         expect(response3.statusText, equals('Not OK'));
         expect(response3.headers, equals({}));
         expect(response3.body.asString(), equals('body'));
 
-        Response response4 = response.replace(headers: {'origin': 'pluto'});
+        final response4 = response.replace(headers: {'origin': 'pluto'});
         expect(response4.status, equals(200));
         expect(response4.statusText, equals('OK'));
         expect(response4.headers, equals({'origin': 'pluto'}));
         expect(response4.body.asString(), equals('body'));
 
-        Response response5 = response.replace(bodyString: 'phrasing');
+        final response5 = response.replace(bodyString: 'phrasing');
         expect(response5.status, equals(200));
         expect(response5.statusText, equals('OK'));
         expect(response5.headers, equals({}));
         expect(response5.body.asString(), equals('phrasing'));
 
-        Response response6 = response.replace(bodyBytes: [10, 134]);
+        final response6 = response.replace(bodyBytes: [10, 134]);
         expect(response6.status, equals(200));
         expect(response6.statusText, equals('OK'));
         expect(response6.headers, equals({}));
@@ -73,50 +73,49 @@ void main() {
 
     group('StreamedResponse', () {
       test('content-length should be taken from headers', () {
-        List<int> bytes = [10, 390];
-        var headers = {'content-length': '${bytes.length}'};
-        StreamedResponse response = new StreamedResponse.fromByteStream(
+        final bytes = <int>[10, 390];
+        final headers = <String, String>{'content-length': '${bytes.length}'};
+        final response = new StreamedResponse.fromByteStream(
             200, 'OK', headers, new Stream.fromIterable([bytes]));
         expect(response.contentLength, equals(bytes.length));
       });
 
       test('body', () async {
-        List<int> bytes = [1, 2, 3, 4];
-        StreamedResponse response = new StreamedResponse.fromByteStream(
+        final bytes = <int>[1, 2, 3, 4];
+        final response = new StreamedResponse.fromByteStream(
             200, 'OK', {}, new Stream.fromIterable([bytes]));
         expect(await response.body.byteStream.toList(), equals([bytes]));
       });
 
       test('replace', () async {
-        List<int> bytes = [1, 2, 3, 4];
-        StreamedResponse response = new StreamedResponse.fromByteStream(
+        final bytes = <int>[1, 2, 3, 4];
+        final response = new StreamedResponse.fromByteStream(
             200, 'OK', {}, new Stream.fromIterable([bytes]));
-        StreamedResponse response2 = response.replace(status: 301);
+        final response2 = response.replace(status: 301);
         expect(response2.status, equals(301));
         expect(response2.statusText, equals('OK'));
         expect(response2.headers, equals({}));
         expect(response2.body, equals(response.body));
 
-        StreamedResponse response3 = response.replace(statusText: 'Not OK');
+        final response3 = response.replace(statusText: 'Not OK');
         expect(response3.status, equals(200));
         expect(response3.statusText, equals('Not OK'));
         expect(response3.headers, equals({}));
         expect(response3.body, equals(response.body));
 
-        StreamedResponse response4 =
-            response.replace(headers: {'origin': 'pluto'});
+        final response4 = response.replace(headers: {'origin': 'pluto'});
         expect(response4.status, equals(200));
         expect(response4.statusText, equals('OK'));
         expect(response4.headers, equals({'origin': 'pluto'}));
         expect(response4.body, equals(response.body));
 
-        bytes = [5, 6, 7];
+        final bytes2 = <int>[5, 6, 7];
         StreamedResponse response5 =
-            response.replace(byteStream: new Stream.fromIterable([bytes]));
+            response.replace(byteStream: new Stream.fromIterable([bytes2]));
         expect(response5.status, equals(200));
         expect(response5.statusText, equals('OK'));
         expect(response5.headers, equals({}));
-        expect(await response5.body.byteStream.toList(), equals([bytes]));
+        expect(await response5.body.byteStream.toList(), equals([bytes2]));
       });
     });
   });

--- a/test/unit/http/streamed_request_test.dart
+++ b/test/unit/http/streamed_request_test.dart
@@ -23,7 +23,7 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -34,15 +34,15 @@ void main() {
       });
 
       test('content-type can be set manually', () {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         request.contentType = new MediaType('application', 'json');
         expect(request.contentType.mimeType, equals('application/json'));
       });
 
       test('setting body', () async {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
 
-        var chunks = [
+        final chunks = <List<int>>[
           [1, 2],
           [3, 4]
         ];
@@ -51,16 +51,16 @@ void main() {
       });
 
       test('setting body in request dispatcher is supported', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        Completer c = new Completer();
+        final c = new Completer<String>();
         MockTransports.http.when(uri, (FinalizedRequest request) async {
           StreamedHttpBody body = request.body;
           c.complete(UTF8.decode(await body.toBytes()));
           return new MockResponse.ok();
         });
 
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         await request.post(
             uri: uri, body: new Stream.fromIterable([UTF8.encode('body')]));
         expect(await c.future, equals('body'));
@@ -68,16 +68,16 @@ void main() {
 
       test('setting body in request dispatcher should throw on invalid data',
           () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
 
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         expect(request.post(uri: uri, body: 'body'), throwsArgumentError);
       });
 
       test('body should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         await request.post(uri: uri);
         expect(() {
           request.body = new Stream.fromIterable([
@@ -87,15 +87,15 @@ void main() {
       });
 
       test('content-length must be set manually', () {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         request.contentLength = 10;
         expect(request.contentLength, equals(10));
       });
 
       test('content-length should be unmodifiable once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         await request.get(uri: uri);
         expect(() {
           request.contentLength = 10;
@@ -103,14 +103,14 @@ void main() {
       });
 
       test('setting encoding to null should throw', () {
-        var request = new StreamedRequest();
+        final request = new StreamedRequest();
         expect(() {
           request.encoding = null;
         }, throwsArgumentError);
       });
 
       test('setting encoding should update content-type', () {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         request.encoding = LATIN1;
@@ -123,7 +123,7 @@ void main() {
       test(
           'setting encoding should not update content-type if content-type has been set manually',
           () {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         expect(request.contentType.parameters['charset'], equals(UTF8.name));
 
         // Manually override content-type.
@@ -138,9 +138,9 @@ void main() {
       });
 
       test('setting content-type should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         await request.get(uri: uri);
         expect(() {
           request.contentType = new MediaType('application', 'x-custom');
@@ -148,9 +148,9 @@ void main() {
       });
 
       test('setting encoding should not be allowed once sent', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('GET', uri);
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         await request.get(uri: uri);
         expect(() {
           request.encoding = LATIN1;
@@ -158,9 +158,9 @@ void main() {
       });
 
       test('custom content-type without inferrable encoding', () async {
-        Uri uri = Uri.parse('/test');
+        final uri = Uri.parse('/test');
         MockTransports.http.expect('POST', uri);
-        var request = new StreamedRequest()
+        final request = new StreamedRequest()
           ..contentType = new MediaType('application', 'x-custom')
           ..body = new Stream.fromIterable([
             [1, 2]
@@ -169,7 +169,7 @@ void main() {
       });
 
       test('clone()', () {
-        StreamedRequest request = new StreamedRequest();
+        final request = new StreamedRequest();
         expect(request.clone, throwsUnsupportedError);
       });
 

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -24,7 +24,7 @@ import 'package:w_transport/src/http/utils.dart' as http_utils;
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicHttp;
 
@@ -36,13 +36,13 @@ void main() {
       });
 
       test('mapToQuery() with default encoding (UTF8)', () {
-        var map = {
+        final map = <String, String>{
           'foo': 'bar',
           'count': '10',
           'sentence': 'words with spaces',
           'chars': 'ç%/\\{].+"\''
         };
-        var expected = [
+        final expected = <String>[
           'foo=bar',
           'count=10',
           'sentence=words+with+spaces',
@@ -52,13 +52,13 @@ void main() {
       });
 
       test('mapToQuery() with non-default encoding (LATIN1)', () {
-        var map = {
+        final map = <String, String>{
           'foo': 'bar',
           'count': '10',
           'sentence': 'words with spaces',
           'chars': 'ç%/\\{].+"\''
         };
-        var expected = [
+        final expected = <String>[
           'foo=bar',
           'count=10',
           'sentence=words+with+spaces',
@@ -68,13 +68,13 @@ void main() {
       });
 
       test('queryToMap() with default encoding (UTF8)', () {
-        var query = [
+        final query = <String>[
           'foo=bar',
           'count=10',
           'sentence=words+with+spaces',
           'chars=%C3%A7%25%2F%5C%7B%5D.%2B%22%27'
         ].join('&');
-        var expected = {
+        final expected = <String, String>{
           'foo': 'bar',
           'count': '10',
           'sentence': 'words with spaces',
@@ -84,13 +84,13 @@ void main() {
       });
 
       test('queryToMap() with default encoding (UTF8)', () {
-        var query = [
+        final query = <String>[
           'foo=bar',
           'count=10',
           'sentence=words+with+spaces',
           'chars=%E7%25%2F%5C%7B%5D.%2B%22%27'
         ].join('&');
-        var expected = {
+        final expected = <String, String>{
           'foo': 'bar',
           'count': '10',
           'sentence': 'words with spaces',
@@ -101,15 +101,15 @@ void main() {
       });
 
       test('parseContentTypeFromHeaders()', () {
-        var headers = {'content-type': 'text/plain'};
-        MediaType ct = http_utils.parseContentTypeFromHeaders(headers);
+        final headers = <String, String>{'content-type': 'text/plain'};
+        final ct = http_utils.parseContentTypeFromHeaders(headers);
         expect(ct.mimeType, equals('text/plain'));
         expect(ct.parameters, isEmpty);
       });
 
       test('parseContentTypeFromHeaders() no content-type header', () {
-        var headers = <String, String>{};
-        MediaType ct = http_utils.parseContentTypeFromHeaders(headers);
+        final headers = <String, String>{};
+        final ct = http_utils.parseContentTypeFromHeaders(headers);
         expect(ct.mimeType, equals('application/octet-stream'),
             reason:
                 'application/octet-stream content-type should be assumed if header is missing.');
@@ -117,15 +117,17 @@ void main() {
       });
 
       test('parseContentTypeFromHeaders() case mismatch', () {
-        var headers = {'cOntEnt-tYPe': 'text/plain'};
-        MediaType ct = http_utils.parseContentTypeFromHeaders(headers);
+        final headers = <String, String>{'cOntEnt-tYPe': 'text/plain'};
+        final ct = http_utils.parseContentTypeFromHeaders(headers);
         expect(ct.mimeType, equals('text/plain'));
         expect(ct.parameters, isEmpty);
       });
 
       test('parseContentTypeFromHeaders() with parameters', () {
-        var headers = {'content-type': 'text/plain; charset=utf-8'};
-        MediaType ct = http_utils.parseContentTypeFromHeaders(headers);
+        final headers = <String, String>{
+          'content-type': 'text/plain; charset=utf-8'
+        };
+        final ct = http_utils.parseContentTypeFromHeaders(headers);
         expect(ct.mimeType, equals('text/plain'));
         expect(ct.parameters, containsPair('charset', 'utf-8'));
       });
@@ -139,7 +141,7 @@ void main() {
       });
 
       test('parseEncodingFromContentType() no charset', () {
-        MediaType ct = new MediaType('text', 'plain');
+        final ct = new MediaType('text', 'plain');
         expect(http_utils.parseEncodingFromContentType(ct, fallback: ASCII),
             equals(ASCII));
       });
@@ -150,7 +152,7 @@ void main() {
       });
 
       test('parseEncodingFromContentType() unrecognized charset', () {
-        MediaType ct = new MediaType('text', 'plain', {'charset': 'unknown'});
+        final ct = new MediaType('text', 'plain', {'charset': 'unknown'});
         expect(http_utils.parseEncodingFromContentType(ct, fallback: ASCII),
             equals(ASCII));
       });
@@ -165,7 +167,7 @@ void main() {
       });
 
       test('parseEncodingFromContentTypeOrFail() no charset', () {
-        MediaType ct = new MediaType('text', 'plain');
+        final ct = new MediaType('text', 'plain');
         expect(() {
           http_utils.parseEncodingFromContentTypeOrFail(ct);
         }, throwsFormatException);
@@ -178,7 +180,7 @@ void main() {
       });
 
       test('parseEncodingFromContentTypeOrFail() unrecognized charset', () {
-        MediaType ct = new MediaType('text', 'plain', {'charset': 'unknown'});
+        final ct = new MediaType('text', 'plain', {'charset': 'unknown'});
         expect(() {
           http_utils.parseEncodingFromContentTypeOrFail(ct);
         }, throwsFormatException);
@@ -193,62 +195,66 @@ void main() {
       });
 
       test('parseEncodingFromHeaders() case mismatch', () {
-        var headers = {'cOnteNt-tYPe': 'text/plain; charset=utf-8'};
+        final headers = <String, String>{
+          'cOnteNt-tYPe': 'text/plain; charset=utf-8'
+        };
         expect(http_utils.parseEncodingFromHeaders(headers), equals(UTF8));
       });
 
       test('parseEncodingFromHeaders() no charset', () {
-        var headers = {'content-type': 'text/plain'};
+        final headers = <String, String>{'content-type': 'text/plain'};
         expect(http_utils.parseEncodingFromHeaders(headers, fallback: ASCII),
             equals(ASCII));
       });
 
       test('parseEncodingFromHeaders() no content-type', () {
-        var headers = <String, String>{};
+        final headers = <String, String>{};
         expect(http_utils.parseEncodingFromHeaders(headers, fallback: ASCII),
             equals(ASCII));
       });
 
       test('parseEncodingFromHeaders() unrecognized charset', () {
-        var headers = {'content-type': 'text/plain; charset=unknown'};
+        final headers = <String, String>{
+          'content-type': 'text/plain; charset=unknown'
+        };
         expect(http_utils.parseEncodingFromHeaders(headers, fallback: ASCII),
             equals(ASCII));
       });
 
       test('reduceByteStream()', () async {
-        var byteStream = new Stream<List<int>>.fromIterable([
+        final byteStream = new Stream.fromIterable([
           [1, 2, 3],
           [4, 5],
           [6, 7, 8]
         ]);
-        var expected = new Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
+        final expected = new Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
         expect(await http_utils.reduceByteStream(byteStream), equals(expected));
       });
 
       test('reduceByteStream() empty', () async {
-        var byteStream = new Stream<List<int>>.fromIterable([]);
+        final byteStream = new Stream<List<int>>.fromIterable([]);
         expect(await http_utils.reduceByteStream(byteStream), isEmpty);
       });
 
       test('reduceByteStream() single element', () async {
-        var byteStream = new Stream<List<int>>.fromIterable([
+        final byteStream = new Stream.fromIterable([
           [1, 2]
         ]);
-        var expected = new Uint8List.fromList([1, 2]);
+        final expected = new Uint8List.fromList([1, 2]);
         expect(await http_utils.reduceByteStream(byteStream), equals(expected));
       });
 
       test('ByteStreamProgressListener', () async {
-        var byteStream = new Stream<List<int>>.fromIterable([
+        final byteStream = new Stream.fromIterable([
           [1, 2, 3],
           [4, 5, 6],
           [7, 8, 9, 10]
         ]);
-        var listener =
+        final listener =
             new http_utils.ByteStreamProgressListener(byteStream, total: 10);
 
-        var chunks = [];
-        await for (var chunk in listener.byteStream) {
+        final chunks = <List<int>>[];
+        await for (final chunk in listener.byteStream) {
           chunks.add(chunk);
         }
         expect(
@@ -259,7 +265,7 @@ void main() {
               [7, 8, 9, 10]
             ]));
 
-        var progressEvents = await listener.progressStream.toList();
+        final progressEvents = await listener.progressStream.toList();
         expect(progressEvents.length, equals(3));
         expect(progressEvents[0].percent, equals(30.0));
         expect(progressEvents[1].percent, equals(60.0));
@@ -267,15 +273,14 @@ void main() {
       });
 
       test('ByteStreamProgressListener pause/resume', () async {
-        var byteStream = new Stream<List<int>>.fromIterable([
+        final byteStream = new Stream.fromIterable([
           [1, 2, 3],
           [4, 5, 6],
         ]);
-        var listener = new http_utils.ByteStreamProgressListener(byteStream);
+        final listener = new http_utils.ByteStreamProgressListener(byteStream);
 
-        Completer done = new Completer();
-        StreamSubscription sub =
-            listener.byteStream.listen((_) {}, onDone: done.complete);
+        final done = new Completer<Null>();
+        final sub = listener.byteStream.listen((_) {}, onDone: done.complete);
         sub.pause();
         sub.resume();
         await done.future;

--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -21,13 +21,13 @@ import '../../naming.dart';
 import '../../utils.dart' show nextTick;
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicMocks;
 
   group(naming.toString(), () {
     group('TransportMocks.http', () {
-      Uri requestUri = Uri.parse('/mock/test');
+      final requestUri = Uri.parse('/mock/test');
 
       setUp(() {
         configureWTransportForTest();
@@ -35,7 +35,7 @@ void main() {
       });
 
       test('causeFailureOnOpen() should cause request to throw', () async {
-        Request request = new Request();
+        final request = new Request();
         MockTransports.http.causeFailureOnOpen(request);
         expect(request.get(uri: requestUri), throws);
       });
@@ -50,14 +50,14 @@ void main() {
 
       group('completeRequest()', () {
         test('completes a request with 200 OK by default', () async {
-          Request request = new Request();
+          final request = new Request();
           MockTransports.http.completeRequest(request);
           expect((await request.get(uri: requestUri)).status, equals(200));
         });
 
         test('can complete a request with custom response', () async {
-          Request request = new Request();
-          Response response = new MockResponse(202);
+          final request = new Request();
+          final response = new MockResponse(202);
           MockTransports.http.completeRequest(request, response: response);
           expect((await request.get(uri: requestUri)).status, equals(202));
         });
@@ -71,13 +71,13 @@ void main() {
         });
 
         test('expected request with custom response', () async {
-          Response response = new MockResponse(202);
+          final response = new MockResponse(202);
           MockTransports.http.expect('POST', requestUri, respondWith: response);
           expect((await Http.post(requestUri)).status, equals(202));
         });
 
         test('expected request failure', () async {
-          Exception exception = new Exception('Custom exception');
+          final exception = new Exception('Custom exception');
           MockTransports.http.expect('DELETE', requestUri, failWith: exception);
           expect(Http.delete(requestUri), throwsA(predicate((error) {
             return error.toString().contains('Custom exception');
@@ -110,14 +110,14 @@ void main() {
         });
 
         test('expected request with custom response', () async {
-          Response response = new MockResponse(202);
+          final response = new MockResponse(202);
           MockTransports.http.expectPattern('POST', requestUri.toString(),
               respondWith: response);
           expect((await Http.post(requestUri)).status, equals(202));
         });
 
         test('expected request failure', () async {
-          Exception exception = new Exception('Custom exception');
+          final exception = new Exception('Custom exception');
           MockTransports.http.expectPattern('DELETE', requestUri.toString(),
               failWith: exception);
           expect(Http.delete(requestUri), throwsA(predicate((error) {
@@ -143,7 +143,7 @@ void main() {
         });
 
         test('handles requests that match a pattern', () async {
-          var pattern = new RegExp('https:\/\/(google|github)\.com');
+          final pattern = new RegExp('https:\/\/(google|github)\.com');
 
           // ignore: unawaited_futures
           Http.get(Uri.parse('https://example.com')); // Wrong URI.
@@ -160,13 +160,13 @@ void main() {
 
       group('failRequest()', () {
         test('causes request to throw', () async {
-          Request request = new Request();
+          final request = new Request();
           MockTransports.http.failRequest(request);
           expect(request.get(uri: requestUri), throws);
         });
 
         test('can include a custom exception', () async {
-          Request request = new Request();
+          final request = new Request();
           MockTransports.http
               .failRequest(request, error: new Exception('Custom exception'));
           expect(request.get(uri: requestUri), throwsA(predicate((error) {
@@ -175,8 +175,8 @@ void main() {
         });
 
         test('can include a custom response', () async {
-          Request request = new Request();
-          Response response = new MockResponse.internalServerError();
+          final request = new Request();
+          final response = new MockResponse.internalServerError();
           MockTransports.http.failRequest(request, response: response);
           expect(request.get(uri: requestUri), throwsA(predicate((error) {
             return error is RequestException && error.response.status == 500;
@@ -193,7 +193,7 @@ void main() {
             requestUri.toString(), (req, match) async => new MockResponse.ok());
         MockTransports.http.expect('GET', Uri.parse('/expected'));
         MockTransports.http.expectPattern('GET', '/expected');
-        Request request = new Request();
+        final request = new Request();
         // ignore: unawaited_futures
         request.get(uri: Uri.parse('/other'));
         MockPlainTextRequest mockRequest = request;
@@ -204,14 +204,14 @@ void main() {
 
         // Would have been handled by either of the handlers, but should no
         // longer be:
-        Request request2 = new Request();
+        final request2 = new Request();
         // ignore: unawaited_futures
         request2.delete(uri: requestUri);
         MockPlainTextRequest mockRequest2 = request2;
         await mockRequest2.onSent;
 
         // Would have been expected, but should no longer be:
-        Request request3 = new Request();
+        final request3 = new Request();
         // ignore: unawaited_futures
         request3.get(uri: Uri.parse('/expected'));
         MockPlainTextRequest mockRequest3 = request3;
@@ -228,7 +228,7 @@ void main() {
         });
 
         test('throws if requests are pending', () async {
-          Request request = new Request();
+          final request = new Request();
           // ignore: unawaited_futures
           request.get(uri: requestUri);
           MockPlainTextRequest mockRequest = request;
@@ -250,7 +250,7 @@ void main() {
         test(
             'registers a handler for all requests with matching URI and method',
             () async {
-          Response ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http.when(requestUri, (_) async => ok, method: 'GET');
           // ignore: unawaited_futures
           Http.get(Uri.parse('/wrong')); // Wrong URI.
@@ -264,7 +264,7 @@ void main() {
         test(
             'registers a handler for all requests with matching URI and ANY method',
             () async {
-          Response ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http.when(requestUri, (_) async => ok);
           // ignore: unawaited_futures
           Http.get(Uri.parse('/wrong')); // Wrong URI.
@@ -275,7 +275,7 @@ void main() {
         });
 
         test('supports all standard methods', () async {
-          var ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http
               .when(requestUri, (_) async => ok, method: 'DELETE');
           MockTransports.http.when(requestUri, (_) async => ok, method: 'GET');
@@ -297,7 +297,7 @@ void main() {
         });
 
         test('supports custom method', () async {
-          var ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http.when(requestUri, (_) async => ok, method: 'COPY');
           await Http.send('COPY', requestUri);
         });
@@ -310,8 +310,8 @@ void main() {
         });
 
         test('registers a handler that can be canceled', () async {
-          var ok = new MockResponse.ok();
-          var handler = MockTransports.http.when(requestUri, (_) async => ok);
+          final ok = new MockResponse.ok();
+          final handler = MockTransports.http.when(requestUri, (_) async => ok);
           await Http.get(requestUri);
           handler.cancel();
           // ignore: unawaited_futures
@@ -322,7 +322,7 @@ void main() {
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
-          var oldHandler = MockTransports.http
+          MockHttpHandler oldHandler = MockTransports.http
               .when(requestUri, (_) async => new MockResponse.notFound());
           MockTransports.http
               .when(requestUri, (_) async => new MockResponse.ok());
@@ -345,7 +345,7 @@ void main() {
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
-          var oldHandler = MockTransports.http
+          MockHttpHandler oldHandler = MockTransports.http
               .when(requestUri, (_) async => new MockResponse.ok());
           MockTransports.reset();
           expect(() {
@@ -363,7 +363,7 @@ void main() {
         test(
             'registers a handler for all requests with a matching URI and method',
             () async {
-          var ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http.whenPattern(
               requestUri.toString(), (_a, _b) async => ok,
               method: 'GET');
@@ -379,7 +379,7 @@ void main() {
         test(
             'registers a handler for all requests with a matching URI and ANY method',
             () async {
-          var ok = new MockResponse.ok();
+          final ok = new MockResponse.ok();
           MockTransports.http
               .whenPattern(requestUri.toString(), (_a, _b) async => ok);
           // ignore: unawaited_futures
@@ -400,8 +400,8 @@ void main() {
         test(
             'registers a handler for all requests with a partially matching URI',
             () async {
-          var pattern = new RegExp('https:\/\/(google|github)\.com.*');
-          var ok = new MockResponse.ok();
+          final pattern = new RegExp('https:\/\/(google|github)\.com.*');
+          final ok = new MockResponse.ok();
           MockTransports.http.whenPattern(pattern, (_a, _b) async => ok);
           // ignore: unawaited_futures
           Http.get(Uri.parse('/wrong')); // Wrong URI.
@@ -412,8 +412,8 @@ void main() {
 
         test('handler should recieve the Match instance from the pattern test',
             () async {
-          var pattern = new RegExp('https:\/\/(google|github)\.com');
-          var matches = <Match>[];
+          final pattern = new RegExp('https:\/\/(google|github)\.com');
+          final matches = <Match>[];
           MockTransports.http.whenPattern(pattern, (_, match) async {
             matches.add(match);
             return new MockResponse.ok();
@@ -429,8 +429,8 @@ void main() {
         });
 
         test('registers a handler that can be canceled', () async {
-          var ok = new MockResponse.ok();
-          var handler = MockTransports.http
+          final ok = new MockResponse.ok();
+          final handler = MockTransports.http
               .whenPattern(requestUri.toString(), (_a, _b) async => ok);
           await Http.get(requestUri);
           handler.cancel();
@@ -442,7 +442,7 @@ void main() {
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
-          var oldHandler = MockTransports.http.whenPattern(
+          MockHttpHandler oldHandler = MockTransports.http.whenPattern(
               requestUri.toString(),
               (_a, _b) async => new MockResponse.notFound());
           MockTransports.http.whenPattern(
@@ -466,7 +466,7 @@ void main() {
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
-          var oldHandler = MockTransports.http.whenPattern(
+          MockHttpHandler oldHandler = MockTransports.http.whenPattern(
               requestUri.toString(), (_a, _b) async => new MockResponse.ok());
           MockTransports.reset();
           expect(() {

--- a/test/unit/mocks/mock_response_test.dart
+++ b/test/unit/mocks/mock_response_test.dart
@@ -23,14 +23,14 @@ import 'package:w_transport/mock.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicMocks;
 
   group(naming.toString(), () {
     group('MockResponse', () {
       test('custom constructor', () async {
-        Response response = new MockResponse(100,
+        final response = new MockResponse(100,
             statusText: 'custom', headers: {'x-custom': 'value'}, body: 'data');
         expect(response.status, equals(100));
         expect(response.statusText, equals('custom'));
@@ -39,71 +39,71 @@ void main() {
       });
 
       test('.ok() 200', () {
-        Response response = new MockResponse.ok();
+        final response = new MockResponse.ok();
         expect(response.status, equals(200));
         expect(response.statusText, equals('OK'));
       });
 
       test('.badRequest() 400', () {
-        Response response = new MockResponse.badRequest();
+        final response = new MockResponse.badRequest();
         expect(response.status, equals(400));
         expect(response.statusText, equals('BAD REQUEST'));
       });
 
       test('.unauthorized() 401', () {
-        Response response = new MockResponse.unauthorized();
+        final response = new MockResponse.unauthorized();
         expect(response.status, equals(401));
         expect(response.statusText, equals('UNAUTHORIZED'));
       });
 
       test('.forbidden() 403', () {
-        Response response = new MockResponse.forbidden();
+        final response = new MockResponse.forbidden();
         expect(response.status, equals(403));
         expect(response.statusText, equals('FORBIDDEN'));
       });
 
       test('.notFound() 404', () {
-        Response response = new MockResponse.notFound();
+        final response = new MockResponse.notFound();
         expect(response.status, equals(404));
         expect(response.statusText, equals('NOT FOUND'));
       });
 
       test('.methodNotAllowed() 405', () {
-        Response response = new MockResponse.methodNotAllowed();
+        final response = new MockResponse.methodNotAllowed();
         expect(response.status, equals(405));
         expect(response.statusText, equals('METHOD NOT ALLOWED'));
       });
 
       test('.internalServerError() 500', () {
-        Response response = new MockResponse.internalServerError();
+        final response = new MockResponse.internalServerError();
         expect(response.status, equals(500));
         expect(response.statusText, equals('INTERNAL SERVER ERROR'));
       });
 
       test('.notImplemented() 501', () {
-        Response response = new MockResponse.notImplemented();
+        final response = new MockResponse.notImplemented();
         expect(response.status, equals(501));
         expect(response.statusText, equals('NOT IMPLEMENTED'));
       });
 
       test('.badGateway() 502', () {
-        Response response = new MockResponse.badGateway();
+        final response = new MockResponse.badGateway();
         expect(response.status, equals(502));
         expect(response.statusText, equals('BAD GATEWAY'));
       });
 
       test('encoding should set charset', () {
-        Response response = new MockResponse(200, encoding: ASCII);
+        final response = new MockResponse(200, encoding: ASCII);
         expect(response.contentType.parameters['charset'], equals(ASCII.name));
       });
 
       test('should support string body', () {
-        Response response = new MockResponse(200, body: 'body');
+        final response = new MockResponse(200, body: 'body');
         expect(response.body.asString(), equals('body'));
       });
 
       test('should support bytes body', () {
-        Response response = new MockResponse(200, body: UTF8.encode('body'));
+        final response = new MockResponse(200, body: UTF8.encode('body'));
         expect(response.body.asString(), equals('body'));
       });
 
@@ -114,12 +114,12 @@ void main() {
       });
 
       test('content-length', () {
-        Response response = new MockResponse.ok(body: [1, 2]);
+        final response = new MockResponse.ok(body: [1, 2]);
         expect(response.contentLength, equals(2));
       });
 
       test('content-type', () {
-        Response response = new MockResponse.ok(
+        final response = new MockResponse.ok(
             headers: {'content-type': 'application/json; charset=utf-8'});
         expect(response.contentType.mimeType, equals('application/json'));
         expect(
@@ -127,8 +127,8 @@ void main() {
       });
 
       test('replace', () {
-        Response response = new MockResponse.ok();
-        Response response2 = response.replace(status: 201);
+        final response = new MockResponse.ok();
+        final response2 = response.replace(status: 201);
         expect(response2.status, equals(201));
       });
     });
@@ -138,7 +138,7 @@ void main() {
           new Stream.fromIterable([UTF8.encode(body)]);
 
       test('custom constructor', () async {
-        StreamedResponse response = new MockStreamedResponse(100,
+        final response = new MockStreamedResponse(100,
             statusText: 'custom',
             headers: {'x-custom': 'value'},
             byteStream: toByteStream('data'));
@@ -149,80 +149,78 @@ void main() {
       });
 
       test('.ok() 200', () {
-        StreamedResponse response = new MockStreamedResponse.ok();
+        final response = new MockStreamedResponse.ok();
         expect(response.status, equals(200));
         expect(response.statusText, equals('OK'));
       });
 
       test('.badRequest() 400', () {
-        StreamedResponse response = new MockStreamedResponse.badRequest();
+        final response = new MockStreamedResponse.badRequest();
         expect(response.status, equals(400));
         expect(response.statusText, equals('BAD REQUEST'));
       });
 
       test('.unauthorized() 401', () {
-        StreamedResponse response = new MockStreamedResponse.unauthorized();
+        final response = new MockStreamedResponse.unauthorized();
         expect(response.status, equals(401));
         expect(response.statusText, equals('UNAUTHORIZED'));
       });
 
       test('.forbidden() 403', () {
-        StreamedResponse response = new MockStreamedResponse.forbidden();
+        final response = new MockStreamedResponse.forbidden();
         expect(response.status, equals(403));
         expect(response.statusText, equals('FORBIDDEN'));
       });
 
       test('.notFound() 404', () {
-        StreamedResponse response = new MockStreamedResponse.notFound();
+        final response = new MockStreamedResponse.notFound();
         expect(response.status, equals(404));
         expect(response.statusText, equals('NOT FOUND'));
       });
 
       test('.methodNotAllowed() 405', () {
-        StreamedResponse response = new MockStreamedResponse.methodNotAllowed();
+        final response = new MockStreamedResponse.methodNotAllowed();
         expect(response.status, equals(405));
         expect(response.statusText, equals('METHOD NOT ALLOWED'));
       });
 
       test('.internalServerError() 500', () {
-        StreamedResponse response =
-            new MockStreamedResponse.internalServerError();
+        final response = new MockStreamedResponse.internalServerError();
         expect(response.status, equals(500));
         expect(response.statusText, equals('INTERNAL SERVER ERROR'));
       });
 
       test('.notImplemented() 501', () {
-        StreamedResponse response = new MockStreamedResponse.notImplemented();
+        final response = new MockStreamedResponse.notImplemented();
         expect(response.status, equals(501));
         expect(response.statusText, equals('NOT IMPLEMENTED'));
       });
 
       test('.badGateway() 502', () {
-        StreamedResponse response = new MockStreamedResponse.badGateway();
+        final response = new MockStreamedResponse.badGateway();
         expect(response.status, equals(502));
         expect(response.statusText, equals('BAD GATEWAY'));
       });
 
       test('encoding should set charset', () {
-        StreamedResponse response =
-            new MockStreamedResponse(200, encoding: ASCII);
+        final response = new MockStreamedResponse(200, encoding: ASCII);
         expect(response.contentType.parameters['charset'], equals(ASCII.name));
       });
 
       test('should support byteStream body', () async {
-        StreamedResponse response =
+        final response =
             new MockStreamedResponse(200, byteStream: toByteStream('body'));
         expect(UTF8.decode(await response.body.toBytes()), equals('body'));
       });
 
       test('content-length', () {
-        StreamedResponse response =
+        final response =
             new MockStreamedResponse.ok(headers: {'content-length': '5'});
         expect(response.contentLength, equals(5));
       });
 
       test('content-type', () {
-        StreamedResponse response = new MockStreamedResponse.ok(
+        final response = new MockStreamedResponse.ok(
             headers: {'content-type': 'application/json; charset=utf-8'});
         expect(response.contentType.mimeType, equals('application/json'));
         expect(
@@ -230,14 +228,13 @@ void main() {
       });
 
       test('encoding', () {
-        StreamedResponse response =
-            new MockStreamedResponse(200, encoding: UTF8);
+        final response = new MockStreamedResponse(200, encoding: UTF8);
         expect(response.encoding, equals(UTF8));
       });
 
       test('replace', () {
-        StreamedResponse response = new MockStreamedResponse.ok();
-        StreamedResponse response2 = response.replace(status: 201);
+        final response = new MockStreamedResponse.ok();
+        final response2 = response.replace(status: 201);
         expect(response2.status, equals(201));
       });
     });

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -24,7 +24,7 @@ import 'package:w_transport/src/web_socket/mock/web_socket.dart';
 import '../../naming.dart';
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicMocks;
 
@@ -34,7 +34,7 @@ void main() {
     });
 
     group('TransportMocks.webSocket', () {
-      Uri webSocketUri = Uri.parse('/mock/ws');
+      final webSocketUri = Uri.parse('/mock/ws');
 
       setUp(() {
         configureWTransportForTest();
@@ -44,7 +44,7 @@ void main() {
       group('expect()', () {
         test('expected web socket connection completes automatically',
             () async {
-          WSocket webSocket = new MockWSocket();
+          final webSocket = new MockWSocket();
           MockTransports.webSocket.expect(webSocketUri, connectTo: webSocket);
           expect(await WSocket.connect(webSocketUri), equals(webSocket));
         });
@@ -79,7 +79,7 @@ void main() {
       group('expectPattern()', () {
         test('expected web socket connection completes automatically',
             () async {
-          WSocket webSocket = new MockWSocket();
+          final webSocket = new MockWSocket();
           MockTransports.webSocket
               .expectPattern(webSocketUri.toString(), connectTo: webSocket);
           expect(await WSocket.connect(webSocketUri), equals(webSocket));
@@ -134,7 +134,7 @@ void main() {
         test(
             'registers a handler for all web socket connections with matching URI',
             () async {
-          WSocket webSocket = new MockWSocket();
+          final webSocket = new MockWSocket();
           Future<WSocket> handler(Uri uri,
                   {Iterable<String> protocols,
                   Map<String, dynamic> headers}) async =>
@@ -183,8 +183,8 @@ void main() {
         });
 
         test('registers a handler that can be canceled', () async {
-          var webSocket = new MockWSocket();
-          var handler = MockTransports.webSocket.when(webSocketUri,
+          final webSocket = new MockWSocket();
+          final handler = MockTransports.webSocket.when(webSocketUri,
               handler: (uri, {protocols, headers}) async => webSocket);
 
           expect(await WSocket.connect(webSocketUri), equals(webSocket));
@@ -194,8 +194,8 @@ void main() {
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
-          var webSocket = new MockWSocket();
-          var oldHandler =
+          final webSocket = new MockWSocket();
+          final oldHandler =
               MockTransports.webSocket.when(webSocketUri, reject: true);
           MockTransports.webSocket.when(webSocketUri,
               handler: (uri, {protocols, headers}) async => webSocket);
@@ -207,8 +207,8 @@ void main() {
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
-          var webSocket = new MockWSocket();
-          var oldHandler = MockTransports.webSocket.when(webSocketUri,
+          final webSocket = new MockWSocket();
+          final oldHandler = MockTransports.webSocket.when(webSocketUri,
               handler: (uri, {protocols, headers}) async => webSocket);
           MockTransports.reset();
 
@@ -224,7 +224,7 @@ void main() {
         test(
             'registers a handler for all web socket connections with matching URI',
             () async {
-          WSocket webSocket = new MockWSocket();
+          final webSocket = new MockWSocket();
           Future<WSocket> handler(Uri uri,
                   {Iterable<String> protocols,
                   Map<String, dynamic> headers,
@@ -279,8 +279,8 @@ void main() {
         test(
             'registers a handler with a pattern that catches any connection with a matching URI',
             () async {
-          var uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
-          WSocket webSocket = new MockWSocket();
+          final uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
+          final webSocket = new MockWSocket();
           Future<WSocket> handler(Uri uri,
                   {Iterable<String> protocols,
                   Map<String, dynamic> headers,
@@ -301,7 +301,7 @@ void main() {
         test(
             'registers a handler that will receive the uri Match on connection',
             () async {
-          var uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
+          final uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
           Match uriMatch;
           Future<WSocket> handler(Uri uri,
               {Iterable<String> protocols,
@@ -319,8 +319,8 @@ void main() {
         });
 
         test('registers a handler that can be canceled', () async {
-          var webSocket = new MockWSocket();
-          var handler = MockTransports.webSocket.whenPattern(
+          final webSocket = new MockWSocket();
+          final handler = MockTransports.webSocket.whenPattern(
               webSocketUri.toString(),
               handler: (uri, {protocols, headers, match}) async => webSocket);
 
@@ -331,8 +331,8 @@ void main() {
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
-          var webSocket = new MockWSocket();
-          var oldHandler = MockTransports.webSocket
+          final webSocket = new MockWSocket();
+          final oldHandler = MockTransports.webSocket
               .whenPattern(webSocketUri.toString(), reject: true);
           MockTransports.webSocket.whenPattern(webSocketUri.toString(),
               handler: (uri, {protocols, headers, match}) async => webSocket);
@@ -344,8 +344,8 @@ void main() {
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
-          var webSocket = new MockWSocket();
-          var oldHandler = MockTransports.webSocket.whenPattern(
+          final webSocket = new MockWSocket();
+          final oldHandler = MockTransports.webSocket.whenPattern(
               webSocketUri.toString(),
               handler: (uri, {protocols, headers, match}) async => webSocket);
           MockTransports.reset();

--- a/test/unit/ws/w_socket_subscription_test.dart
+++ b/test/unit/ws/w_socket_subscription_test.dart
@@ -31,12 +31,13 @@ void main() {
     group('WSocketSubscription', () {
       test('cancel() should cancel underlying subscription and call callback',
           () async {
-        var subCanceled = new Completer();
-        var onCancelCalled = new Completer();
+        final subCanceled = new Completer<Null>();
+        final onCancelCalled = new Completer<Null>();
 
-        var sc = new StreamController(onCancel: subCanceled.complete);
-        var sub = sc.stream.listen((_) {});
-        var wsub = new WSocketSubscription(sub, () {},
+        final sc =
+            new StreamController<dynamic>(onCancel: subCanceled.complete);
+        final sub = sc.stream.listen((_) {});
+        final wsub = new WSocketSubscription(sub, () {},
             onCancel: onCancelCalled.complete);
 
         await Future.wait([
@@ -48,9 +49,9 @@ void main() {
 
       test('isPaused should return the status of the underlying subscription',
           () {
-        var sc = new StreamController();
-        var sub = sc.stream.listen((_) {});
-        var wsub = new WSocketSubscription(sub, () {});
+        final sc = new StreamController<dynamic>();
+        final sub = sc.stream.listen((_) {});
+        final wsub = new WSocketSubscription(sub, () {});
 
         expect(sub.isPaused, isFalse);
         expect(wsub.isPaused, isFalse);
@@ -61,9 +62,9 @@ void main() {
       });
 
       test('onDone() should update the done handler', () {
-        var sub = new MockStreamSubscription();
-        var wsub = new WSocketSubscription(sub, () {});
-        var doneHandler = () {};
+        final sub = new MockStreamSubscription();
+        final wsub = new WSocketSubscription(sub, () {});
+        final doneHandler = () {};
 
         wsub.onDone(doneHandler);
         expect(wsub.doneHandler, equals(doneHandler));
@@ -71,18 +72,18 @@ void main() {
 
       test('onError() should call onError() on the underlying subscription',
           () {
-        var sub = new MockStreamSubscription();
-        var wsub = new WSocketSubscription(sub, () {});
-        var errorHandler = (_) {};
+        final sub = new MockStreamSubscription();
+        final wsub = new WSocketSubscription(sub, () {});
+        final errorHandler = (_) {};
 
         wsub.onError(errorHandler);
         verify(sub.onError(errorHandler));
       });
 
       test('onData() should call onData() on the underlying subscription', () {
-        var sub = new MockStreamSubscription();
-        var wsub = new WSocketSubscription(sub, () {});
-        var dataHandler = (_) {};
+        final sub = new MockStreamSubscription();
+        final wsub = new WSocketSubscription(sub, () {});
+        final dataHandler = (_) {};
 
         wsub.onData(dataHandler);
         verify(sub.onData(dataHandler));

--- a/test/unit/ws/web_socket_test.dart
+++ b/test/unit/ws/web_socket_test.dart
@@ -23,7 +23,7 @@ import '../../naming.dart';
 import '../../utils.dart' show nextTick;
 
 void main() {
-  Naming naming = new Naming()
+  final naming = new Naming()
     ..testType = testTypeUnit
     ..topic = topicWebSocket;
 
@@ -39,7 +39,7 @@ void main() {
 }
 
 void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
-  Uri webSocketUri = Uri.parse('ws://mock.com/ws');
+  final webSocketUri = Uri.parse('ws://mock.com/ws');
 
   setUp(() {
     configureWTransportForTest();
@@ -47,15 +47,15 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('message events should be discarded prior to a subscription', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
     mockWebSocket.addIncoming('1');
     mockWebSocket.addIncoming('2');
     await nextTick();
 
-    var messages = [];
+    final messages = <String>[];
     webSocket.listen((data) {
       messages.add(data);
     });
@@ -72,11 +72,11 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   test(
       'the first event should be received if a subscription is made immediately',
       () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var c = new Completer();
+    final c = new Completer<String>();
     webSocket.listen((data) {
       c.complete(data);
     });
@@ -87,17 +87,17 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
 
   test('all event streams should respect pause() and resume() signals',
       () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
-    var messages = [];
+    final webSocket = await WSocket.connect(webSocketUri);
+    final messages = <String>[];
 
     // no subscription yet, messages should be discarded
     mockWebSocket.addIncoming('1');
     await nextTick();
 
     // setup a subscription, messages should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       messages.add(data);
     });
     mockWebSocket.addIncoming('2');
@@ -117,15 +117,15 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('onData() handler should be reassignable', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var origHandlerMessages = [];
-    var newHandlerMessages = [];
+    final origHandlerMessages = <String>[];
+    final newHandlerMessages = <String>[];
 
     // Messages from original handler should be recorded
-    var sub = webSocket.listen((data) {
+    final sub = webSocket.listen((data) {
       origHandlerMessages.add(data);
     });
     mockWebSocket.addIncoming('orig');
@@ -143,13 +143,13 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('onDone() handler should be reassignable', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var sub = webSocket.listen((_) {}, onDone: () {});
+    final sub = webSocket.listen((_) {}, onDone: () {});
 
-    var c = new Completer();
+    final c = new Completer<Null>();
     sub.onDone(() {
       c.complete();
     });
@@ -159,11 +159,11 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('add() should send data to underlying web socket', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var c = new Completer();
+    final c = new Completer<String>();
     mockWebSocket.onOutgoing(c.complete);
 
     webSocket.add('message');
@@ -173,11 +173,11 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('addStream() should send data to underlying web socket', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var controller = new StreamController();
+    final controller = new StreamController<dynamic>();
     mockWebSocket.onOutgoing(controller.add);
 
     await webSocket.addStream(new Stream.fromIterable(['one', 'two']));
@@ -191,11 +191,11 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
 
   test('addStream() should cause the web socket to close when erorr is added',
       () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
-    var controller = new StreamController();
+    final controller = new StreamController<dynamic>();
     controller.add('message');
     controller.addError(new Exception('addStream error, should close socket'));
     // ignore: unawaited_futures
@@ -206,9 +206,9 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
   });
 
   test('addError() should cause the web socket to close', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
     expect(webSocket.done, throwsException);
     webSocket.addError(new Exception('web socket consumer error'));
@@ -216,18 +216,18 @@ void _runWebSocketSuite(Future<WSocket> getWebSocket(Uri uri)) {
 
   // TODO: remove this test once triggerServerError has been removed
   test('DEPRECATED: error should close the socket', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
 
     mockWebSocket.triggerServerError(new Exception('Server Exception'));
     await webSocket.done;
   });
 
   test('server closing the connection should close the socket', () async {
-    var mockWebSocket = new MockWSocket();
+    final mockWebSocket = new MockWSocket();
     MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
-    var webSocket = await WSocket.connect(webSocketUri);
+    final webSocket = await WSocket.connect(webSocketUri);
     mockWebSocket.triggerServerClose(1000, 'closed');
     await webSocket.done;
     expect(webSocket.closeCode, equals(1000));

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -14,6 +14,6 @@
 
 import 'dart:async';
 
-Future nextTick() {
-  return new Future.delayed(new Duration(milliseconds: 1));
+Future<Null> nextTick() {
+  return new Future<Null>.delayed(new Duration(milliseconds: 1));
 }

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -22,7 +22,7 @@ import 'server/server.dart' show Server;
 Future<Null> main(List<String> args) async {
   // https://github.com/Workiva/dart_dev
 
-  List<String> directories = ['example/', 'lib/', 'test/', 'tool/'];
+  final directories = <String>['example/', 'lib/', 'test/', 'tool/'];
 
   config.analyze.entryPoints = [
     'example/',

--- a/tool/server/handler.dart
+++ b/tool/server/handler.dart
@@ -27,7 +27,7 @@ abstract class Handler {
 
   /// Main entry point for request handling.
   /// Sub-classes should implement only the necessary REST method handlers.
-  Future processRequest(HttpRequest request) async {
+  Future<Null> processRequest(HttpRequest request) async {
     Function handler;
     switch (request.method) {
       case 'COPY':
@@ -90,14 +90,13 @@ abstract class Handler {
   /// configured in the call to [enableCors].
   void setCorsHeaders(HttpRequest request) {
     // Use given allow origin, but default to allowing every origin (by using origin of request)
-    String origin = _allowedOrigin != null
+    final origin = _allowedOrigin != null
         ? _allowedOrigin
         : request.headers.value('Origin');
     request.response.headers.set('Access-Control-Allow-Origin', origin);
 
     // Allow all headers (by using the requested headers)
-    List<String> requestHeaders =
-        request.headers['Access-Control-Request-Headers'];
+    final requestHeaders = request.headers['Access-Control-Request-Headers'];
     if (requestHeaders != null) {
       requestHeaders.forEach((h) {
         request.response.headers.add('Access-Control-Allow-Headers', h);
@@ -116,26 +115,41 @@ abstract class Handler {
   }
 
   /// RESTful method handlers. Override as necessary.
-  Future copy(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future delete(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future get(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future head(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future patch(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future post(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future put(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
-  Future trace(HttpRequest request) async =>
-      request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  Future<Null> copy(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> delete(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> get(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> head(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> patch(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> post(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> put(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
+
+  Future<Null> trace(HttpRequest request) async {
+    request.response.statusCode = HttpStatus.METHOD_NOT_ALLOWED;
+  }
 
   /// Handler for the OPTIONS request. For convenience, this returns
   /// 200 OK by default if CORS support has been enabled.
-  Future options(HttpRequest request) async {
+  Future<Null> options(HttpRequest request) async {
     if (_corsEnabled) {
       request.response.statusCode = HttpStatus.OK;
       setCorsHeaders(request);
@@ -147,8 +161,8 @@ abstract class Handler {
 
 abstract class WebSocketHandler extends Handler {
   @override
-  Future processRequest(HttpRequest request) async {
-    WebSocket webSocket = await WebSocketTransformer.upgrade(request);
+  Future<Null> processRequest(HttpRequest request) async {
+    final webSocket = await WebSocketTransformer.upgrade(request);
     onConnection(webSocket);
   }
 

--- a/tool/server/handlers/example/http/cross_origin_credentials_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_credentials_handlers.dart
@@ -61,7 +61,7 @@ class SessionHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
     request.response
@@ -69,10 +69,10 @@ class SessionHandler extends Handler {
   }
 
   @override
-  Future post(HttpRequest request) async {
+  Future<Null> post(HttpRequest request) async {
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
-    Map<String, String> headers = createSessionHeaders(generateSessionCookie());
+    final headers = createSessionHeaders(generateSessionCookie());
     headers.forEach((h, v) {
       request.response.headers.set(h, v);
     });
@@ -80,11 +80,11 @@ class SessionHandler extends Handler {
   }
 
   @override
-  Future delete(HttpRequest request) async {
+  Future<Null> delete(HttpRequest request) async {
     session = null;
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
-    Map<String, String> headers = createSessionHeaders('deleted');
+    final headers = createSessionHeaders('deleted');
     headers.forEach((h, v) {
       request.response.headers.set(h, v);
     });
@@ -98,7 +98,7 @@ class CredentialedRequestHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     // Verify the request has a valid session cookie
     if (isValidSession(request)) {
       request.response.statusCode = HttpStatus.OK;

--- a/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
@@ -33,13 +33,13 @@ Directory filesDirectory =
     new Directory('example/http/cross_origin_file_transfer/files');
 
 Future<String> _readFileUploadAsString(HttpMultipartFormData formData) async {
-  var parts = await formData.toList();
+  final parts = await formData.toList();
   return parts.join('');
 }
 
 Future<List<int>> _readFileUploadAsBytes(HttpMultipartFormData formData) async {
   List<int> bytes = [];
-  await for (var data in formData) {
+  await for (final data in formData) {
     if (data is List<int>) {
       bytes.addAll(data);
     }
@@ -49,17 +49,17 @@ Future<List<int>> _readFileUploadAsBytes(HttpMultipartFormData formData) async {
 
 void _writeFileUploadAsString(String filename, String contents) {
   _createUploadDirectory();
-  Uri uploadDestination =
+  final uploadDestination =
       Uri.parse('example/http/cross_origin_file_transfer/files/$filename');
-  File upload = new File.fromUri(uploadDestination);
+  final upload = new File.fromUri(uploadDestination);
   upload.writeAsStringSync(contents);
 }
 
 void _writeFileUploadAsBytes(String filename, List<int> bytes) {
   _createUploadDirectory();
-  Uri uploadDestination =
+  final uploadDestination =
       Uri.parse('example/http/cross_origin_file_transfer/files/$filename');
-  File upload = new File.fromUri(uploadDestination);
+  final upload = new File.fromUri(uploadDestination);
   upload.writeAsBytesSync(bytes);
 }
 
@@ -114,17 +114,17 @@ class UploadHandler extends Handler {
   }
 
   @override
-  Future post(HttpRequest request) async {
+  Future<Null> post(HttpRequest request) async {
     if (request.headers['content-type'] == null) {
       request.response.statusCode = HttpStatus.BAD_REQUEST;
       setCorsHeaders(request);
       return;
     }
 
-    ContentType contentType =
+    final contentType =
         ContentType.parse(request.headers.value('content-type'));
-    String boundary = contentType.parameters['boundary'];
-    Stream stream = request
+    final boundary = contentType.parameters['boundary'];
+    final stream = request
         .transform(new MimeMultipartTransformer(boundary))
         .map(HttpMultipartFormData.parse);
 
@@ -137,10 +137,10 @@ class UploadHandler extends Handler {
           }
 
           if (formData.isText) {
-            String contents = await _readFileUploadAsString(formData);
+            final contents = await _readFileUploadAsString(formData);
             _writeFileUploadAsString(filename, contents);
           } else {
-            List<int> bytes = await _readFileUploadAsBytes(formData);
+            final bytes = await _readFileUploadAsBytes(formData);
             _writeFileUploadAsBytes(filename, bytes);
           }
       }
@@ -160,7 +160,7 @@ class FilesHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     Iterable<File> files = fw.files.where(
         (FileSystemEntity entity) => entity is File && entity.existsSync());
     List<Map> filesPayload = files
@@ -175,7 +175,7 @@ class FilesHandler extends Handler {
   }
 
   @override
-  Future delete(HttpRequest request) async {
+  Future<Null> delete(HttpRequest request) async {
     Iterable<File> files =
         fw.files.where((FileSystemEntity entity) => entity is File);
     files.forEach((File entity) {
@@ -192,13 +192,13 @@ class DownloadHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     if (request.uri.queryParameters['file'] == null) {
       request.response.statusCode = HttpStatus.NOT_FOUND;
       setCorsHeaders(request);
       return;
     }
-    String requestedFile =
+    final requestedFile =
         Uri.parse(request.uri.queryParameters['file']).pathSegments.last;
     if (requestedFile == '' || requestedFile == null) {
       request.response.statusCode = HttpStatus.NOT_FOUND;
@@ -206,18 +206,18 @@ class DownloadHandler extends Handler {
       return;
     }
 
-    bool shouldForceDownload = request.uri.queryParameters['dl'] == '1';
+    final shouldForceDownload = request.uri.queryParameters['dl'] == '1';
 
-    Uri fileUri = Uri
+    final fileUri = Uri
         .parse('example/http/cross_origin_file_transfer/files/$requestedFile');
-    File file = new File.fromUri(fileUri);
+    final file = new File.fromUri(fileUri);
     if (!file.existsSync()) {
       request.response.statusCode = HttpStatus.NOT_FOUND;
       setCorsHeaders(request);
       return;
     }
 
-    Map headers = {
+    final headers = <String, String>{
       'content-length': file.lengthSync().toString(),
       'content-type': lookupMimeType(fileUri.path),
     };

--- a/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/proxy_cross_origin_file_transfer_handlers.dart
@@ -49,15 +49,14 @@ class FilesProxy extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
-    Map<String, String> headers = {};
+  Future<Null> get(HttpRequest request) async {
+    final headers = <String, String>{};
     request.headers.forEach((name, values) {
       headers[name] = values.join(', ');
     });
-    Request proxyRequest = getHttpClient().newRequest()..headers = headers;
+    final proxyRequest = getHttpClient().newRequest()..headers = headers;
 
-    StreamedResponse proxyResponse =
-        await proxyRequest.streamGet(uri: filesEndpoint);
+    final proxyResponse = await proxyRequest.streamGet(uri: filesEndpoint);
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
     proxyResponse.headers.forEach((h, v) {
@@ -67,15 +66,14 @@ class FilesProxy extends Handler {
   }
 
   @override
-  Future delete(HttpRequest request) async {
-    Map<String, String> headers = {};
+  Future<Null> delete(HttpRequest request) async {
+    final headers = <String, String>{};
     request.headers.forEach((name, values) {
       headers[name] = values.join(', ');
     });
-    Request proxyRequest = getHttpClient().newRequest()..headers = headers;
+    final proxyRequest = getHttpClient().newRequest()..headers = headers;
 
-    StreamedResponse proxyResponse =
-        await proxyRequest.streamDelete(uri: filesEndpoint);
+    final proxyResponse = await proxyRequest.streamDelete(uri: filesEndpoint);
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
     proxyResponse.headers.forEach((h, v) {
@@ -91,14 +89,14 @@ class UploadProxy extends Handler {
   }
 
   @override
-  Future post(HttpRequest request) async {
-    Map<String, String> headers = {};
+  Future<Null> post(HttpRequest request) async {
+    final headers = <String, String>{};
     request.headers.forEach((name, values) {
       headers[name] = values.join(', ');
     });
-    MediaType contentType =
+    final contentType =
         new MediaType.parse(request.headers.value('content-type'));
-    StreamedRequest proxyRequest = getHttpClient().newStreamedRequest()
+    final proxyRequest = getHttpClient().newStreamedRequest()
       ..headers = headers
       ..body = request
       ..contentLength = request.contentLength
@@ -131,12 +129,12 @@ class DownloadProxy extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
-    Map<String, String> headers = {};
+  Future<Null> get(HttpRequest request) async {
+    final headers = <String, String>{};
     request.headers.forEach((name, values) {
       headers[name] = values.join(', ');
     });
-    Request proxyRequest = getHttpClient().newRequest()
+    final proxyRequest = getHttpClient().newRequest()
       ..uri = downloadEndpoint
       ..query = request.uri.query
       ..headers = headers;

--- a/tool/server/handlers/ping_handler.dart
+++ b/tool/server/handlers/ping_handler.dart
@@ -24,7 +24,7 @@ class PingHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     request.response.statusCode = HttpStatus.OK;
     setCorsHeaders(request);
   }

--- a/tool/server/handlers/test/http/404_handler.dart
+++ b/tool/server/handlers/test/http/404_handler.dart
@@ -23,32 +23,32 @@ class FourzerofourHandler extends Handler {
     enableCors();
   }
 
-  Future notFound(HttpRequest request) async {
+  Future<Null> notFound(HttpRequest request) async {
     request.response.statusCode = HttpStatus.NOT_FOUND;
     setCorsHeaders(request);
   }
 
   @override
-  Future delete(HttpRequest request) => notFound(request);
+  Future<Null> delete(HttpRequest request) => notFound(request);
 
   @override
-  Future get(HttpRequest request) => notFound(request);
+  Future<Null> get(HttpRequest request) => notFound(request);
 
   @override
-  Future head(HttpRequest request) => notFound(request);
+  Future<Null> head(HttpRequest request) => notFound(request);
 
   @override
-  Future options(HttpRequest request) => notFound(request);
+  Future<Null> options(HttpRequest request) => notFound(request);
 
   @override
-  Future patch(HttpRequest request) => notFound(request);
+  Future<Null> patch(HttpRequest request) => notFound(request);
 
   @override
-  Future post(HttpRequest request) => notFound(request);
+  Future<Null> post(HttpRequest request) => notFound(request);
 
   @override
-  Future put(HttpRequest request) => notFound(request);
+  Future<Null> put(HttpRequest request) => notFound(request);
 
   @override
-  Future trace(HttpRequest request) => notFound(request);
+  Future<Null> trace(HttpRequest request) => notFound(request);
 }

--- a/tool/server/handlers/test/http/custom.dart
+++ b/tool/server/handlers/test/http/custom.dart
@@ -24,7 +24,7 @@ class CustomHandler extends Handler {
   }
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     request.response.statusCode =
         request.uri.queryParameters['status'] ?? HttpStatus.OK;
     request.response.headers.contentType = request.headers.contentType;

--- a/tool/server/handlers/test/http/download.dart
+++ b/tool/server/handlers/test/http/download.dart
@@ -24,9 +24,9 @@ class DownloadHandler extends Handler {
     enableCors();
   }
 
-  Future download(HttpRequest request) async {
-    File file = new File('tool/server/handlers/test/http/file.txt');
-    var downloadStream = file.openRead();
+  Future<Null> download(HttpRequest request) async {
+    final file = new File('tool/server/handlers/test/http/file.txt');
+    final downloadStream = file.openRead();
     request.response.statusCode = HttpStatus.OK;
     request.response.headers
         .set('content-length', file.lengthSync().toString());
@@ -36,29 +36,29 @@ class DownloadHandler extends Handler {
   }
 
   @override
-  Future copy(HttpRequest request) async => download(request);
+  Future<Null> copy(HttpRequest request) async => download(request);
 
   @override
-  Future delete(HttpRequest request) async => download(request);
+  Future<Null> delete(HttpRequest request) async => download(request);
 
   @override
-  Future get(HttpRequest request) async => download(request);
+  Future<Null> get(HttpRequest request) async => download(request);
 
   @override
-  Future head(HttpRequest request) async => download(request);
+  Future<Null> head(HttpRequest request) async => download(request);
 
   @override
-  Future options(HttpRequest request) async => download(request);
+  Future<Null> options(HttpRequest request) async => download(request);
 
   @override
-  Future patch(HttpRequest request) async => download(request);
+  Future<Null> patch(HttpRequest request) async => download(request);
 
   @override
-  Future post(HttpRequest request) async => download(request);
+  Future<Null> post(HttpRequest request) async => download(request);
 
   @override
-  Future put(HttpRequest request) async => download(request);
+  Future<Null> put(HttpRequest request) async => download(request);
 
   @override
-  Future trace(HttpRequest request) async => download(request);
+  Future<Null> trace(HttpRequest request) async => download(request);
 }

--- a/tool/server/handlers/test/http/echo.dart
+++ b/tool/server/handlers/test/http/echo.dart
@@ -25,7 +25,7 @@ class EchoHandler extends Handler {
     enableCors();
   }
 
-  Future echo(HttpRequest request) async {
+  Future<Null> echo(HttpRequest request) async {
     request.response.statusCode = HttpStatus.OK;
     request.response.headers.contentType = request.headers.contentType;
     setCorsHeaders(request);
@@ -33,29 +33,29 @@ class EchoHandler extends Handler {
   }
 
   @override
-  Future copy(HttpRequest request) async => echo(request);
+  Future<Null> copy(HttpRequest request) async => echo(request);
 
   @override
-  Future delete(HttpRequest request) async => echo(request);
+  Future<Null> delete(HttpRequest request) async => echo(request);
 
   @override
-  Future get(HttpRequest request) async => echo(request);
+  Future<Null> get(HttpRequest request) async => echo(request);
 
   @override
-  Future head(HttpRequest request) async => echo(request);
+  Future<Null> head(HttpRequest request) async => echo(request);
 
   @override
-  Future options(HttpRequest request) async => echo(request);
+  Future<Null> options(HttpRequest request) async => echo(request);
 
   @override
-  Future patch(HttpRequest request) async => echo(request);
+  Future<Null> patch(HttpRequest request) async => echo(request);
 
   @override
-  Future post(HttpRequest request) async => echo(request);
+  Future<Null> post(HttpRequest request) async => echo(request);
 
   @override
-  Future put(HttpRequest request) async => echo(request);
+  Future<Null> put(HttpRequest request) async => echo(request);
 
   @override
-  Future trace(HttpRequest request) async => echo(request);
+  Future<Null> trace(HttpRequest request) async => echo(request);
 }

--- a/tool/server/handlers/test/http/error.dart
+++ b/tool/server/handlers/test/http/error.dart
@@ -22,7 +22,7 @@ class ErrorHandler extends Handler {
   ErrorHandler() : super();
 
   @override
-  Future get(HttpRequest request) async {
+  Future<Null> get(HttpRequest request) async {
     request.response.statusCode =
         request.uri.queryParameters['status'] ?? HttpStatus.OK;
     request.response.headers.contentType = request.headers.contentType;

--- a/tool/server/handlers/test/http/reflect_handler.dart
+++ b/tool/server/handlers/test/http/reflect_handler.dart
@@ -31,8 +31,8 @@ class ReflectHandler extends Handler {
     enableCors();
   }
 
-  Future reflect(HttpRequest request) async {
-    Map<String, String> headers = {};
+  Future<Null> reflect(HttpRequest request) async {
+    final headers = <String, String>{};
     request.headers.forEach((name, values) {
       headers[name] = values.join(', ');
     });
@@ -41,7 +41,7 @@ class ReflectHandler extends Handler {
     if (request.headers.contentType == null) {
       encoding = LATIN1;
     } else {
-      MediaType contentType = new MediaType(
+      final contentType = new MediaType(
           request.headers.contentType.primaryType,
           request.headers.contentType.subType,
           request.headers.contentType.parameters);
@@ -49,7 +49,7 @@ class ReflectHandler extends Handler {
           fallback: LATIN1);
     }
 
-    Map reflection = {
+    final reflection = <String, Object>{
       'method': request.method,
       'path': request.uri.path,
       'headers': headers,
@@ -64,29 +64,29 @@ class ReflectHandler extends Handler {
   }
 
   @override
-  Future copy(HttpRequest request) async => reflect(request);
+  Future<Null> copy(HttpRequest request) async => reflect(request);
 
   @override
-  Future delete(HttpRequest request) async => reflect(request);
+  Future<Null> delete(HttpRequest request) async => reflect(request);
 
   @override
-  Future get(HttpRequest request) async => reflect(request);
+  Future<Null> get(HttpRequest request) async => reflect(request);
 
   @override
-  Future head(HttpRequest request) async => reflect(request);
+  Future<Null> head(HttpRequest request) async => reflect(request);
 
   @override
-  Future options(HttpRequest request) async => reflect(request);
+  Future<Null> options(HttpRequest request) async => reflect(request);
 
   @override
-  Future patch(HttpRequest request) async => reflect(request);
+  Future<Null> patch(HttpRequest request) async => reflect(request);
 
   @override
-  Future post(HttpRequest request) async => reflect(request);
+  Future<Null> post(HttpRequest request) async => reflect(request);
 
   @override
-  Future put(HttpRequest request) async => reflect(request);
+  Future<Null> put(HttpRequest request) async => reflect(request);
 
   @override
-  Future trace(HttpRequest request) async => reflect(request);
+  Future<Null> trace(HttpRequest request) async => reflect(request);
 }

--- a/tool/server/handlers/test/http/timeout_handler.dart
+++ b/tool/server/handlers/test/http/timeout_handler.dart
@@ -23,29 +23,29 @@ class TimeoutHandler extends Handler {
     enableCors();
   }
 
-  Future timeout() => new Completer().future;
+  Future<Null> timeout() => new Completer<Null>().future;
 
   @override
-  Future delete(HttpRequest request) => timeout();
+  Future<Null> delete(HttpRequest request) => timeout();
 
   @override
-  Future get(HttpRequest request) => timeout();
+  Future<Null> get(HttpRequest request) => timeout();
 
   @override
-  Future head(HttpRequest request) => timeout();
+  Future<Null> head(HttpRequest request) => timeout();
 
   @override
-  Future options(HttpRequest request) => timeout();
+  Future<Null> options(HttpRequest request) => timeout();
 
   @override
-  Future patch(HttpRequest request) => timeout();
+  Future<Null> patch(HttpRequest request) => timeout();
 
   @override
-  Future post(HttpRequest request) => timeout();
+  Future<Null> post(HttpRequest request) => timeout();
 
   @override
-  Future put(HttpRequest request) => timeout();
+  Future<Null> put(HttpRequest request) => timeout();
 
   @override
-  Future trace(HttpRequest request) => timeout();
+  Future<Null> trace(HttpRequest request) => timeout();
 }

--- a/tool/server/handlers/test/http/upload.dart
+++ b/tool/server/handlers/test/http/upload.dart
@@ -26,11 +26,11 @@ class UploadHandler extends Handler {
     enableCors();
   }
 
-  Future upload(HttpRequest request) async {
-    ContentType contentType =
+  Future<Null> upload(HttpRequest request) async {
+    final contentType =
         ContentType.parse(request.headers.value('content-type'));
-    String boundary = contentType.parameters['boundary'];
-    Stream stream = request
+    final boundary = contentType.parameters['boundary'];
+    final stream = request
         .transform(new MimeMultipartTransformer(boundary))
         .map(HttpMultipartFormData.parse);
 
@@ -47,26 +47,26 @@ class UploadHandler extends Handler {
   }
 
   @override
-  Future delete(HttpRequest request) async => upload(request);
+  Future<Null> delete(HttpRequest request) async => upload(request);
 
   @override
-  Future get(HttpRequest request) async => upload(request);
+  Future<Null> get(HttpRequest request) async => upload(request);
 
   @override
-  Future head(HttpRequest request) async => upload(request);
+  Future<Null> head(HttpRequest request) async => upload(request);
 
   @override
-  Future options(HttpRequest request) async => upload(request);
+  Future<Null> options(HttpRequest request) async => upload(request);
 
   @override
-  Future patch(HttpRequest request) async => upload(request);
+  Future<Null> patch(HttpRequest request) async => upload(request);
 
   @override
-  Future post(HttpRequest request) async => upload(request);
+  Future<Null> post(HttpRequest request) async => upload(request);
 
   @override
-  Future put(HttpRequest request) async => upload(request);
+  Future<Null> put(HttpRequest request) async => upload(request);
 
   @override
-  Future trace(HttpRequest request) async => upload(request);
+  Future<Null> trace(HttpRequest request) async => upload(request);
 }

--- a/tool/server/handlers/test/ws/close_handler.dart
+++ b/tool/server/handlers/test/ws/close_handler.dart
@@ -28,9 +28,9 @@ class CloseHandler extends WebSocketHandler {
   void onConnection(WebSocket webSocket) {
     webSocket.listen((message) {
       if (message.startsWith('close')) {
-        var parts = message.split(':');
-        var closeCode;
-        var closeReason;
+        final parts = message.split(':');
+        int closeCode;
+        String closeReason;
         if (parts.length >= 2) {
           closeCode = int.parse(parts[1]);
         }

--- a/tool/server/handlers/test/ws/ping_handler.dart
+++ b/tool/server/handlers/test/ws/ping_handler.dart
@@ -29,7 +29,7 @@ class PingHandler extends WebSocketHandler {
   void onConnection(WebSocket webSocket) {
     webSocket.listen((message) async {
       message = message.replaceAll('ping', '');
-      var numPongs = 1;
+      int numPongs = 1;
       try {
         numPongs = int.parse(message);
       } catch (_) {}

--- a/tool/server/logger.dart
+++ b/tool/server/logger.dart
@@ -16,7 +16,7 @@ import 'dart:async';
 import 'dart:io';
 
 class Logger implements Function {
-  StreamController<String> _controller = new StreamController();
+  StreamController<String> _controller = new StreamController<String>();
 
   Logger();
 
@@ -30,17 +30,17 @@ class Logger implements Function {
     }
   }
 
-  Future close() {
-    return _controller.close();
+  Future<Null> close() async {
+    await _controller.close();
   }
 
   void logError(Object error, [StackTrace stackTrace]) {
-    var e = stackTrace != null ? '$error\n$stackTrace' : '$error';
+    final e = stackTrace != null ? '$error\n$stackTrace' : '$error';
     this(e, true);
   }
 
   void logRequest(HttpRequest request) {
-    DateTime time = new DateTime.now();
+    final time = new DateTime.now();
     this(
         '$time\t${request.method}\t${request.response.statusCode}\t${request.uri.path}');
   }

--- a/tool/server/router.dart
+++ b/tool/server/router.dart
@@ -42,7 +42,7 @@ class Router implements Function {
       ..addAll(getTestWebSocketIntegrationRoutes(logger));
   }
 
-  Future call(HttpRequest request) async {
+  Future<Null> call(HttpRequest request) async {
     if (routes.containsKey(request.uri.path)) {
       await routes[request.uri.path].processRequest(request);
     } else {

--- a/tool/server/server.dart
+++ b/tool/server/server.dart
@@ -37,7 +37,7 @@ class Server {
       {bool dumpOutput: false,
       String host: defaultHost,
       int port: defaultPort}) {
-    Server server = new Server(host: host, port: port);
+    final server = new Server(host: host, port: port);
     server.output.listen(print);
     return server.start();
   }
@@ -45,7 +45,7 @@ class Server {
   Stream get output => _logger.stream;
 
   Future<Null> start() async {
-    var router = new Router(_logger);
+    final router = new Router(_logger);
 
     try {
       _server = await HttpServer.bind(host, port);
@@ -67,7 +67,7 @@ class Server {
     }
   }
 
-  Future stop() async {
+  Future<Null> stop() async {
     await Future.wait(
         [_server.close(force: true), _subscription.cancel(), _logger.close()]);
   }


### PR DESCRIPTION
## Improvement
Now that strong-mode analyzer and linter have been enabled, I wanted to standardize the way variables are declared in this codebase. The goal was to provide strong typing (which is guaranteed by the strong-mode analysis) while avoiding overly-verbose syntax (like specifying the type on both the left- and right-hand side everywhere.

## Changes
In this process, I developed a set of guidelines based on the "Effective Dart" guides as well as input from the Dart community that I've come across.

1. **Always type public members.**

  This one is pretty straightforward and there's even a linter rule for it. Anything exposed publicly should be strongly typed so that there's no confusion for consumers.

1. **If the return type is unknown, but you expect it to be an object (in other words, you expect it to implement `toString()` and `hashCode`): use `Object`.**

  There are times when the return type just isn't known. This is totally fine, but it should be communicated explicitly by using `Object` instead of omitting the type.

1. **If the return type is _truly unknown_: use `dynamic`.**

  If the return type is unknown _and_ you can't guarantee that it will be an `Object`, use `dynamic`.

1. **Don't use `var`.**

  This one is probably the most surprising because of how often it is used. [Jim Beveridge originally pointed me in this direction](https://github.com/Workiva/w_flux/pull/63#r67577219) and I've convinced myself that it's a good idea.

  Using `var` tells the analyzer absolutely nothing. Using `final` tells the analyzer that the variable should not be overwritten.

  If the value doesn't change, then using `final` instead of `var` is an easy switch that tells the analyzer more without requiring any additional changes.

    ```dart
    // This variable can be reassigned later to any type.
    var number = 4;

    // This variable cannot be reassigned.
    // We have a guarantee of the value and type.
    final number = 4;
    ```

  If the value can change after the initial declaration/assignment, then we should leverage typing so that the analyzer can ensure we don't set the variable to an incompatible type when it does change.

    ```dart
    // If we use `var`, we have no guarantee on the type of `result`.
    // Theoretically, `result` could be assigned to an incompatible type later.
    var result;
    if (condition) {
      result = 'success';
    } else {
      result = 'failure';
    }
    return result;

    // If we specify the expected type, we regain the type guarantee and
    // the analyzer can help us detect invalid assignments/operations.
    String result;
    if (condition) {
      result = 'success';
    } else {
      result = 'failure';
    }
    return result;
    ```

1. **Omit the type on the LHS if it can be sufficiently inferred from the RHS.**

  This applies only to non-public members because of rule 1. The goal of this rule is to avoid unnecessarily verbose typing like the following:

    ```dart
    StreamController<List<int>> byteStreamController = new StreamController<List<int>>();
    ```

  If the RHS is fully-typed, we can omit the typing on the LHS while still satisfying the strong-mode analysis:

    ```dart
    final byteStreamController = new StreamController<List<int>>();
    ```

1. **Don't omit the generic type. If no return value is expected, use `Null`.**

    ```diff
    - Future
    + Future<Null>
    - Completer
    + Completer<Null>
    ```

## Testing
- [ ] CI passes.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 