### PR TITLE
CP-1883 Use null-aware operators

### DIFF
--- a/example/common/global_example_menu_component.dart
+++ b/example/common/global_example_menu_component.dart
@@ -74,9 +74,7 @@ class GlobalExampleMenuComponent extends react.Component {
 
   @override
   void componentWillUnmount() {
-    if (serverPolling != null) {
-      serverPolling.cancel();
-    }
+    serverPolling?.cancel();
   }
 
   Object _buildServerStatusComponent(String name, bool online) {

--- a/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -64,10 +64,8 @@ class DropZoneComponent extends react.Component {
   }
 
   void showDropTarget(Event e) {
-    if (_hideDropTargetTimer != null) {
-      _hideDropTargetTimer.cancel();
-    }
     e.preventDefault();
+    _hideDropTargetTimer?.cancel();
     this.props['onDragStart']();
     this.setState({'overDropZone': true});
   }

--- a/example/http/cross_origin_file_transfer/services/remote_files.dart
+++ b/example/http/cross_origin_file_transfer/services/remote_files.dart
@@ -96,9 +96,7 @@ class RemoteFiles {
 
   /// Cancel polling.
   void _endPolling() {
-    if (_pollingTimer != null) {
-      _pollingTimer.cancel();
-    }
+    _pollingTimer?.cancel();
   }
 }
 

--- a/lib/src/http/auto_retry.dart
+++ b/lib/src/http/auto_retry.dart
@@ -185,7 +185,7 @@ class RetryBackOff {
       {bool withJitter: true, Duration maxInterval})
       : method = RetryBackOffMethod.exponential,
         withJitter = withJitter,
-        maxInterval = maxInterval != null ? maxInterval : defaultMaxInterval;
+        maxInterval = maxInterval ?? defaultMaxInterval;
 
   /// Construct a new fixed back-off representation where [interval] is the
   /// delay between each retry.

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -128,8 +128,7 @@ class BrowserMultipartRequest extends CommonRequest
         } else if (value is Blob) {
           formData.appendBlob(name, value);
         } else if (value is MultipartFile) {
-          final contentType =
-              value.contentType != null ? value.contentType.toString() : null;
+          final contentType = value.contentType?.toString();
           final blob = new Blob(await value.byteStream.toList(), contentType);
           formData.appendBlob(name, blob, value.filename);
         }

--- a/lib/src/http/browser/request_mixin.dart
+++ b/lib/src/http/browser/request_mixin.dart
@@ -29,9 +29,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
 
   @override
   void abortRequest() {
-    if (_request != null) {
-      _request.abort();
-    }
+    _request?.abort();
   }
 
   @override
@@ -120,9 +118,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
   }
 
   Future<BaseResponse> _createResponse({bool streamResponse: false}) async {
-    if (streamResponse == null) {
-      streamResponse = false;
-    }
+    streamResponse ??= false;
 
     BaseResponse response;
     if (streamResponse) {
@@ -134,8 +130,7 @@ abstract class BrowserRequestMixin implements BaseRequest, CommonRequest {
       });
       // ignore: unawaited_futures
       reader.onError.first.then(result.completeError);
-      reader.readAsArrayBuffer(
-          _request.response != null ? _request.response : new Blob([]));
+      reader.readAsArrayBuffer(_request.response ?? new Blob([]));
       final bytes = await result.future;
       final byteStream = new Stream.fromIterable([bytes]);
       response = new StreamedResponse.fromByteStream(_request.status,

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -44,10 +44,7 @@ abstract class CommonFormRequest extends CommonRequest implements FormRequest {
   @override
   set fields(Map<String, dynamic> fields) {
     verifyUnsent();
-    if (fields == null) {
-      fields = {};
-    }
-    _fields = fields;
+    _fields = fields ?? {};
   }
 
   Uint8List get _encodedQuery {

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -74,9 +74,7 @@ abstract class CommonMultipartRequest extends CommonRequest
   }
 
   String get boundary {
-    if (_boundary == null) {
-      _boundary = _generateBoundaryString();
-    }
+    _boundary ??= _generateBoundaryString();
     return _boundary;
   }
 

--- a/lib/src/http/common/streamed_request.dart
+++ b/lib/src/http/common/streamed_request.dart
@@ -71,9 +71,7 @@ abstract class CommonStreamedRequest extends CommonRequest
       }
     }
 
-    if (this.body == null) {
-      this.body = new Stream.fromIterable([]);
-    }
+    this.body ??= new Stream.fromIterable([]);
     return new StreamedHttpBody.fromByteStream(contentType, this.body,
         contentLength: contentLength);
   }

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -67,20 +67,10 @@ class HttpBody extends BaseHttpBody {
   /// `charset` param), then [fallbackEncoding] will be used (UTF8 by default).
   HttpBody.fromBytes(this.contentType, List<int> bytes,
       {Encoding encoding, Encoding fallbackEncoding}) {
-    if (fallbackEncoding == null) {
-      fallbackEncoding = UTF8;
-    }
-    if (encoding != null) {
-      _encoding = encoding;
-    } else {
-      _encoding = http_utils.parseEncodingFromContentType(contentType,
-          fallback: fallbackEncoding);
-    }
-
-    if (bytes == null) {
-      bytes = [];
-    }
-    _bytes = new Uint8List.fromList(bytes);
+    _encoding = encoding ??
+        http_utils.parseEncodingFromContentType(contentType,
+            fallback: fallbackEncoding ?? UTF8);
+    _bytes = new Uint8List.fromList(bytes ?? []);
   }
 
   /// Construct the body to an HTTP request or an HTTP response from text.
@@ -99,20 +89,10 @@ class HttpBody extends BaseHttpBody {
   /// `charset` param), then [fallbackEncoding] will be used (UTF8 by default).
   HttpBody.fromString(this.contentType, String body,
       {Encoding encoding, Encoding fallbackEncoding}) {
-    if (fallbackEncoding == null) {
-      fallbackEncoding = UTF8;
-    }
-    if (encoding != null) {
-      _encoding = encoding;
-    } else {
-      _encoding = http_utils.parseEncodingFromContentType(contentType,
-          fallback: fallbackEncoding);
-    }
-
-    if (body == null) {
-      body = '';
-    }
-    _body = body;
+    _encoding = encoding ??
+        http_utils.parseEncodingFromContentType(contentType,
+            fallback: fallbackEncoding ?? UTF8);
+    _body = body ?? '';
   }
 
   /// The size of this request/response body in bytes.

--- a/lib/src/http/mock/request_mixin.dart
+++ b/lib/src/http/mock/request_mixin.dart
@@ -84,9 +84,7 @@ abstract class MockRequestMixin implements MockBaseRequest, CommonRequest {
 
   @override
   void complete({BaseResponse response}) {
-    if (response == null) {
-      response = new MockResponse.ok();
-    }
+    response ??= new MockResponse.ok();
     // Defer the "fetching" of the response until the request has been sent.
     onSent.then((_) async {
       // Coerce the response to the correct format (streamed or not).

--- a/lib/src/http/mock/response.dart
+++ b/lib/src/http/mock/response.dart
@@ -30,8 +30,7 @@ class MockResponse implements Response {
       Map<String, String> headers,
       String statusText}) {
     // Ensure the headers are case insensitive.
-    headers =
-        new CaseInsensitiveMap<String>.from(headers != null ? headers : {});
+    headers = new CaseInsensitiveMap<String>.from(headers ?? {});
 
     // If an encoding was given, update the content-type charset parameter.
     if (encoding != null) {
@@ -41,13 +40,8 @@ class MockResponse implements Response {
     }
 
     // Use a default status text based on the status code if one is not given.
-    if (statusText == null) {
-      statusText = _mapStatusToText(status);
-    }
-
-    if (body == null) {
-      body = '';
-    }
+    statusText ??= _mapStatusToText(status);
+    body ??= '';
 
     // Construct the body according to the data type.
     if (body is String) {
@@ -151,8 +145,7 @@ class MockStreamedResponse implements StreamedResponse {
       Map<String, String> headers,
       String statusText}) {
     // Ensure the headers are case insensitive.
-    headers =
-        new CaseInsensitiveMap<String>.from(headers != null ? headers : {});
+    headers = new CaseInsensitiveMap<String>.from(headers ?? {});
 
     // If an encoding was given, update the content-type charset parameter.
     if (encoding != null) {
@@ -162,13 +155,8 @@ class MockStreamedResponse implements StreamedResponse {
     }
 
     // Use a default status text based on the status code if one is not given.
-    if (statusText == null) {
-      statusText = _mapStatusToText(status);
-    }
-
-    if (byteStream == null) {
-      byteStream = new Stream.fromIterable([]);
-    }
+    statusText ??= _mapStatusToText(status);
+    byteStream ??= new Stream.fromIterable([]);
 
     // Construct the body according to the data type.
     _response = new StreamedResponse.fromByteStream(

--- a/lib/src/http/response.dart
+++ b/lib/src/http/response.dart
@@ -109,15 +109,9 @@ class Response extends BaseResponse {
       int status,
       String statusText,
       Map<String, String> headers}) {
-    if (status == null) {
-      status = this.status;
-    }
-    if (statusText == null) {
-      statusText = this.statusText;
-    }
-    if (headers == null) {
-      headers = this.headers;
-    }
+    status ??= this.status;
+    statusText ??= this.statusText;
+    headers ??= this.headers;
     if (bodyBytes == null) {
       if (bodyString == null) {
         return new Response._(status, statusText, headers, _body);
@@ -167,15 +161,9 @@ class StreamedResponse extends BaseResponse {
       int status,
       String statusText,
       Map<String, String> headers}) {
-    if (status == null) {
-      status = this.status;
-    }
-    if (statusText == null) {
-      statusText = this.statusText;
-    }
-    if (headers == null) {
-      headers = this.headers;
-    }
+    status ??= this.status;
+    statusText ??= this.statusText;
+    headers ??= this.headers;
     if (byteStream == null) {
       return new StreamedResponse._(status, statusText, headers, _body);
     } else {

--- a/lib/src/http/response_format_exception.dart
+++ b/lib/src/http/response_format_exception.dart
@@ -49,7 +49,7 @@ class ResponseFormatException implements Exception {
     }
 
     String msg = description;
-    final encodingName = encoding != null ? encoding.name : 'null';
+    final encodingName = encoding?.name ?? 'null';
     msg += '\n\tContent-Type: $contentType';
     msg += '\n\tEncoding: $encodingName';
     msg += '\n\t$bodyLine';

--- a/lib/src/http/utils.dart
+++ b/lib/src/http/utils.dart
@@ -36,18 +36,10 @@ String mapToQuery(Map<String, Object> map, {Encoding encoding}) {
     // Support fields with multiple values.
     final valueList = value is List ? value : [value];
     for (final v in valueList) {
-      Iterable<String> encoded;
-      if (encoding != null) {
-        encoded = <String>[
-          Uri.encodeQueryComponent(key, encoding: encoding),
-          Uri.encodeQueryComponent(v, encoding: encoding)
-        ];
-      } else {
-        encoded = <String>[
-          Uri.encodeQueryComponent(key),
-          Uri.encodeQueryComponent(v)
-        ];
-      }
+      final encoded = <String>[
+        Uri.encodeQueryComponent(key, encoding: encoding ?? UTF8),
+        Uri.encodeQueryComponent(v, encoding: encoding ?? UTF8),
+      ];
       params.add(encoded.join('='));
     }
   });
@@ -62,8 +54,9 @@ String mapToQuery(Map<String, Object> map, {Encoding encoding}) {
 MediaType parseContentTypeFromHeaders(Map<String, String> headers) {
   // Ensure the headers are case-insensitive.
   headers = new CaseInsensitiveMap<String>.from(headers);
-  if (headers['content-type'] != null)
+  if (headers['content-type'] != null) {
     return new MediaType.parse(headers['content-type']);
+  }
   return new MediaType('application', 'octet-stream');
 }
 
@@ -78,7 +71,7 @@ Encoding parseEncodingFromContentType(MediaType contentType,
   if (contentType == null) return fallback;
   if (contentType.parameters['charset'] == null) return fallback;
   final encoding = Encoding.getByName(contentType.parameters['charset']);
-  return encoding != null ? encoding : fallback;
+  return encoding ?? fallback;
 }
 
 /// Returns the [Encoding] specified by the `charset` parameter of
@@ -118,15 +111,13 @@ Map<String, Object> queryToMap(String query, {Encoding encoding}) {
   for (final pair in query.split('&')) {
     final pieces = pair.split('=');
     if (pieces.isEmpty) continue;
+
     String key = pieces.first;
     String value = pieces.length > 1 ? pieces.sublist(1).join('') : '';
-    if (encoding != null) {
-      key = Uri.decodeQueryComponent(key, encoding: encoding);
-      value = Uri.decodeQueryComponent(value, encoding: encoding);
-    } else {
-      key = Uri.decodeQueryComponent(key);
-      value = Uri.decodeQueryComponent(value);
-    }
+
+    key = Uri.decodeQueryComponent(key, encoding: encoding ?? UTF8);
+    value = Uri.decodeQueryComponent(value, encoding: encoding ?? UTF8);
+
     if (fields.containsKey(key)) {
       if (fields[key] is! List) {
         fields[key] = [fields[key]];

--- a/lib/src/http/vm/http_client.dart
+++ b/lib/src/http/vm/http_client.dart
@@ -29,9 +29,7 @@ class VMHttpClient extends CommonHttpClient implements HttpClient {
   /// Close the underlying HTTP client.
   @override
   void closeClient() {
-    if (_ioHttpClient != null) {
-      _ioHttpClient.close();
-    }
+    _ioHttpClient?.close();
   }
 
   /// Constructs a new [FormRequest] that will use this client to send the

--- a/lib/src/http/vm/request_mixin.dart
+++ b/lib/src/http/vm/request_mixin.dart
@@ -36,15 +36,13 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
 
   @override
   void abortRequest() {
-    if (_request != null) {
-      _request.close();
-    }
+    _request?.close();
   }
 
   @override
   void cleanUp() {
-    if (_isSingle && _client != null) {
-      _client.close();
+    if (_isSingle) {
+      _client?.close();
     }
   }
 
@@ -65,9 +63,7 @@ abstract class VMRequestMixin implements BaseRequest, CommonRequest {
   Future<BaseResponse> sendRequestAndFetchResponse(
       FinalizedRequest finalizedRequest,
       {bool streamResponse: false}) async {
-    if (streamResponse == null) {
-      streamResponse = false;
-    }
+    streamResponse ??= false;
 
     if (finalizedRequest.headers != null) {
       finalizedRequest.headers.forEach(_request.headers.set);

--- a/lib/src/mocks/web_socket.dart
+++ b/lib/src/mocks/web_socket.dart
@@ -62,7 +62,7 @@ class MockWebSocket {
   MockWebSocketHandler whenPattern(Pattern uriPattern,
       {WSocketPatternConnectHandler handler, bool reject}) {
     MockWebSocketInternal._validateWhenParams(handler: handler, reject: reject);
-    if (reject != null && reject) {
+    if (reject == true) {
       handler = (uri, {protocols, headers, match}) {
         throw new WebSocketException('Mock connection to $uri rejected.');
       };

--- a/lib/src/web_socket/browser/sockjs.dart
+++ b/lib/src/web_socket/browser/sockjs.dart
@@ -66,7 +66,7 @@ class SockJSWebSocket extends CommonWebSocket implements WebSocket {
         debug: debug == true,
         noCredentials: noCredentials == true,
         protocolsWhitelist: protocolsWhitelist,
-        timeout: timeout != null ? timeout.inMilliseconds : null);
+        timeout: timeout?.inMilliseconds);
 
     // Listen for and store the close event. This will determine whether or
     // not the socket connected successfully, and will also be used later

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: ">=1.14.0 <2.0.0"
 
 dependencies:
   fluri: ^1.1.0

--- a/test/integration/http/http_static/suite.dart
+++ b/test/integration/http/http_static/suite.dart
@@ -14,7 +14,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:test/test.dart';
 import 'package:w_transport/w_transport.dart';

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
 void mockCustomEndpoint(Uri uri) {

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -21,9 +21,7 @@ import '../integration_paths.dart';
 
 void runCommonWebSocketIntegrationTests(
     {Future<WSocket> connect(Uri uri), int port}) {
-  if (connect == null) {
-    connect = (uri) => WSocket.connect(uri);
-  }
+  connect ??= (uri) => WSocket.connect(uri);
   Uri closeUri = IntegrationPaths.closeUri;
   Uri echoUri = IntegrationPaths.echoUri;
   final fourOhFourUri = IntegrationPaths.fourOhFourUri;

--- a/test/unit/http/browser_utils_test.dart
+++ b/test/unit/http/browser_utils_test.dart
@@ -17,7 +17,6 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport.dart' show RequestProgress;
 
 import 'package:w_transport/src/http/browser/utils.dart'
     show transformProgressEvents;

--- a/test/unit/http/request_exception_test.dart
+++ b/test/unit/http/request_exception_test.dart
@@ -14,7 +14,7 @@
 
 @TestOn('vm || browser')
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport.dart' show RequestException, Response;
+import 'package:w_transport/w_transport.dart' show RequestException;
 import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';

--- a/test/unit/mocks/mock_response_test.dart
+++ b/test/unit/mocks/mock_response_test.dart
@@ -17,7 +17,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:test/test.dart';
-import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/mock.dart';
 
 import '../../naming.dart';

--- a/tool/server/handler.dart
+++ b/tool/server/handler.dart
@@ -70,29 +70,26 @@ abstract class Handler {
       {bool credentials: true, List<String> methods, String origin}) {
     _corsEnabled = true;
     _credentialsAllowed = credentials == true;
-    _allowedMethods = (methods != null)
-        ? methods
-        : [
-            'COPY',
-            'DELETE',
-            'GET',
-            'HEAD',
-            'OPTIONS',
-            'PATCH',
-            'POST',
-            'PUT',
-            'TRACE'
-          ];
-    _allowedOrigin = (origin != null) ? origin : null;
+    _allowedMethods = methods ??
+        [
+          'COPY',
+          'DELETE',
+          'GET',
+          'HEAD',
+          'OPTIONS',
+          'PATCH',
+          'POST',
+          'PUT',
+          'TRACE'
+        ];
+    _allowedOrigin = origin;
   }
 
   /// Creates and sets the Access-Control headers based on the CORS settings
   /// configured in the call to [enableCors].
   void setCorsHeaders(HttpRequest request) {
     // Use given allow origin, but default to allowing every origin (by using origin of request)
-    final origin = _allowedOrigin != null
-        ? _allowedOrigin
-        : request.headers.value('Origin');
+    final origin = _allowedOrigin ?? request.headers.value('Origin');
     request.response.headers.set('Access-Control-Allow-Origin', origin);
 
     // Allow all headers (by using the requested headers)

--- a/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
@@ -131,10 +131,9 @@ class UploadHandler extends Handler {
     await for (HttpMultipartFormData formData in stream) {
       switch (formData.contentDisposition.parameters['name']) {
         case 'file':
-          String filename = formData.contentDisposition.parameters['filename'];
-          if (filename == null) {
-            filename = new DateTime.now().toString();
-          }
+          String filename =
+              formData.contentDisposition.parameters['filename'] ??
+                  new DateTime.now().toString();
 
           if (formData.isText) {
             final contents = await _readFileUploadAsString(formData);


### PR DESCRIPTION
_Fixes #144._

## Improvement
Now that we've bumped the minimum SDK version, we can leverage null-aware operators.

## Changes
Update all applicable areas in the example/source/test code where null-aware operators can be used to simplify null-checking logic.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 