### PR TITLE
CP-2786 Mock updates

### DIFF
--- a/lib/mock.dart
+++ b/lib/mock.dart
@@ -24,7 +24,7 @@
 ///     }
 library w_transport.mock;
 
-import 'package:w_transport/src/mocks/transport.dart' show MockTransports;
+import 'package:w_transport/src/mocks/mock_transports.dart' show MockTransports;
 
 export 'package:w_transport/src/http/finalized_request.dart'
     show FinalizedRequest;
@@ -40,11 +40,17 @@ export 'package:w_transport/src/http/mock/requests.dart'
 export 'package:w_transport/src/http/mock/response.dart'
     show MockResponse, MockStreamedResponse;
 
-export 'package:w_transport/src/mocks/http.dart'
-    show MockHttpHandler, PatternRequestHandler, RequestHandler;
-export 'package:w_transport/src/mocks/transport.dart' show MockTransports;
-export 'package:w_transport/src/mocks/web_socket.dart'
-    show MockWebSocketHandler;
+export 'package:w_transport/src/mocks/mock_transports.dart'
+    show
+        MockHttpHandler,
+        MockTransports,
+        MockWebSocketConnection,
+        MockWebSocketHandler,
+        MockWebSocketServer,
+        PatternRequestHandler,
+        RequestHandler,
+        WebSocketConnectHandler,
+        WebSocketPatternConnectHandler;
 
 export 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -29,8 +29,9 @@ import 'package:w_transport/src/http/request_progress.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/http/response.dart';
 import 'package:w_transport/src/http/common/backoff.dart';
-import 'package:w_transport/src/mocks/http.dart' show MockHttpInternal;
-import 'package:w_transport/src/mocks/transport.dart'
+import 'package:w_transport/src/mocks/mock_transports.dart'
+    show MockHttpInternal;
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 
 abstract class CommonRequest extends Object

--- a/lib/src/http/http_client.dart
+++ b/lib/src/http/http_client.dart
@@ -14,7 +14,7 @@
 
 import 'package:w_transport/src/global_transport_platform.dart';
 import 'package:w_transport/src/http/client.dart';
-import 'package:w_transport/src/mocks/transport.dart'
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
 

--- a/lib/src/http/mock/base_request.dart
+++ b/lib/src/http/mock/base_request.dart
@@ -14,10 +14,12 @@
 
 import 'dart:async';
 
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/finalized_request.dart';
 import 'package:w_transport/src/http/response.dart';
 
+@Deprecated(v3Deprecation)
 abstract class MockBaseRequest extends BaseRequest {
   Future<Null> get onCanceled;
   Future<FinalizedRequest> get onSent;

--- a/lib/src/http/mock/client.dart
+++ b/lib/src/http/mock/client.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/transport_platform.dart';
@@ -20,6 +21,7 @@ import 'package:w_transport/src/transport_platform.dart';
 /// mock implementations of each request. Since the mock request implementations
 /// don't ever actually send an HTTP request, this client doesn't need to do
 /// anything else.
+@Deprecated(v3Deprecation)
 class MockClient extends MockHttpClient implements HttpClient {
   MockClient(TransportPlatform transport) : super(transport);
 }

--- a/lib/src/http/mock/request_mixin.dart
+++ b/lib/src/http/mock/request_mixin.dart
@@ -24,7 +24,8 @@ import 'package:w_transport/src/http/request_progress.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/http/response.dart';
 import 'package:w_transport/src/http/utils.dart' as http_utils;
-import 'package:w_transport/src/mocks/http.dart' show MockHttpInternal;
+import 'package:w_transport/src/mocks/mock_transports.dart'
+    show MockHttpInternal;
 
 abstract class MockRequestMixin implements MockBaseRequest, CommonRequest {
   Completer<Null> _canceled = new Completer<Null>();

--- a/lib/src/http/mock/requests.dart
+++ b/lib/src/http/mock/requests.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/http/client.dart';
 import 'package:w_transport/src/http/common/form_request.dart';
 import 'package:w_transport/src/http/common/json_request.dart';
@@ -22,6 +23,7 @@ import 'package:w_transport/src/http/mock/request_mixin.dart';
 import 'package:w_transport/src/http/requests.dart';
 import 'package:w_transport/src/transport_platform.dart';
 
+@Deprecated(v3Deprecation)
 class MockFormRequest extends CommonFormRequest with MockRequestMixin {
   TransportPlatform _realTransport;
 
@@ -38,6 +40,7 @@ class MockFormRequest extends CommonFormRequest with MockRequestMixin {
   }
 }
 
+@Deprecated(v3Deprecation)
 class MockJsonRequest extends CommonJsonRequest with MockRequestMixin {
   TransportPlatform _realTransport;
 
@@ -54,6 +57,7 @@ class MockJsonRequest extends CommonJsonRequest with MockRequestMixin {
   }
 }
 
+@Deprecated(v3Deprecation)
 class MockMultipartRequest extends CommonMultipartRequest
     with MockRequestMixin {
   TransportPlatform _realTransport;
@@ -73,6 +77,7 @@ class MockMultipartRequest extends CommonMultipartRequest
   }
 }
 
+@Deprecated(v3Deprecation)
 class MockPlainTextRequest extends CommonPlainTextRequest
     with MockRequestMixin {
   TransportPlatform _realTransport;
@@ -90,6 +95,7 @@ class MockPlainTextRequest extends CommonPlainTextRequest
   }
 }
 
+@Deprecated(v3Deprecation)
 class MockStreamedRequest extends CommonStreamedRequest with MockRequestMixin {
   TransportPlatform _realTransport;
 

--- a/lib/src/http/requests.dart
+++ b/lib/src/http/requests.dart
@@ -18,7 +18,7 @@ import 'dart:typed_data';
 import 'package:w_transport/src/global_transport_platform.dart';
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/multipart_file.dart';
-import 'package:w_transport/src/mocks/transport.dart'
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
 

--- a/lib/src/mocks/mock_transports.dart
+++ b/lib/src/mocks/mock_transports.dart
@@ -12,14 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+library w_transport.src.mocks.mock_transports;
+
 import 'dart:async';
 
-import 'package:w_transport/src/mocks/http.dart';
-import 'package:w_transport/src/mocks/web_socket.dart';
+import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
+
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
+import 'package:w_transport/src/http/base_request.dart' show BaseRequest;
+import 'package:w_transport/src/http/finalized_request.dart'
+    show FinalizedRequest;
+import 'package:w_transport/src/http/mock/base_request.dart'
+    show MockBaseRequest;
+import 'package:w_transport/src/http/mock/response.dart' show MockResponse;
+import 'package:w_transport/src/http/response.dart' show BaseResponse;
+import 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
+import 'package:w_transport/src/web_socket/w_socket.dart' show WSocket;
+import 'package:w_transport/src/web_socket/web_socket_exception.dart'
+    show WebSocketException;
+
+part 'package:w_transport/src/mocks/mock_http.dart';
+part 'package:w_transport/src/mocks/mock_web_socket.dart';
+part 'package:w_transport/src/mocks/mock_web_socket_server.dart';
 
 class MockTransports {
   static const MockHttp http = const MockHttp();
-  static const MockWebSocket webSocket = const MockWebSocket();
+  static const MockWebSockets webSocket = const MockWebSockets();
 
   /// Install mocking logic & controls for all transports. This will effectively
   /// wrap all [BaseRequest], [HttpClient], and [WebSocket] instances in a

--- a/lib/src/mocks/mock_web_socket_server.dart
+++ b/lib/src/mocks/mock_web_socket_server.dart
@@ -1,0 +1,53 @@
+part of w_transport.src.mocks.mock_transports;
+
+class MockWebSocketConnection {
+  final Map<String, dynamic> headers;
+  final Iterable<String> protocols;
+  final Uri uri;
+
+  final MockWSocket _connectedClient;
+
+  MockWebSocketConnection._(this._connectedClient, this.uri,
+      {Map<String, dynamic> headers, Iterable<String> protocols})
+      : headers = new Map.unmodifiable(headers ?? {}),
+        protocols = new List.unmodifiable(protocols ?? []);
+
+  Future<Null> close([int code, String reason]) {
+    return _connectedClient.close(code, reason);
+  }
+
+  void onData(callback(dynamic data)) {
+    _connectedClient.onOutgoing(callback);
+  }
+
+  void send(Object data) {
+    _connectedClient.addIncoming(data);
+  }
+}
+
+class MockWebSocketServer {
+  List<MockWSocket> _connectedClients = [];
+
+  StreamController<MockWebSocketConnection> _onClientConnected =
+      new StreamController<MockWebSocketConnection>();
+
+  Stream<MockWebSocketConnection> get onClientConnected =>
+      _onClientConnected.stream;
+
+  Future<Null> shutDown() async {
+    final futures = _connectedClients.map((client) => client.close());
+    await Future.wait(futures);
+  }
+
+  void _connectClient(MockWSocket client, Uri uri,
+      {Map<String, dynamic> headers, Iterable<String> protocols}) {
+    _connectedClients.add(client);
+    client.done.then((_) {
+      _connectedClients.remove(client);
+    }).catchError((_) {
+      _connectedClients.remove(client);
+    });
+    _onClientConnected.add(new MockWebSocketConnection._(client, uri,
+        headers: headers, protocols: protocols));
+  }
+}

--- a/lib/src/mocks/mock_web_socket_server.dart
+++ b/lib/src/mocks/mock_web_socket_server.dart
@@ -12,6 +12,8 @@ class MockWebSocketConnection {
       : headers = new Map.unmodifiable(headers ?? {}),
         protocols = new List.unmodifiable(protocols ?? []);
 
+  Future<Null> get done => _connectedClient.done;
+
   Future<Null> close([int code, String reason]) {
     return _connectedClient.close(code, reason);
   }

--- a/lib/src/transport_platform.dart
+++ b/lib/src/transport_platform.dart
@@ -5,7 +5,7 @@ import 'package:w_transport/src/http/http_client.dart';
 import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';
 import 'package:w_transport/src/http/requests.dart';
-import 'package:w_transport/src/mocks/transport.dart'
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/web_socket/mock/w_socket.dart';
 import 'package:w_transport/src/web_socket/web_socket.dart';
@@ -83,7 +83,7 @@ class MockAwareTransportPlatform {
       @Deprecated(v3Deprecation) Duration sockJSTimeout,
       @Deprecated(v3Deprecation) bool useSockJS}) {
     if (MockTransportsInternal.isInstalled) {
-      return MockWSocket.connect(uri, protocols: protocols, headers: headers);
+      return MockWSocket.connect(uri, headers: headers, protocols: protocols);
     } else if (realTransportPlatform != null) {
       return realTransportPlatform.newWebSocket(uri,
           headers: headers, protocols: protocols);

--- a/lib/src/vm_transport_platform.dart
+++ b/lib/src/vm_transport_platform.dart
@@ -48,5 +48,5 @@ class VMTransportPlatform implements TransportPlatform {
           @Deprecated(v3Deprecation) List<String> sockJSProtocolsWhitelist,
           @Deprecated(v3Deprecation) Duration sockJSTimeout,
           @Deprecated(v3Deprecation) bool useSockJS}) =>
-      VMWebSocket.connect(uri, protocols: protocols, headers: headers);
+      VMWebSocket.connect(uri, headers: headers, protocols: protocols);
 }

--- a/lib/src/web_socket/browser/web_socket.dart
+++ b/lib/src/web_socket/browser/web_socket.dart
@@ -39,7 +39,7 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
   }
 
   static Future<WebSocket> connect(Uri uri,
-      {Iterable<String> protocols, Map<String, dynamic> headers}) async {
+      {Map<String, dynamic> headers, Iterable<String> protocols}) async {
     // Establish a Web Socket connection.
     final webSocket = new html.WebSocket(uri.toString(), protocols);
     if (webSocket == null) {

--- a/lib/src/web_socket/mock/w_socket.dart
+++ b/lib/src/web_socket/mock/w_socket.dart
@@ -14,16 +14,18 @@
 
 import 'dart:async';
 
-import 'package:w_transport/src/mocks/web_socket.dart'
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockWebSocketInternal;
 import 'package:w_transport/src/web_socket/mock/web_socket.dart';
 import 'package:w_transport/src/web_socket/web_socket.dart';
 
+@Deprecated(v3Deprecation)
 abstract class MockWSocket extends MockWebSocket implements WebSocket {
   factory MockWSocket() => new MockWebSocket();
 
   static Future<WebSocket> connect(Uri uri,
-          {Iterable<String> protocols, Map<String, dynamic> headers}) =>
+          {Map<String, dynamic> headers, Iterable<String> protocols}) =>
       MockWebSocketInternal.handleWebSocketConnection(uri,
-          protocols: protocols, headers: headers);
+          headers: headers, protocols: protocols);
 }

--- a/lib/src/web_socket/mock/web_socket.dart
+++ b/lib/src/web_socket/mock/web_socket.dart
@@ -14,7 +14,8 @@
 
 import 'dart:async';
 
-import 'package:w_transport/src/mocks/web_socket.dart'
+import 'package:w_transport/src/constants.dart' show v3Deprecation;
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockWebSocketInternal;
 import 'package:w_transport/src/web_socket/common/web_socket.dart';
 import 'package:w_transport/src/web_socket/mock/w_socket.dart';
@@ -24,12 +25,13 @@ abstract class MockWebSocket implements WebSocket {
   factory MockWebSocket() => new _MockWebSocket();
 
   static Future<WebSocket> connect(Uri uri,
-          {Iterable<String> protocols, Map<String, dynamic> headers}) =>
+          {Map<String, dynamic> headers, Iterable<String> protocols}) =>
       MockWebSocketInternal.handleWebSocketConnection(uri,
-          protocols: protocols, headers: headers);
+          headers: headers, protocols: protocols);
 
   /// Simulate an incoming message that the owner of this [WSocket] instance
   /// will receive if listening.
+  @Deprecated(v3Deprecation)
   void addIncoming(dynamic data);
 
   /// Register a callback that will be called for every outgoing data event that
@@ -37,10 +39,12 @@ abstract class MockWebSocket implements WebSocket {
   ///
   /// [data] will either be the single data item or the stream, depending on
   /// whether `add()` or `addStream()` was called.
+  @Deprecated(v3Deprecation)
   void onOutgoing(callback(dynamic data));
 
   /// Cause the "server" to close, effectively severing the connection between
   /// the server and client.
+  @Deprecated(v3Deprecation)
   void triggerServerClose([int code, String reason]);
 
   /// Cause the "server" to add an error to the stream.

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -34,11 +34,11 @@ class VMWebSocket extends CommonWebSocket implements WebSocket {
   }
 
   static Future<WebSocket> connect(Uri uri,
-      {Iterable<String> protocols, Map<String, dynamic> headers}) async {
+      {Map<String, dynamic> headers, Iterable<String> protocols}) async {
     io.WebSocket webSocket;
     try {
       webSocket = await io.WebSocket
-          .connect(uri.toString(), protocols: protocols, headers: headers);
+          .connect(uri.toString(), headers: headers, protocols: protocols);
     } on io.SocketException catch (e) {
       throw new WebSocketException(e.toString());
     }

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -22,7 +22,7 @@ import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/global_transport_platform.dart';
-import 'package:w_transport/src/mocks/transport.dart'
+import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';

--- a/test/integration/http/common_request/mock_test.dart
+++ b/test/integration/http/common_request/mock_test.dart
@@ -35,7 +35,7 @@ void main() {
     setUp(() {
       configureWTransportForTest();
       mock404Endpoint(IntegrationPaths.fourOhFourEndpointUri);
-      mockCustomEndpoint(IntegrationPaths.customEndpointUri);
+      mockCustomEndpoint(IntegrationPaths.customEndpointUriPattern);
       mockDownloadEndpoint(IntegrationPaths.downloadEndpointUri);
       mockReflectEndpoint(IntegrationPaths.reflectEndpointUri);
       mockTimeoutEndpoint(IntegrationPaths.timeoutEndpointUri);

--- a/test/integration/http/mock_endpoints/custom.dart
+++ b/test/integration/http/mock_endpoints/custom.dart
@@ -14,8 +14,8 @@
 
 import 'package:w_transport/mock.dart';
 
-void mockCustomEndpoint(Uri uri) {
-  MockTransports.http.when(uri, (request) async {
+void mockCustomEndpoint(Pattern uriPattern) {
+  MockTransports.http.whenPattern(uriPattern, (request, match) async {
     final status = int.parse(request.uri.queryParameters['status'] ?? '200');
     return new MockResponse(status);
   });

--- a/test/integration/integration_paths.dart
+++ b/test/integration/integration_paths.dart
@@ -20,6 +20,8 @@ class IntegrationPaths {
 
   static final Uri customEndpointUri =
       hostUri.replace(path: '/test/http/custom');
+  static final Pattern customEndpointUriPattern = new RegExp(
+      customEndpointUri.toString().replaceAll('/', '\/') + r'(\?.*)');
   static final Uri downloadEndpointUri =
       hostUri.replace(path: '/test/http/download');
   static final Uri echoEndpointUri = hostUri.replace(path: '/test/http/echo');

--- a/test/integration/platforms/mock_platform_test.dart
+++ b/test/integration/platforms/mock_platform_test.dart
@@ -20,6 +20,7 @@ import 'package:w_transport/mock.dart';
 import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';
 import 'package:w_transport/src/web_socket/mock/w_socket.dart';
+import 'package:w_transport/src/web_socket/mock/web_socket.dart';
 
 import '../../naming.dart';
 
@@ -62,7 +63,27 @@ void main() {
       expect(new StreamedRequest(), new isInstanceOf<MockStreamedRequest>());
     });
 
-    test('newWSocket()', () async {
+    test('newWebSocket() (using MockWebSocketServer)', () async {
+      final wsUri = Uri.parse('ws://test/ws');
+      MockTransports.webSocket
+          .expect(wsUri, connectTo: new MockWebSocketServer());
+      expect(await WebSocket.connect(wsUri), new isInstanceOf<MockWebSocket>());
+    });
+
+    test('newWebSocket() (using MockWSocket)', () async {
+      final wsUri = Uri.parse('ws://test/ws');
+      MockTransports.webSocket.expect(wsUri, connectTo: new MockWebSocket());
+      expect(await WebSocket.connect(wsUri), new isInstanceOf<MockWebSocket>());
+    });
+
+    test('newWSocket() (using MockWebSocketServer)', () async {
+      final wsUri = Uri.parse('ws://test/ws');
+      MockTransports.webSocket
+          .expect(wsUri, connectTo: new MockWebSocketServer());
+      expect(await WSocket.connect(wsUri), new isInstanceOf<MockWSocket>());
+    });
+
+    test('newWSocket() (using MockWSocket)', () async {
       final wsUri = Uri.parse('ws://test/ws');
       MockTransports.webSocket.expect(wsUri, connectTo: new MockWSocket());
       expect(await WSocket.connect(wsUri), new isInstanceOf<MockWSocket>());

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -29,6 +29,81 @@ void main() {
     ..topic = topicWebSocket;
 
   group(naming.toString(), () {
+    MockWebSocketServer mockCloseWebSocketServer;
+    MockWebSocketServer mockEchoWebSocketServer;
+    MockWebSocketServer mockPingWebSocketServer;
+
+    setUp(() async {
+      configureWTransportForTest();
+      await MockTransports.reset();
+
+      mockCloseWebSocketServer = new MockWebSocketServer();
+      mockEchoWebSocketServer = new MockWebSocketServer();
+      mockPingWebSocketServer = new MockWebSocketServer();
+
+      mockCloseWebSocketServer.onClientConnected.listen((connection) {
+        connection.onData((data) {
+          if (data.startsWith('close')) {
+            final parts = data.split(':');
+            int closeCode;
+            String closeReason;
+            if (parts.length >= 2) {
+              closeCode = int.parse(parts[1]);
+            }
+            if (parts.length >= 3) {
+              closeReason = parts[2];
+            }
+            connection.close(closeCode, closeReason);
+          }
+        });
+      });
+
+      mockEchoWebSocketServer.onClientConnected.listen((connection) {
+        connection.onData(connection.send);
+      });
+
+      mockPingWebSocketServer.onClientConnected.listen((connection) {
+        connection.onData((data) async {
+          data = data.replaceAll('ping', '');
+          int numPongs = 1;
+          try {
+            numPongs = int.parse(data);
+          } catch (_) {}
+          for (int i = 0; i < numPongs; i++) {
+            await new Future.delayed(new Duration(milliseconds: 5));
+            connection.send('pong');
+          }
+        });
+      });
+
+      MockTransports.webSocket
+          .when(IntegrationPaths.fourOhFourUri, reject: true);
+
+      MockTransports.webSocket.when(IntegrationPaths.closeUri,
+          handler: (Uri uri, {protocols, headers}) async =>
+              mockCloseWebSocketServer);
+
+      MockTransports.webSocket.when(IntegrationPaths.echoUri,
+          handler: (Uri uri, {protocols, headers}) async =>
+              mockEchoWebSocketServer);
+
+      MockTransports.webSocket.when(IntegrationPaths.pingUri,
+          handler: (Uri uri, {protocols, headers}) async =>
+              mockPingWebSocketServer);
+    });
+
+    tearDown(() async {
+      await Future.wait([
+        mockCloseWebSocketServer.shutDown(),
+        mockEchoWebSocketServer.shutDown(),
+        mockPingWebSocketServer.shutDown(),
+      ]);
+    });
+
+    runCommonWebSocketIntegrationTests();
+  });
+
+  group(naming.toString() + ' legacy', () {
     setUp(() async {
       configureWTransportForTest();
 

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -1078,7 +1078,7 @@ void _runAutoRetryTestSuiteFor(
         // 2nd attempt = +0 to 50s (25*2^1)
         // 3rd attempt = +0 to 100s (25*2^2) + 2nd attempt
         // 4th attempt = +0 to 200s (25*2^3) + 3rd attempt
-        await new Future.delayed(new Duration(milliseconds: 350));
+        await new Future.delayed(new Duration(milliseconds: 400));
         expect(request.autoRetry.numAttempts, equals(4));
       });
 
@@ -1102,10 +1102,10 @@ void _runAutoRetryTestSuiteFor(
         request.get(uri: requestUri);
 
         // 1st attempt = immediate
-        // 2nd attempt = +0 to 25s
-        // 3rd attempt = +0 to 25s
-        // 4th attempt = +0 to 25s
-        await new Future.delayed(new Duration(milliseconds: 110));
+        // 2nd attempt = +0 to 25ms
+        // 3rd attempt = +0 to 25ms
+        // 4th attempt = +0 to 25ms
+        await new Future.delayed(new Duration(milliseconds: 200));
         expect(request.autoRetry.numAttempts, equals(4));
       });
 

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -424,5 +424,21 @@ void main() {
         });
       });
     });
+
+    group('MockWebSocketServer', () {
+      test('should expose `done` for connected clients', () async {
+        final c = new Completer<Null>();
+        final mockWebSocketServer = new MockWebSocketServer();
+        mockWebSocketServer.onClientConnected.listen((connection) {
+          connection.done.then((_) => c.complete());
+        });
+
+        MockTransports.webSocket
+            .expect(webSocketUri, connectTo: mockWebSocketServer);
+        final webSocket = await WSocket.connect(webSocketUri);
+        await webSocket.close();
+        await c.future;
+      });
+    });
   });
 }


### PR DESCRIPTION
_Dependent on #222._

## Description
This PR addresses a couple of issues with the transport mocks:

- There are several mock classes that were exported publicly that are unnecessary and only serve to add confusion.

- Controlling mock websockets involved creating an instance of `MockWSocket` via the transport mocks. This instance would get returned when an actual `WebSocket` instance was constructed, but it also served as the control point for tests, which is confusing.

- The HTTP mock API stores handlers based on the URI, but it was stripping off the query param to make one of our integration tests easier. This really shouldn't have been the case - `expect()` and `when()` are given an expected URI and that URI should match exactly. Now that we have `expectPattern()` and `whenPattern()`, the original use case is much easier so the stripping of query params should no longer be done.

## Changes

- Add a `MockWebSocketServer` class that will be used for controlling the behavior of mock websockets.

- Deprecate any mock class that was publicly exposed but should not be necessary for testing.

- Remove the query param stripping logic from the http mocks.

## Testing

- [ ] CI passes (tests have been added and updated).

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf