### PR TITLE
CP-2788 Release w_transport 3.0.0-rc.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.8.0
+version: 3.0.0-rc.1
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2430 Minimum sdk 1.14; Upgrade dependencies](https://github.com/Workiva/w_transport/pull/197)
* [CP-2090 Simplify entry point names.](https://github.com/Workiva/w_transport/pull/198)
* [CP-2243 Rename Client to HttpClient](https://github.com/Workiva/w_transport/pull/209)
* [CP-2787 Docs overhaul & v3.0.0 upgrade guide](https://github.com/Workiva/w_transport/pull/210)
* [CP-2611 Rename WebSocket classes](https://github.com/Workiva/w_transport/pull/212)
* [CP-2619 Enable strong mode](https://github.com/Workiva/w_transport/pull/217)
* [CP-2620 Enable Linter](https://github.com/Workiva/w_transport/pull/219)
* [CP-2657 Standardize variable declarations](https://github.com/Workiva/w_transport/pull/220)
* [CP-1883 Use null-aware operators](https://github.com/Workiva/w_transport/pull/221)
* [CP-2658 Refactor platform configuration](https://github.com/Workiva/w_transport/pull/222)
* [CP-2786 Mock updates](https://github.com/Workiva/w_transport/pull/224)


Requested by: evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.4...version-bump-w_transport-3-0-0-rc-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.4...3.0.0-rc.1