### PR TITLE
Dont wait for WebSocket to close when the subscription is canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
 # Changelog
 
-## [2.9.3](https://github.com/Workvia/w_transport/compare/2.9.2...2.9.3)
+## [2.9.4](https://github.com/Workiva/w_transport/compare/2.9.3...2.9.4)
+_October 14, 2016_
+
+- **Bug Fix:** The `Future` returned from `WSocket.cancel()` no longer waits for
+  the WebSocket to be closed.
+
+## [2.9.3](https://github.com/Workiva/w_transport/compare/2.9.2...2.9.3)
 _September 8, 2016_
 
 - **Bug Fix:** if a request is canceled right before it would also have exceeded
   the timeout threshold, a `StateError` may be thrown due to a `Completer` being
   completed more than once. This is fixed now.
 
-## [2.9.2](https://github.com/Workvia/w_transport/compare/2.9.1...2.9.2)
+## [2.9.2](https://github.com/Workiva/w_transport/compare/2.9.1...2.9.2)
 _August 11, 2016_
 
 - Widen the version range for the `http_parser` dependency to speed up and/or
   fix downstream consumers experiencing version conflicts.
 
-## [2.9.1](https://github.com/Workvia/w_transport/compare/2.9.0...2.9.1)
+## [2.9.1](https://github.com/Workiva/w_transport/compare/2.9.0...2.9.1)
 _August 2, 2016_
 
 - **Bug Fix:** previously, listening to a `WSocket` instance and then canceling
@@ -22,7 +28,7 @@ _August 2, 2016_
   `WSocket.done` and `WSocket.close()` will always resolve once the connection
   is closed.
 
-## [2.9.0](https://github.com/Workvia/w_transport/compare/2.8.0...2.9.0)
+## [2.9.0](https://github.com/Workiva/w_transport/compare/2.8.0...2.9.0)
 _July 26, 2016_
 
 - **Improvement:** All request classes now have a `bool isDone` getter that can
@@ -32,7 +38,7 @@ _July 26, 2016_
 - **Bug Fix:** Calling `request.abort()` more than once will no longer throw a
   `StateError`.
 
-## [2.8.0](https://github.com/Workvia/w_transport/compare/2.7.1...2.8.0)
+## [2.8.0](https://github.com/Workiva/w_transport/compare/2.7.1...2.8.0)
 _July 21, 2016_
 
 - **Improvement:** Mock transport handlers can now be canceled. This will allow
@@ -52,7 +58,7 @@ _July 21, 2016_
     /// The same works for the `whenPattern()` methods, as well.
     ```
 
-## [2.7.1](https://github.com/Workvia/w_transport/compare/2.7.0...2.7.1)
+## [2.7.1](https://github.com/Workiva/w_transport/compare/2.7.0...2.7.1)
 _July 20, 2016_
 
 - **Bug Fix:** previously, you could not retry a request that failed with a
@@ -70,7 +76,7 @@ _July 20, 2016_
       };
     ```
 
-## [2.7.0](https://github.com/Workvia/w_transport/compare/2.6.0...2.7.0)
+## [2.7.0](https://github.com/Workiva/w_transport/compare/2.6.0...2.7.0)
 _June 23, 2016_
 
 - **Deprecation:** `autoRetry.backOff.duration` has been deprecated in
@@ -99,7 +105,7 @@ _June 23, 2016_
   will now pass in the value of its `encoding` property, which should now always
   be non-null.
 
-## [2.6.0](https://github.com/Workvia/w_transport/compare/2.5.1...2.6.0)
+## [2.6.0](https://github.com/Workiva/w_transport/compare/2.5.1...2.6.0)
 _June 20, 2016_
 
 - **Improvement:** The `MockTransport` utilities now support expecting

--- a/lib/src/web_socket/common/w_socket.dart
+++ b/lib/src/web_socket/common/w_socket.dart
@@ -151,7 +151,6 @@ abstract class CommonWSocket extends Stream implements WSocket {
         .listen(onData, onError: onError, cancelOnError: cancelOnError);
     _incomingSubscription = new WSocketSubscription(sub, onDone, onCancel: () {
       _incomingSubscription = null;
-      return done;
     });
     return _incomingSubscription;
   }

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -223,7 +223,7 @@ void runCommonWebSocketIntegrationTests(
     var webSocket = await connect(echoUri);
 
     var subscription = webSocket.listen((_) {});
-    subscription.cancel();
+    await subscription.cancel();
 
     await webSocket.close(4001, 'Closed.');
     expect(webSocket.closeCode, equals(4001));
@@ -244,7 +244,7 @@ void runCommonWebSocketIntegrationTests(
     webSocket.add('one');
     await new Future.delayed(new Duration(milliseconds: 50));
 
-    subscription.cancel();
+    await subscription.cancel();
 
     webSocket.add('two');
     await new Future.delayed(new Duration(milliseconds: 50));
@@ -252,6 +252,18 @@ void runCommonWebSocketIntegrationTests(
 
     await webSocket.close();
     expect(doneEventReceived, isFalse);
+  });
+
+  test('should not close if the only listener is canceled', () async {
+    var webSocket = await connect(echoUri);
+
+    var subscription = webSocket.listen((_) {});
+    await subscription.cancel();
+
+    // Should still be able to add events.
+    webSocket.add('one');
+    expect(webSocket.closeCode, isNull);
+    expect(webSocket.closeReason, isNull);
   });
 
   test('should work as a broadcast stream', () async {
@@ -306,7 +318,7 @@ void runCommonWebSocketIntegrationTests(
     expect(webSocket.closeReason, equals('Closed by server.'));
   });
 
-  test('should ignore close() calls after the first', () async {
+  test('should ignore close() calls after the first call', () async {
     var webSocket = await connect(echoUri);
     await webSocket.close(4001, 'Custom close.');
     await webSocket.close(4002, 'Late close.');


### PR DESCRIPTION
## Issue
Currently, `WSocket.cancel()` returns the same `Future` as `WSocket.done`, which means that if you were to wait for cancellation to complete, you would be waiting until the websocket closes.

```dart
final webSocket = await WSocket.connect(...);
final subscription = webSocket.listen((_) { ... });
await subscription.cancel(); // hangs until the websocket closes
```

This is not in line with the behavior that the builtin Dart streams exhibit:

```dart
final sc = new StreamController();
final subscription = sc.stream.listen((_) { .. });
await subscription.cancel(); // completes (doesn't wait for stream to close)
```

## Solution
- Do not wait for the websocket to close when handling the subscription cancellation.
- **Bonus:** also added a test to ensure that the websocket is not closed just because the subscription is canceled. This was added because it's another way in which we should make sure we're in line with `Stream`/`StreamSink` behavior, and because I made a change in 3.0.0-wip that violates this contract, for which I will PR a fix.

## Testing
- [ ] CI passes (tests updated/added)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 