### PR TITLE
Don't close websocket after subsription is canceled

### DIFF
--- a/lib/src/web_socket/common/web_socket.dart
+++ b/lib/src/web_socket/common/web_socket.dart
@@ -156,7 +156,6 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
         .listen(onData, onError: onError, cancelOnError: cancelOnError);
     _incomingSubscription = new WSocketSubscription(sub, onDone, onCancel: () {
       _incomingSubscription = null;
-      return close();
     });
     return _incomingSubscription;
   }


### PR DESCRIPTION
## Issue
The `WSocket` is designed and intended to behave like a `Stream` and `StreamSink` at the same time, and as such it should behave just like the builtin Dart classes.

Consider a `StreamController`:

```dart
final sc = new StreamController();
final sub = sc.stream.listen(print);

sc.add(1);
await nextTick();

await sub.cancel();

sc.add(2);
await nextTick();

// OUTPUT:
// 1
```

The first event is added, received, and printed. Then the subscription is canceled, so the second event is added, but not received. The important thing to note, however, is that the stream does not close, since we were able to add the second event without a `StateError` being thrown.

Due to a change I made in this 3.0.0-wip line, `WSocket` does not currently behave like this:

```
// Assume this websocket connection echos all messages
final webSocket = await WSocket.connect('/echo');
final sub = webSocket.listen(print);

webSocket.add(1);
await nextTick();

await sub.cancel();

webSocket.add(2);
await nextTick();

// OUTPUT:
// 1
// Bad State: ...
```

As you can see above, a `StateError` will be thrown when adding events after the subscription has been canceled since it causes the websocket to close. **This is a deviation from the expected behavior of `Stream`s and `StreamSink`s.**

## Solution
- Do not close the websocket when the subscription is canceled.

## Testing
- [ ] CI passes (test for this added in #227 and will be present once 3.0.0-wip is rebased against the latest)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 