### PR TITLE
CP-2616 Release w_transport 2.9.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.3
+version: 2.9.4
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [Dont wait for WebSocket to close when the subscription is canceled](https://github.com/Workiva/w_transport/pull/227)


Requested by: evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.3...version-bump-w_transport-2-9-4
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.3...2.9.4