### PR TITLE
CP-2820 Restore existing MockClient() constructor

### DIFF
--- a/lib/src/http/mock/client.dart
+++ b/lib/src/http/mock/client.dart
@@ -23,5 +23,5 @@ import 'package:w_transport/src/transport_platform.dart';
 /// anything else.
 @Deprecated(v3Deprecation)
 class MockClient extends MockHttpClient implements HttpClient {
-  MockClient(TransportPlatform transport) : super(transport);
+  MockClient([TransportPlatform transport]) : super(transport);
 }


### PR DESCRIPTION
## Issue
In 2.x, the `MockClient` class is exported from the `w_transport_mock.dart` entry point and is not deprecated. In 3.0.0-wip, I deprecated the class, but unknowingly changed the existing constructor signature in a backwards-incompatible way. If consumers are constructing instances of `MockClient`, it would break when upgrading.

## Solution
The `MockClient` constructor needs to accept a `TransportPlatform` parameter in order for the mock-aware logic to work (which is why I made the change). But, we can make it optional so that existing consumptions still work.

I've tested this with two consumers that were constructing `MockClient()` instances for use in tests, and all tests pass with this fix.

## Testing
- [ ] CI passes
- [ ] wf-home-html tests pass with this branch
- [ ] messaging-sdk tests pass with this branch

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 