### PR TITLE
CP-2846 Release w_transport 3.0.0-rc.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.0-rc.1
+version: 3.0.0-rc.2-rc.1
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.0-rc.2-rc.1
+version: 3.0.0-rc.2
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2820 Restore existing MockClient() constructor](https://github.com/Workiva/w_transport/pull/231)
* [CP-2821 Documentation tweaks](https://github.com/Workiva/w_transport/pull/232)
* [Update tests and increase coverage](https://github.com/Workiva/w_transport/pull/233)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.0-rc.1...version-bump-w_transport-3-0-0-rc-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.0-rc.1...3.0.0-rc.2