### PR TITLE
CP-2909 Pin Dart to 1.19.1 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.19.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0


### PR DESCRIPTION
## Description
Until [this issue with Dart 1.20.1](https://github.com/dart-lang/sdk/issues/27760) is resolved or worked around, we should pin the Dart SDK version to 1.19.1 for our Travis CI runs. This should give us a passing build.

## Testing
- [x] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 