### PR TITLE
CP-3301 Disallow retry of canceled requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [3.0.0](https://github.com/Workiva/w_transport/compare/2.9.2...3.0.0)
+## [3.0.1](https://github.com/Workiva/w_transport/compare/3.0.0...3.0.1)
+_January 18th, 2017_
+
+- **Bug Fix:** If a request's `autoRetry.test` function is supplied and returns
+  true when the `response` is null, a request that was canceled would
+  erroneously be retried. Canceling a request now properly makes it ineligible
+  for retry regardless of other factors.
+
+## [3.0.0](https://github.com/Workiva/w_transport/compare/2.9.4...3.0.0)
 _October 25th, 2016_
 
 This major release includes deprecations and an increased minimum Dart SDK

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -562,6 +562,9 @@ abstract class CommonRequest extends Object
         !autoRetry.supported ||
         autoRetry.didExceedMaxNumberOfAttempts) return false;
 
+    // If the request was explicitly canceled, then there is no reason to retry.
+    if (isCanceled) return false;
+
     // If the request failed due to exceeding the timeout threshold, check if
     // it is configured to retry for timeouts.
     if (requestException.error is TimeoutException) {


### PR DESCRIPTION
_Fixes #241._

## Issue
If a request's `autoRetry.test` function is supplied and returns true when the `response` is null, a request that was canceled would erroneously be retried.

## Solution
Canceling a request now properly makes it ineligible for retry regardless of other factors.

## Testing
- [ ] CI passes (tests added)

## Code Review
@Workiva/web-platform-pp 