### PR TITLE
CP-3323 BACKPATCH Disallow retry of canceled requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.19.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.9.5](https://github.com/Workiva/w_transport/compare/2.9.4...2.9.5)
+_January 19th, 2017_
+
+- **Bug Fix:** If a request's `autoRetry.test` function is supplied and returns
+  true when the `response` is null, a request that was canceled would
+  erroneously be retried. Canceling a request now properly makes it ineligible
+  for retry regardless of other factors.
+
 ## [2.9.4](https://github.com/Workiva/w_transport/compare/2.9.3...2.9.4)
 _October 14, 2016_
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -496,6 +496,9 @@ abstract class CommonRequest extends Object
         !autoRetry.supported ||
         autoRetry.didExceedMaxNumberOfAttempts) return false;
 
+    // If the request was explicitly canceled, then there is no reason to retry.
+    if (isCanceled) return false;
+
     // If the request failed due to exceeding the timeout threshold, check if
     // it is configured to retry for timeouts.
     if (requestException.error is TimeoutException) {


### PR DESCRIPTION
Same as #243 but backpatched to the 2.x line.

@Workiva/web-platform-pp 