### PR TITLE
CP-2849 Release w_transport 3.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.0
+version: 3.0.1
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3301 Disallow retry of canceled requests](https://github.com/Workiva/w_transport/pull/243)
* [[RED-659] Add Aviary.yaml](https://github.com/Workiva/w_transport/pull/225)
* [CP-2849 Update release date for 3.0.0](https://github.com/Workiva/w_transport/pull/237)
* [CP-2909 Pin Dart to 1.19.1 for Travis CI](https://github.com/Workiva/w_transport/pull/238)
* [CP-2942 Adding smithy.yaml](https://github.com/Workiva/w_transport/pull/239)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.0-rc.2...version-bump-w_transport-3-0-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.0-rc.2...3.0.1