### PR TITLE
CP-3328 Fix 'vm.dart' docs

### DIFF
--- a/lib/vm.dart
+++ b/lib/vm.dart
@@ -16,7 +16,7 @@
 /// must be called before instantiating any of the transport classes.
 ///
 ///     import 'package:w_transport/vm.dart'
-///         show configureWTransportForServer;
+///         show configureWTransportForVM;
 ///
 ///     void main() {
 ///       configureWTransportForVM();


### PR DESCRIPTION
The docs say `show configureWTransportForServer`, but it actually is `configureWTransportForVM`