### PR TITLE
CP-3299 Release w_transport 2.9.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.4
+version: 2.9.5
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3323 BACKPATCH Disallow retry of canceled requests](https://github.com/Workiva/w_transport/pull/244)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.4...version-bump-w_transport-2-9-5
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.4...2.9.5