### PR TITLE
CP-3434 Pass SockJS params through mock-aware proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.0.2](https://github.com/Workiva/w_transport/compare/3.0.1...3.0.2)
+_February 3rd, 2017_
+
+- **Bug Fix:** When `MockTransports` is installed with "fall-through" enabled,
+  the optional SockJS params that are available on the
+  `new transport.WebSocket()` constructor are now properly passed through.
+  Previously, a standard WebSocket implementation would have been constructed
+  erroneously if `useSockJS: true` was set, but it now correctly constructs the
+  SockJS implementation.
+
 ## [3.0.1](https://github.com/Workiva/w_transport/compare/3.0.0...3.0.1)
 _January 18th, 2017_
 

--- a/lib/src/transport_platform.dart
+++ b/lib/src/transport_platform.dart
@@ -88,7 +88,13 @@ class MockAwareTransportPlatform {
     } else if (MockTransportsInternal.fallThrough &&
         realTransportPlatform != null) {
       return realTransportPlatform.newWebSocket(uri,
-          headers: headers, protocols: protocols);
+          headers: headers,
+          protocols: protocols,
+          sockJSDebug: sockJSDebug,
+          sockJSNoCredentials: sockJSNoCredentials,
+          sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+          sockJSTimeout: sockJSTimeout,
+          useSockJS: useSockJS);
     } else {
       throw new TransportPlatformMissing.webSocketFailed(uri);
     }

--- a/test/integration/platforms/browser_transport_platform_test.dart
+++ b/test/integration/platforms/browser_transport_platform_test.dart
@@ -697,12 +697,21 @@ void main() {
           final webSocket = await transport.WebSocket.connect(
               IntegrationPaths.pingUri,
               transportPlatform: browserTransportPlatform);
+          expect(webSocket, new isInstanceOf<BrowserWebSocket>());
           await webSocket.close();
 
           final pingUri = IntegrationPaths.pingUri.replace(port: sockjsPort);
           final sockJS = await transport.WebSocket.connect(pingUri,
               transportPlatform: browserTransportPlatformWithSockJS);
+          expect(sockJS, new isInstanceOf<SockJSWebSocket>());
           await sockJS.close();
+
+          // This verifies the ability to override the transport platform's
+          // "useSockJS" value when constructing a single WebSocket instance.
+          final singleSockJS = await transport.WebSocket.connect(pingUri,
+              transportPlatform: browserTransportPlatform, useSockJS: true);
+          expect(singleSockJS, new isInstanceOf<SockJSWebSocket>());
+          await singleSockJS.close();
         });
       });
     });

--- a/test/integration/platforms/mock_aware_transport_platform.dart
+++ b/test/integration/platforms/mock_aware_transport_platform.dart
@@ -19,7 +19,6 @@ import 'package:w_transport/w_transport.dart' as transport;
 
 import 'package:w_transport/src/http/mock/http_client.dart';
 import 'package:w_transport/src/http/mock/requests.dart';
-import 'package:w_transport/src/web_socket/mock/w_socket.dart';
 import 'package:w_transport/src/web_socket/mock/web_socket.dart';
 
 import '../../naming.dart';
@@ -65,7 +64,7 @@ void main() {
       await MockTransports.uninstall();
     });
 
-    test('configureWTransportForVM()', () async {
+    test('configureWTransportForTest()', () async {
       configureWTransportForTest();
 
       // Properly constructs mock-aware implementations of HTTP classes


### PR DESCRIPTION
_Fixes #249._

## Issue
The SockJS params are not being passed through the mock-aware transport platform proxy. It's a corner case that would only have been seen with the following setup:

- MockTransports installed with "fall-through" enabled
- A WebSocket is constructed with the non-SockJS browser transport platform (either directly via the `transportPlatform` parameter or inherited from the globally configured transport platform
- The WebSocket is constructed with SockJS parameters (with the goal of overriding whatever the global configuration may be).

The SockJS params on the `WebSocket` constructor are deprecated and a workaround would be to inject the SockJS-enabled browser transport platform instead.

## Solution
Pass the SockJS params through the mock-aware proxy.

## Testing
- [ ] CI passes (tests added)

## Code Review
@Workiva/web-platform-pp 
fyi: @aldenpeterson-wf 