### PR TITLE
Release w_transport 3.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.1
+version: 3.0.2
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3328 Fix 'vm.dart' docs](https://github.com/Workiva/w_transport/pull/247)
* [CP-3434 Pass SockJS params through mock-aware proxy](https://github.com/Workiva/w_transport/pull/250)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.1...version-bump-w_transport-3-0-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.1...3.0.2