### PR TITLE
CP-3486 Prevent XHR mutation after abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.9.6](https://github.com/Workiva/w_transport/compare/2.9.5...2.9.6)
+_February 9th, 2017_
+
+- **Bug Fix:** If a request is canceled while the underlying XHR instance is
+  being built, it previously would throw due to the XHR not being OPENED. This
+  unhandled exception is now prevented.
+
 ## [2.9.5](https://github.com/Workiva/w_transport/compare/2.9.4...2.9.5)
 _January 19th, 2017_
 


### PR DESCRIPTION
## Issue
If the request is canceled right as we are setting up the underlying XHR instance, attempting to set anything on that XHR instance (like a header or `withCredentials`) will throw this exception:

```
InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
```

## Solution

Add `isCanceled` guards in the `BrowserRequestMixin.sendRequestAndFetchResponse()`

## Testing
- [ ] CI passes (a88bdfa adds the test that should fail, e5f84cb adds the fix)

## Code Review
@Workiva/web-platform-pp 