### PR TITLE
CP-3502 Release w_transport 2.9.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.5
+version: 2.9.6
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3486 Prevent XHR mutation after abort](https://github.com/Workiva/w_transport/pull/252)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.5...version-bump-w_transport-2-9-6
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.5...2.9.6