### PR TITLE
Complete `BaseRequest.done` on cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.9.7](https://github.com/Workiva/w_transport/compare/2.9.6...2.9.7)
+_March 15th, 2017_
+
+- **Bug Fix:** When a request is canceled, it will now always result in the
+  `done` Future resolving. Previously it was possible for the `done` Future to
+  never resolve if the request was canceled at a certain point during the
+  request lifecycle.
+
 ## [2.9.6](https://github.com/Workiva/w_transport/compare/2.9.5...2.9.6)
 _February 9th, 2017_
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -299,6 +299,9 @@ abstract class CommonRequest extends Object
     abortRequest();
     _cancellationError = error;
     _cancellationCompleter.complete();
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
   }
 
   /// Check if this request has been canceled.

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -271,8 +271,14 @@ void _runCommonRequestSuiteFor(
         () async {
       BaseRequest request = requestFactory();
       request.abort();
-      expect(request.get(uri: requestUri),
-          throwsA(new isInstanceOf<RequestException>()));
+      Future future = request.get(uri: requestUri);
+      expect(future, throwsA(new isInstanceOf<RequestException>()));
+      await future.catchError((_) {});
+      expect(request.isDone, isTrue,
+          reason: 'canceled request should be marked as "done"');
+      expect(request.done, completes,
+          reason:
+              'canceled request should trigger completion of `done` future');
     });
 
     test(
@@ -283,6 +289,12 @@ void _runCommonRequestSuiteFor(
       await new Future.delayed(new Duration(milliseconds: 100));
       request.abort();
       expect(future, throwsA(new isInstanceOf<RequestException>()));
+      await future.catchError((_) {});
+      expect(request.isDone, isTrue,
+          reason: 'canceled request should be marked as "done"');
+      expect(request.done, completes,
+          reason:
+              'canceled request should trigger completion of `done` future');
     });
 
     test('request cancellation after request has succeeded should do nothing',


### PR DESCRIPTION
## Issue
Depending on when a request is canceled, the `done` future may or may not resolve.

## Solution
Complete the underlying completer for `BaseRequest.done` whenever a request is canceled to ensure that the `done` future is always resolved when expected.

## Testing
- [ ] CI passes
- [ ] Verify that new tests fail on 9d69223
- [ ] Verify that new tests pass on 2a44cdd

## Code Review
@Workiva/web-platform-pp 