### PR TITLE
Complete `BaseRequest.done` on cancellation (3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [3.0.2](https://github.com/Workiva/w_transport/compare/3.0.1...3.0.2)
+_March 15th, 2017_
+
+- **Bug Fix:** When a request is canceled, it will now always result in the
+  `done` Future resolving. Previously it was possible for the `done` Future to
+  never resolve if the request was canceled at a certain point during the
+  request lifecycle.
+
+## [3.0.2](https://github.com/Workiva/w_transport/compare/3.0.1...3.0.2)
 _February 3rd, 2017_
 
 - **Bug Fix:** When `MockTransports` is installed with "fall-through" enabled,

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -332,6 +332,9 @@ abstract class CommonRequest extends Object
     abortRequest();
     _cancellationError = error;
     _cancellationCompleter.complete();
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
   }
 
   /// Check if this request has been canceled.

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -288,8 +288,14 @@ void _runCommonRequestSuiteFor(
         () async {
       final request = requestFactory();
       request.abort();
-      expect(request.get(uri: requestUri),
-          throwsA(new isInstanceOf<transport.RequestException>()));
+      Future future = request.get(uri: requestUri);
+      expect(future, throwsA(new isInstanceOf<transport.RequestException>()));
+      await future.catchError((_) {});
+      expect(request.isDone, isTrue,
+          reason: 'canceled request should be marked as "done"');
+      expect(request.done, completes,
+          reason:
+              'canceled request should trigger completion of `done` future');
     });
 
     test(
@@ -300,6 +306,12 @@ void _runCommonRequestSuiteFor(
       await new Future.delayed(new Duration(milliseconds: 100));
       request.abort();
       expect(future, throwsA(new isInstanceOf<transport.RequestException>()));
+      await future.catchError((_) {});
+      expect(request.isDone, isTrue,
+          reason: 'canceled request should be marked as "done"');
+      expect(request.done, completes,
+          reason:
+              'canceled request should trigger completion of `done` future');
     });
 
     test('request cancellation after request has succeeded should do nothing',


### PR DESCRIPTION
## Issue
Depending on when a request is canceled, the `done` future may or may not resolve.

## Solution
Complete the underlying completer for `BaseRequest.done` whenever a request is canceled to ensure that the `done` future is always resolved when expected.

## Testing
- [ ] CI passes
- [ ] Verify that new tests fail on 0f847a9
- [ ] Verify that new tests pass on 8369bf7

## Code Review
@Workiva/web-platform-pp 