### PR TITLE
WP-3505 Release w_transport 2.9.7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.6
+version: 2.9.7
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3777 Complete `BaseRequest.done` on cancellation (BACKPATCH)](https://github.com/Workiva/w_transport/pull/256)


Requested by: @maxwellpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.6...version-bump-w_transport-2-9-7
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.6...2.9.7