### PR TITLE
WP-4567 Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 packages
 pubspec.lock
 
+# IDEs
+.idea
+
 # Coverage
 /coverage/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - 1.19.1
+  - stable
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/example/common/global_example_menu_component.dart
+++ b/example/common/global_example_menu_component.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:w_transport/w_transport.dart';
 
 void renderGlobalExampleMenu({bool nav: true, bool serverStatus: false}) {
@@ -27,7 +28,7 @@ void renderGlobalExampleMenu({bool nav: true, bool serverStatus: false}) {
   // Use react to render the menu.
   final menu =
       globalExampleMenuComponent({'nav': nav, 'serverStatus': serverStatus});
-  react.render(menu, container);
+  react_dom.render(menu, container);
 }
 
 Future<bool> _ping(Uri uri) async {

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -14,7 +14,7 @@
 
 import 'dart:html';
 
-import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -28,6 +28,6 @@ void main() {
   configureWTransportForBrowser();
   renderGlobalExampleMenu(serverStatus: true);
   Element container = querySelector('#app');
-  react.render(appComponent({}), container);
+  react_dom.render(appComponent({}), container);
   removeLoadingOverlay();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 
 environment:
-  sdk: ">=1.14.0 <2.0.0"
+  sdk: ">=1.23.0 <2.0.0"
 
 dependencies:
   fluri: ^1.1.0
@@ -26,18 +26,26 @@ dependencies:
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
-      ref: 0.3.1
+      ref: 0.3.2
 
 dev_dependencies:
   ansicolor: ^0.0.9
   args: ^0.13.0
   browser: ^0.10.0+2
   coverage: ^0.7.9
-  dart_dev: ^1.4.0
-  dart_style: ^0.2.4
+  dart_dev: ^1.7.7
+  dart_style: ^1.0.6
   http_server: ^0.9.5+1
-  mockito: ^0.11.0
+  mockito: ">=1.0.0 <3.0.0"
   path: ^1.3.9
-  react: ^0.6.1
-  test: ^0.12.15
+  react: ^3.4.0
+  test: ^0.12.22+1
   uuid: ^0.5.0
+
+
+dependency_overrides:
+  fluri:
+    git:
+      url: git@github.com:aaronlademann-wf/fluri.git
+      ref: update-deps
+

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,7 @@
 project: dart
 language: dart
 
-# dart 1.19.1
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818 # Dart 1.23.0
 
 script:
   - pub get

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -41,7 +41,8 @@ void runCommonRequestSuite([transport.TransportPlatform transportPlatform]) {
     transport.MultipartRequest multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new transport.MultipartRequest(
-          transportPlatform: transportPlatform)..fields['field'] = 'value';
+          transportPlatform: transportPlatform)
+        ..fields['field'] = 'value';
     }
 
     transport.Request reqFactory({bool withBody: false}) {

--- a/test/integration/platforms/vm_transport_platform_test.dart
+++ b/test/integration/platforms/vm_transport_platform_test.dart
@@ -109,7 +109,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           MockTransports.http.expect('GET', IntegrationPaths.pingEndpointUri);
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -174,7 +175,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =
@@ -260,7 +262,8 @@ void main() {
           jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           // ignore: unawaited_futures
           multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -341,7 +344,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           MockTransports.http.expect('GET', IntegrationPaths.pingEndpointUri);
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -406,7 +410,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =
@@ -491,7 +496,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =


### PR DESCRIPTION
> Depends on https://github.com/Workiva/fluri/pull/66

### Problem
Consumers need sockjs version 0.3.2 in order to have a chance at strong mode / DDC compilation.

### Solution
Bump that dependency, and a few other really old ones.

@Workiva/web-platform-pp 