### PR TITLE
WP-4568 Fix tests on Dart 1.24.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - 1.19.1
+  - 1.24.2
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - sleep 3
 script:
   - npm install
+  - pub get --packages-dir
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test --integration

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,24 +20,23 @@ environment:
   sdk: ">=1.14.0 <2.0.0"
 
 dependencies:
-  fluri: ^1.1.0
-  http_parser: ">=2.2.0 <4.0.0"
+  fluri: ^1.2.2
+  http_parser: '>=2.2.0 <4.0.0'
   mime: ^0.9.3
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
-      ref: 0.3.1
+      ref: 0.3.2
 
 dev_dependencies:
   ansicolor: ^0.0.9
-  args: ^0.13.0
   browser: ^0.10.0+2
   coverage: ^0.7.9
-  dart_dev: ^1.4.0
-  dart_style: ^0.2.4
-  http_server: ^0.9.5+1
-  mockito: ^0.11.0
-  path: ^1.3.9
+  dart_dev: ^1.7.7
+  dart_style: ^1.0.6
+  http_server: ^0.9.6
+  mockito: ^2.0.2
+  path: ^1.4.2
   react: ^0.6.1
-  test: ^0.12.15
-  uuid: ^0.5.0
+  test: ^0.12.23+1
+  uuid: ^0.5.3

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# dart 1.19.1
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+# dart 1.24.2
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735
 
 script:
   - pub get

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -41,7 +41,8 @@ void runCommonRequestSuite([transport.TransportPlatform transportPlatform]) {
     transport.MultipartRequest multipartReqFactory({bool withBody}) {
       // Multipart requests can't be empty.
       return new transport.MultipartRequest(
-          transportPlatform: transportPlatform)..fields['field'] = 'value';
+          transportPlatform: transportPlatform)
+        ..fields['field'] = 'value';
     }
 
     transport.Request reqFactory({bool withBody: false}) {

--- a/test/integration/platforms/vm_transport_platform_test.dart
+++ b/test/integration/platforms/vm_transport_platform_test.dart
@@ -109,7 +109,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           MockTransports.http.expect('GET', IntegrationPaths.pingEndpointUri);
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -174,7 +175,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =
@@ -260,7 +262,8 @@ void main() {
           jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           // ignore: unawaited_futures
           multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -341,7 +344,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           MockTransports.http.expect('GET', IntegrationPaths.pingEndpointUri);
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
@@ -406,7 +410,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =
@@ -491,7 +496,8 @@ void main() {
           await jsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final multipartRequest = new transport.MultipartRequest(
-              transportPlatform: vmTransportPlatform)..fields['foo'] = 'bar';
+              transportPlatform: vmTransportPlatform)
+            ..fields['foo'] = 'bar';
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request =

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -242,12 +242,12 @@ void runCommonWebSocketIntegrationTests(
       doneEventReceived = true;
     });
     webSocket.add('one');
-    await new Future.delayed(new Duration(milliseconds: 50));
+    await new Future.delayed(new Duration(milliseconds: 200));
 
     await subscription.cancel();
 
     webSocket.add('two');
-    await new Future.delayed(new Duration(milliseconds: 50));
+    await new Future.delayed(new Duration(milliseconds: 200));
     expect(messagesReceived, equals(1));
 
     await webSocket.close();
@@ -264,6 +264,9 @@ void runCommonWebSocketIntegrationTests(
     webSocket.add('one');
     expect(webSocket.closeCode, isNull);
     expect(webSocket.closeReason, isNull);
+
+    await new Future.delayed(const Duration(milliseconds: 100));
+    await webSocket.close();
   });
 
   test('should work as a broadcast stream', () async {

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -48,7 +48,7 @@ void main() {
     ..testType = testTypeIntegration
     ..topic = topicWebSocket;
 
-  group(wsNaming.toString(), () {
+  group(wsDeprecatedNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
         useSockJS: true,
         sockJSNoCredentials: true,
@@ -56,7 +56,7 @@ void main() {
         transportPlatform: browserTransportPlatform));
   });
 
-  group(xhrNaming.toString(), () {
+  group(xhrDeprecatedNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
         useSockJS: true,
         sockJSNoCredentials: true,
@@ -64,14 +64,14 @@ void main() {
         transportPlatform: browserTransportPlatform));
   });
 
-  group(wsDeprecatedNaming.toString(), () {
+  group(wsNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
         transportPlatform: new BrowserTransportPlatformWithSockJS(
             sockJSNoCredentials: true,
             sockJSProtocolsWhitelist: ['websocket'])));
   });
 
-  group(xhrDeprecatedNaming.toString(), () {
+  group(xhrNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
         transportPlatform: new BrowserTransportPlatformWithSockJS(
             sockJSNoCredentials: true,

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -49,7 +49,7 @@ Future<Null> main(List<String> args) async {
     ..before = [_streamServer, _streamSockJSServer]
     ..after = [_stopServer, _stopSockJSServer];
 
-  config.format.directories = directories;
+  config.format.paths = directories;
 
   config.test
     ..unitTests = [


### PR DESCRIPTION
## Issue

There were a few tests that started failing after updating to the latest Dart SDK.

## Solution

Increase some waits to ensure enough time for WS events to occur correctly.

## Testing

- [ ] CI passes

## Code Review
@Workiva/web-platform-pp 