### PR TITLE
WP-4569 Fix tests on Dart 1.24.x (BACKPATCH 2.X)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - 1.19.1
+  - 1.24.2
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 script:
   - npm install
+  - pub get --packages-dir
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test --integration

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,25 +19,23 @@ environment:
   sdk: ">=1.9.0 <2.0.0"
 
 dependencies:
-  fluri: ^1.1.0
-  http_parser: ">=1.0.0 <4.0.0"
+  fluri: ^1.2.2
+  http_parser: '>=1.0.0 <4.0.0'
   mime: ^0.9.3
   sockjs_client:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
-      ref: 0.3.1
-  stack_trace: ^1.4.0
+      ref: 0.3.2
 
 dev_dependencies:
   ansicolor: ^0.0.9
-  args: ^0.13.0
   browser: ^0.10.0+2
-  coverage: ^0.7.4
-  dart_dev: ^1.1.2
-  dart_style: ^0.2.4
-  http_server: ^0.9.5+1
-  mockito: ^0.9.0
-  path: ^1.3.5
+  coverage: ^0.7.9
+  dart_dev: ^1.7.7
+  dart_style: ^1.0.6
+  http_server: ^0.9.6
+  mockito: ^2.0.2
+  path: ^1.4.2
   react: ^0.6.1
-  test: ^0.12.3+5
-  uuid: ^0.5.0
+  test: ^0.12.23+1
+  uuid: ^0.5.3

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# dart 1.19.1
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+# dart 1.24.2
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735
 
 script:
   - pub get

--- a/test/integration/ws/common.dart
+++ b/test/integration/ws/common.dart
@@ -242,12 +242,12 @@ void runCommonWebSocketIntegrationTests(
       doneEventReceived = true;
     });
     webSocket.add('one');
-    await new Future.delayed(new Duration(milliseconds: 50));
+    await new Future.delayed(new Duration(milliseconds: 200));
 
     await subscription.cancel();
 
     webSocket.add('two');
-    await new Future.delayed(new Duration(milliseconds: 50));
+    await new Future.delayed(new Duration(milliseconds: 200));
     expect(messagesReceived, equals(1));
 
     await webSocket.close();
@@ -264,6 +264,9 @@ void runCommonWebSocketIntegrationTests(
     webSocket.add('one');
     expect(webSocket.closeCode, isNull);
     expect(webSocket.closeReason, isNull);
+
+    await new Future.delayed(const Duration(milliseconds: 100));
+    await webSocket.close();
   });
 
   test('should work as a broadcast stream', () async {

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -51,7 +51,7 @@ main(List<String> args) async {
     ..before = [_streamServer, _streamSockJSServer]
     ..after = [_stopServer, _stopSockJSServer];
 
-  config.format.directories = directories;
+  config.format.paths = directories;
 
   config.test
     ..unitTests = [


### PR DESCRIPTION
## Issue

There were a few tests that started failing after updating to the latest Dart SDK.

## Solution

Increase some waits to ensure enough time for WS events to occur correctly.

## Testing

- [ ] CI passes

## Code Review
@Workiva/web-platform-pp 