### PR TITLE
WP-3801 Release w_transport 2.9.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.7
+version: 2.9.8
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4421 strong mode 2.x](https://github.com/Workiva/w_transport/pull/264)
* [WP-4569 Fix tests on Dart 1.24.x (BACKPATCH 2.X)](https://github.com/Workiva/w_transport/pull/268)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.7...version-bump-w_transport-2-9-8
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.7...2.9.8