### PR TITLE
Re-add stack_trace dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.2
+  stack_trace: ^1.4.0
 
 dev_dependencies:
   ansicolor: ^0.0.9


### PR DESCRIPTION
Re-add a stack_trace dependency that was erroneously removed.