### PR TITLE
Release w_transport 2.9.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.8
+version: 2.9.9
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4629 Re-add stack_trace dependency](https://github.com/Workiva/w_transport/pull/270)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.8...version-bump-w_transport-2-9-9
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.8...2.9.9