### PR TITLE
WP-4632 Global WebSocket monitor

### DIFF
--- a/lib/src/web_socket/browser/w_socket.dart
+++ b/lib/src/web_socket/browser/w_socket.dart
@@ -21,6 +21,7 @@ import 'dart:typed_data';
 import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 
 /// Implementation of the platform-dependent pieces of the [WSocket] class for
 /// the browser. This class uses native WebSockets.
@@ -41,11 +42,17 @@ class BrowserWSocket extends CommonWSocket implements WSocket {
     // Will complete if the socket successfully opens, or complete with
     // an error if the socket moves straight to the closed state.
     Completer connected = new Completer();
-    socket.onOpen.first.then(connected.complete);
+    socket.onOpen.first.then((_) {
+      connected.complete();
+      emitWebSocketConnectEvent(
+          newWebSocketConnectEvent(url: uri.toString(), wasSuccessful: true));
+    });
     closed.then((_) {
       if (!connected.isCompleted) {
         connected
             .completeError(new WSocketException('Could not connect to $uri'));
+        emitWebSocketConnectEvent(newWebSocketConnectEvent(
+            url: uri.toString(), wasSuccessful: false));
       }
     });
 

--- a/lib/src/web_socket/global_web_socket_monitor.dart
+++ b/lib/src/web_socket/global_web_socket_monitor.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart' show required;
+
+List<GlobalWebSocketMonitor> _monitors = [];
+
+void emitWebSocketConnectEvent(WebSocketConnectEvent connectEvent) {
+  for (final monitor in _monitors) {
+    monitor._didAttemptToConnect.add(connectEvent);
+  }
+}
+
+GlobalWebSocketMonitor newGlobalWebSocketMonitor() =>
+    new GlobalWebSocketMonitor._();
+
+WebSocketConnectEvent newWebSocketConnectEvent(
+        {@required String url,
+        @required bool wasSuccessful,
+        String sockJsSelectedProtocol,
+        List<String> sockJsProtocolsWhitelist}) =>
+    new WebSocketConnectEvent._(
+        url: url,
+        wasSuccessful: wasSuccessful,
+        sockJsProtocolsWhitelist: sockJsProtocolsWhitelist,
+        sockJsSelectedProtocol: sockJsSelectedProtocol);
+
+class GlobalWebSocketMonitor {
+  StreamController<WebSocketConnectEvent> _didAttemptToConnect =
+      new StreamController<WebSocketConnectEvent>.broadcast();
+
+  Stream<WebSocketConnectEvent> get didAttemptToConnect =>
+      _didAttemptToConnect.stream;
+
+  GlobalWebSocketMonitor._() {
+    _monitors.add(this);
+  }
+
+  Future<Null> close() async {
+    _monitors.remove(this);
+    await _didAttemptToConnect.close();
+  }
+}
+
+class WebSocketConnectEvent {
+  final List<String> sockJsProtocolsWhitelist;
+  final String sockJsSelectedProtocol;
+  final String url;
+  final bool wasSuccessful;
+
+  WebSocketConnectEvent._(
+      {@required this.url,
+      @required this.wasSuccessful,
+      this.sockJsProtocolsWhitelist,
+      this.sockJsSelectedProtocol});
+}

--- a/lib/src/web_socket/vm/w_socket.dart
+++ b/lib/src/web_socket/vm/w_socket.dart
@@ -20,6 +20,7 @@ import 'dart:io';
 import 'package:w_transport/src/web_socket/common/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 
 /// Implementation of the platform-dependent pieces of the [WSocket] class for
 /// the Dart VM. This class uses native Dart WebSockets.
@@ -29,11 +30,17 @@ class VMWSocket extends CommonWSocket implements WSocket {
     // Note: closing this sink is handled by VMWSocket
     // ignore: close_sinks
     WebSocket webSocket;
+    bool wasSuccessful;
     try {
       webSocket = await WebSocket.connect(uri.toString(),
           protocols: protocols, headers: headers);
+      wasSuccessful = true;
     } on SocketException catch (e) {
+      wasSuccessful = false;
       throw new WSocketException(e.toString());
+    } finally {
+      emitWebSocketConnectEvent(newWebSocketConnectEvent(
+          url: uri.toString(), wasSuccessful: wasSuccessful));
     }
 
     return new VMWSocket._(webSocket);

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -23,6 +23,7 @@ library w_transport.src.web_socket.w_socket;
 import 'dart:async';
 
 import 'package:w_transport/src/platform_adapter.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 
 /// A two-way communication object for WebSocket clients. Establishes
 /// a WebSocket connection, sends data or streams of data to the server,
@@ -77,6 +78,13 @@ import 'package:w_transport/src/platform_adapter.dart';
 ///     webSocket.listen((_) {}, onDone: () { ... });
 ///
 abstract class WSocket implements Stream, StreamSink {
+  /// Returns a monitor that provides streams of events for all WebSockets
+  /// constructed via w_transport.
+  ///
+  /// These streams may be useful for reporting analytics/metrics.
+  static GlobalWebSocketMonitor getGlobalEventMonitor() =>
+      newGlobalWebSocketMonitor();
+
   /// Create a new WebSocket connection. The given [uri] must use the scheme
   /// `ws` or `wss`.
   ///

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -117,5 +117,7 @@ export 'package:w_transport/src/web_socket/w_socket_close_event.dart'
     show WSocketCloseEvent;
 export 'package:w_transport/src/web_socket/w_socket_exception.dart'
     show WSocketException;
+export 'package:w_transport/src/web_socket/global_web_socket_monitor.dart'
+    show GlobalWebSocketMonitor, WebSocketConnectEvent;
 
 export 'package:http_parser/http_parser.dart' show MediaType;

--- a/test/integration/browser_integration_test.dart
+++ b/test/integration/browser_integration_test.dart
@@ -17,6 +17,11 @@ library w_transport.test.integration.browser_suite_test;
 
 import 'package:test/test.dart';
 
+import 'global_web_socket_monitor/browser_test.dart'
+    as global_web_socket_monitor_browser;
+import 'global_web_socket_monitor/sockjs_test.dart'
+    as global_web_socket_monitor_sockjs;
+
 import 'http/client/browser_test.dart' as http_client_browser;
 import 'http/common_request/browser_test.dart' as http_common_request_browser;
 import 'http/form_request/browser_test.dart' as http_form_request_browser;
@@ -35,6 +40,9 @@ import 'ws/browser_test.dart' as ws_browser;
 import 'ws/sockjs_test.dart' as ws_sockjs;
 
 void main() {
+  global_web_socket_monitor_browser.main();
+  global_web_socket_monitor_sockjs.main();
+
   http_client_browser.main();
   http_common_request_browser.main();
   http_form_request_browser.main();

--- a/test/integration/global_web_socket_monitor/browser_test.dart
+++ b/test/integration/global_web_socket_monitor/browser_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_browser.dart';
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..platform = platformBrowser
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(naming.toString(), () {
+    setUp(() {
+      configureWTransportForBrowser();
+    });
+
+    runCommonGlobalWebSocketMonitorIntegrationTests();
+
+    test('didAttemptToConnect events should not include sockJS info', () async {
+      var monitor = WSocket.getGlobalEventMonitor();
+      var events = <WebSocketConnectEvent>[];
+      monitor.didAttemptToConnect.listen(events.add);
+
+      var webSocket = await WSocket.connect(IntegrationPaths.echoUri);
+      await webSocket.close();
+
+      await WSocket.connect(IntegrationPaths.fourOhFourUri).catchError((_) {});
+
+      await monitor.close();
+
+      expect(events.length, equals(2));
+
+      expect(events[0].url, equals(IntegrationPaths.echoUri.toString()));
+      expect(events[0].wasSuccessful, isTrue);
+      expect(events[0].sockJsProtocolsWhitelist, isNull);
+      expect(events[0].sockJsSelectedProtocol, isNull);
+
+      expect(events[1].url, equals(IntegrationPaths.fourOhFourUri.toString()));
+      expect(events[1].wasSuccessful, isFalse);
+      expect(events[1].sockJsProtocolsWhitelist, isNull);
+      expect(events[1].sockJsSelectedProtocol, isNull);
+    });
+  });
+}

--- a/test/integration/global_web_socket_monitor/common.dart
+++ b/test/integration/global_web_socket_monitor/common.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart'
+    show WSocket, WebSocketConnectEvent;
+
+import '../integration_paths.dart';
+
+void runCommonGlobalWebSocketMonitorIntegrationTests(
+    {Future<WSocket> connect(Uri uri), int port}) {
+  if (connect == null) {
+    connect = (uri) => WSocket.connect(uri);
+  }
+  var closeUri = IntegrationPaths.closeUri;
+  var echoUri = IntegrationPaths.echoUri;
+  var fourOhFourUri = IntegrationPaths.fourOhFourUri;
+  var pingUri = IntegrationPaths.pingUri;
+  if (port != null) {
+    closeUri = closeUri.replace(port: port);
+    echoUri = echoUri.replace(port: port);
+    pingUri = pingUri.replace(port: port);
+  }
+
+  test('should support multiple monitors, each of which can be closed',
+      () async {
+    // First connection attempt - no monitors.
+    var webSocket1 = await connect(closeUri);
+    await webSocket1.close();
+
+    var monitor1 = WSocket.getGlobalEventMonitor();
+    var monitor1Events = <WebSocketConnectEvent>[];
+    monitor1.didAttemptToConnect.listen(monitor1Events.add);
+
+    // Second connection attempt - monitor 1 should receive it.
+    var webSocket2 = await connect(echoUri);
+    await webSocket2.close();
+
+    var monitor2 = WSocket.getGlobalEventMonitor();
+    var monitor2Events = <WebSocketConnectEvent>[];
+    monitor2.didAttemptToConnect.listen(monitor2Events.add);
+
+    // Third connection attempt - monitors 1 & 2 should both receive it.
+    var webSocket3 = await connect(pingUri);
+    await webSocket3.close();
+
+    await monitor2.close();
+
+    // Fourth connection attempt - only monitor 1 should receive it.
+    await connect(fourOhFourUri).catchError((_) {});
+
+    await monitor1.close();
+
+    expect(monitor1Events.length, equals(3));
+    expect(monitor2Events.length, equals(1));
+
+    expect(monitor1Events[0].url, equals(echoUri.toString()));
+    expect(monitor1Events[0].wasSuccessful, isTrue);
+
+    expect(monitor1Events[1].url, equals(pingUri.toString()));
+    expect(monitor1Events[1].wasSuccessful, isTrue);
+    expect(monitor2Events[0].url, equals(pingUri.toString()));
+    expect(monitor2Events[0].wasSuccessful, isTrue);
+
+    expect(monitor1Events[2].url, equals(fourOhFourUri.toString()));
+    expect(monitor1Events[2].wasSuccessful, isFalse);
+  });
+}

--- a/test/integration/global_web_socket_monitor/sockjs_test.dart
+++ b/test/integration/global_web_socket_monitor/sockjs_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_browser.dart';
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+const int sockjsPort = 8026;
+
+void main() {
+  Naming wsNaming = new Naming()
+    ..platform = platformBrowserSockjsWS
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  Naming xhrNaming = new Naming()
+    ..platform = platformBrowserSockjsXhr
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  Naming wsDeprecatedNaming = new Naming()
+    ..platform = platformBrowserSockjsWSDeprecated
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  Naming xhrDeprecatedNaming = new Naming()
+    ..platform = platformBrowserSockjsXhrDeprecated
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(wsNaming.toString(), () {
+    setUp(() {
+      configureWTransportForBrowser();
+    });
+
+    var protocolsWhitelist = ['websocket'];
+    sockJSSuite(
+        (Uri uri) => WSocket.connect(uri,
+            useSockJS: true,
+            sockJSNoCredentials: true,
+            sockJSProtocolsWhitelist: protocolsWhitelist),
+        protocolsWhitelist);
+  });
+
+  group(xhrNaming.toString(), () {
+    setUp(() {
+      configureWTransportForBrowser();
+    });
+
+    var protocolsWhitelist = ['xhr-streaming'];
+    sockJSSuite(
+        (Uri uri) => WSocket.connect(uri,
+            useSockJS: true,
+            sockJSNoCredentials: true,
+            sockJSProtocolsWhitelist: protocolsWhitelist),
+        protocolsWhitelist);
+  });
+
+  group(wsDeprecatedNaming.toString(), () {
+    var protocolsWhitelist = ['websocket'];
+
+    setUp(() {
+      configureWTransportForBrowser(
+          useSockJS: true,
+          sockJSNoCredentials: true,
+          sockJSProtocolsWhitelist: protocolsWhitelist);
+    });
+
+    sockJSSuite((Uri uri) => WSocket.connect(uri), protocolsWhitelist);
+  });
+
+  group(xhrDeprecatedNaming.toString(), () {
+    var protocolsWhitelist = ['xhr-streaming'];
+
+    setUp(() {
+      configureWTransportForBrowser(
+          useSockJS: true,
+          sockJSNoCredentials: true,
+          sockJSProtocolsWhitelist: protocolsWhitelist);
+    });
+
+    sockJSSuite((Uri uri) => WSocket.connect(uri), protocolsWhitelist);
+  });
+}
+
+void sockJSSuite(connect(Uri uri), List<String> protocolsWhitelist) {
+  runCommonGlobalWebSocketMonitorIntegrationTests(
+      connect: connect, port: sockjsPort);
+
+  var echoUri = IntegrationPaths.echoUri.replace(port: sockjsPort);
+  var fourOhFourUri = IntegrationPaths.fourOhFourUri;
+
+  test('didAttemptToConnect events should include sockJS info', () async {
+    var monitor = WSocket.getGlobalEventMonitor();
+    var events = <WebSocketConnectEvent>[];
+    monitor.didAttemptToConnect.listen(events.add);
+
+    var webSocket = await connect(echoUri);
+    await webSocket.close();
+
+    await connect(fourOhFourUri).catchError((_) {});
+
+    await monitor.close();
+
+    expect(events.length, equals(2));
+
+    expect(events[0].url, equals(echoUri.toString()));
+    expect(events[0].wasSuccessful, isTrue);
+    expect(events[0].sockJsProtocolsWhitelist, equals(protocolsWhitelist));
+    expect(events[0].sockJsSelectedProtocol, equals(protocolsWhitelist.last));
+
+    expect(events[1].url, equals(fourOhFourUri.toString()));
+    expect(events[1].wasSuccessful, isFalse);
+    expect(events[1].sockJsProtocolsWhitelist, equals(protocolsWhitelist));
+    expect(events[1].sockJsSelectedProtocol, isNull);
+  });
+}

--- a/test/integration/global_web_socket_monitor/vm_test.dart
+++ b/test/integration/global_web_socket_monitor/vm_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart';
+import 'package:w_transport/w_transport_vm.dart';
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..platform = platformVM
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(naming.toString(), () {
+    setUp(() {
+      configureWTransportForVM();
+    });
+
+    runCommonGlobalWebSocketMonitorIntegrationTests();
+
+    test('didAttemptToConnect events should not include sockJS info', () async {
+      var monitor = WSocket.getGlobalEventMonitor();
+      var events = <WebSocketConnectEvent>[];
+      monitor.didAttemptToConnect.listen(events.add);
+
+      var webSocket = await WSocket.connect(IntegrationPaths.echoUri);
+      await webSocket.close();
+
+      await WSocket.connect(IntegrationPaths.fourOhFourUri).catchError((_) {});
+
+      await monitor.close();
+
+      expect(events.length, equals(2));
+
+      expect(events[0].url, equals(IntegrationPaths.echoUri.toString()));
+      expect(events[0].wasSuccessful, isTrue);
+      expect(events[0].sockJsProtocolsWhitelist, isNull);
+      expect(events[0].sockJsSelectedProtocol, isNull);
+
+      expect(events[1].url, equals(IntegrationPaths.fourOhFourUri.toString()));
+      expect(events[1].wasSuccessful, isFalse);
+      expect(events[1].sockJsProtocolsWhitelist, isNull);
+      expect(events[1].sockJsSelectedProtocol, isNull);
+    });
+  });
+}

--- a/test/integration/vm_integration_test.dart
+++ b/test/integration/vm_integration_test.dart
@@ -17,6 +17,8 @@ library w_transport.test.integration.vm_suite_test;
 
 import 'package:test/test.dart';
 
+import 'global_web_socket_monitor/vm_test.dart' as global_web_socket_monitor_vm;
+
 import 'http/client/vm_test.dart' as http_client_vm;
 import 'http/common_request/vm_test.dart' as http_common_request_vm;
 import 'http/form_request/vm_test.dart' as http_form_request_vm;
@@ -31,6 +33,8 @@ import 'platforms/vm_platform_test.dart' as vm_platform_adapter_test;
 import 'ws/vm_test.dart' as ws_vm;
 
 void main() {
+  global_web_socket_monitor_vm.main();
+
   http_client_vm.main();
   http_common_request_vm.main();
   http_form_request_vm.main();

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -31,6 +31,7 @@ const String testTypeUnit = 'unit';
 
 /// Topics
 const String topicBackoff = 'Backoff';
+const String topicGlobalWebSocketMonitor = 'GlobalWebSocketMonitor';
 const String topicHttp = 'HTTP';
 const String topicMocks = 'Mocks';
 const String topicPlatformAdapter = 'Platform Adapter';


### PR DESCRIPTION
## Description

In order to provide some insight into WebSocket connections at a global level, this PR adds a global "event monitor" for WebSocket connections. This monitor can be used to report analytics.

To obtain a WebSocket event monitor:

```dart
var monitor = WSocket.getGlobalEventMonitor();
```

To listen for connection attempt events:

```dart
var monitor = WSocket.getGlobalEventMonitor();
monitor.didAttemptToConnect.listen((event) {
  // event.wasSuccessful
  // event.url
  // event.sockJsProtocolsWhitelist
  // event.sockJsSelectedProtocol
});
```

## Testing

- [ ] CI pass (tests added)
- [ ] Use this branch to successfully listen for and report analytics on WebSocket connections (instructions coming)

## Code Review

@Workiva/web-platform-pp 