### PR TITLE
WP-3805 Release w_transport 3.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.3
+version: 3.0.4
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3986 Fix 3.0.3 changelog header](https://github.com/Workiva/w_transport/pull/261)
* [WP-4253 tweak docs.yaml to match guide layout](https://github.com/Workiva/w_transport/pull/263)
* [WP-4568 Fix tests on Dart 1.24.x](https://github.com/Workiva/w_transport/pull/267)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.3...version-bump-w_transport-3-0-4
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.3...3.0.4