### PR TITLE
WP-4672 Dart dev compiler compatibility

### DIFF
--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -477,80 +477,160 @@ abstract class CommonRequest extends Object
   }
 
   @override
-  Future<Response> delete({Map<String, String> headers, Uri uri}) =>
-      _send('DELETE', headers: headers, uri: uri);
+  Future<Response> delete({Map<String, String> headers, Uri uri}) async {
+    final r = await _send('DELETE', headers: headers, uri: uri);
+    assert(r is Response, 'delete() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
-  Future<Response> get({Map<String, String> headers, Uri uri}) =>
-      _send('GET', headers: headers, uri: uri);
+  Future<Response> get({Map<String, String> headers, Uri uri}) async {
+    final r = await _send('GET', headers: headers, uri: uri);
+    assert(r is Response, 'get() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
-  Future<Response> head({Map<String, String> headers, Uri uri}) =>
-      _send('HEAD', headers: headers, uri: uri);
+  Future<Response> head({Map<String, String> headers, Uri uri}) async {
+    final r = await _send('HEAD', headers: headers, uri: uri);
+    assert(r is Response, 'head() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
-  Future<Response> options({Map<String, String> headers, Uri uri}) =>
-      _send('OPTIONS', headers: headers, uri: uri);
+  Future<Response> options({Map<String, String> headers, Uri uri}) async {
+    final r = await _send('OPTIONS', headers: headers, uri: uri);
+    assert(r is Response, 'options() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
   Future<Response> patch(
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('PATCH', body: body, headers: headers, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('PATCH', body: body, headers: headers, uri: uri);
+    assert(r is Response, 'patch() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
-  Future<Response> post({dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('POST', body: body, headers: headers, uri: uri);
+  Future<Response> post(
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('POST', body: body, headers: headers, uri: uri);
+    assert(r is Response, 'post() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
-  Future<Response> put({dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('PUT', body: body, headers: headers, uri: uri);
+  Future<Response> put(
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('PUT', body: body, headers: headers, uri: uri);
+    assert(r is Response, 'put() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
   Future<Response> send(String method,
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send(method, headers: headers, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send(method, headers: headers, uri: uri);
+    assert(r is Response, 'delete() should return a Response');
+    Response response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamDelete(
-          {Map<String, String> headers, Uri uri}) =>
-      _send('DELETE', headers: headers, streamResponse: true, uri: uri);
+      {Map<String, String> headers, Uri uri}) async {
+    final r =
+        await _send('DELETE', headers: headers, streamResponse: true, uri: uri);
+    assert(r is StreamedResponse,
+        'streamDelete() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
-  Future<StreamedResponse> streamGet({Map<String, String> headers, Uri uri}) =>
-      _send('GET', headers: headers, streamResponse: true, uri: uri);
+  Future<StreamedResponse> streamGet(
+      {Map<String, String> headers, Uri uri}) async {
+    final r =
+        await _send('GET', headers: headers, streamResponse: true, uri: uri);
+    assert(
+        r is StreamedResponse, 'streamGet() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
-  Future<StreamedResponse> streamHead({Map<String, String> headers, Uri uri}) =>
-      _send('HEAD', headers: headers, streamResponse: true, uri: uri);
+  Future<StreamedResponse> streamHead(
+      {Map<String, String> headers, Uri uri}) async {
+    final r =
+        await _send('HEAD', headers: headers, streamResponse: true, uri: uri);
+    assert(
+        r is StreamedResponse, 'streamHead() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamOptions(
-          {Map<String, String> headers, Uri uri}) =>
-      _send('OPTIONS', headers: headers, streamResponse: true, uri: uri);
+      {Map<String, String> headers, Uri uri}) async {
+    final r = await _send('OPTIONS',
+        headers: headers, streamResponse: true, uri: uri);
+    assert(r is StreamedResponse,
+        'streamOptions() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamPatch(
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('PATCH',
-          body: body, headers: headers, streamResponse: true, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('PATCH',
+        body: body, headers: headers, streamResponse: true, uri: uri);
+    assert(r is StreamedResponse,
+        'streamPatch() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamPost(
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('POST',
-          body: body, headers: headers, streamResponse: true, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('POST',
+        body: body, headers: headers, streamResponse: true, uri: uri);
+    assert(
+        r is StreamedResponse, 'streamPost() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamPut(
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send('PUT',
-          body: body, headers: headers, streamResponse: true, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send('PUT',
+        body: body, headers: headers, streamResponse: true, uri: uri);
+    assert(
+        r is StreamedResponse, 'streamPut() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<StreamedResponse> streamSend(String method,
-          {dynamic body, Map<String, String> headers, Uri uri}) =>
-      _send(method,
-          body: body, headers: headers, streamResponse: true, uri: uri);
+      {dynamic body, Map<String, String> headers, Uri uri}) async {
+    final r = await _send(method,
+        body: body, headers: headers, streamResponse: true, uri: uri);
+    assert(
+        r is StreamedResponse, 'streamSend() should return a StreamedResponse');
+    StreamedResponse response = r;
+    return response;
+  }
 
   @override
   Future<Response> retry() {

--- a/lib/src/mocks/mock_transports.dart
+++ b/lib/src/mocks/mock_transports.dart
@@ -28,6 +28,7 @@ import 'package:w_transport/src/http/mock/response.dart' show MockResponse;
 import 'package:w_transport/src/http/response.dart' show BaseResponse;
 import 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
 import 'package:w_transport/src/web_socket/w_socket.dart' show WSocket;
+import 'package:w_transport/src/web_socket/web_socket.dart' show WebSocket;
 import 'package:w_transport/src/web_socket/web_socket_exception.dart'
     show WebSocketException;
 

--- a/lib/src/mocks/mock_web_socket.dart
+++ b/lib/src/mocks/mock_web_socket.dart
@@ -95,7 +95,7 @@ class MockWebSocketInternal {
   static Map<String, WebSocketConnectHandler> _handlers = {};
   static Map<Pattern, WebSocketPatternConnectHandler> _patternHandlers = {};
 
-  static Future<WSocket> handleWebSocketConnection(Uri uri,
+  static Future<WebSocket> handleWebSocketConnection(Uri uri,
       {Map<String, dynamic> headers, Iterable<String> protocols}) async {
     final matchingExpectations = _getMatchingExpectations(uri);
     if (matchingExpectations.isNotEmpty) {

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -87,7 +87,7 @@ abstract class WSocket implements Stream, StreamSink {
   /// Additional headers to be used in setting up the connection can be
   /// specified in [headers]. This only applies to server-side usage. See
   /// `dart:io`'s [WebSocket] for more information.
-  static Future<WSocket> connect(Uri uri,
+  static Future<WebSocket> connect(Uri uri,
           {Map<String, dynamic> headers,
           Iterable<String> protocols,
           TransportPlatform transportPlatform,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,3 +40,7 @@ dev_dependencies:
   react: ^0.6.1
   test: ^0.12.23+1
   uuid: ^0.5.3
+
+transformers:
+- test/pub_serve:
+    $include: test/**_test.dart

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -485,6 +485,7 @@ void _runCommonRequestSuiteFor(
           (FinalizedRequest request, response, [exception]) async {
         expect(request.method, equals('GET'));
         expect(request.uri, equals(requestUri));
+        return response;
       };
       await request.get(uri: requestUri);
     });
@@ -498,6 +499,7 @@ void _runCommonRequestSuiteFor(
         expect(response, new isInstanceOf<transport.Response>());
         transport.Response standardResponse = response;
         expect(standardResponse.body.asString(), equals('original'));
+        return standardResponse;
       };
       await request.get(uri: requestUri);
     });
@@ -508,6 +510,7 @@ void _runCommonRequestSuiteFor(
       final request = requestFactory();
       request.responseInterceptor = (request, response, [exception]) async {
         expect(exception, isNull);
+        return response;
       };
       await request.get(uri: requestUri);
     });


### PR DESCRIPTION
Fixes #277.

## Issue

There were a few typing issues that were preventing compatibility with the dart dev compiler.

## Solution

Fix them!

## Testing
- [ ] CI passes
- [ ] Unit tests pass when compiled via the dart dev compiler:
  - Checkout this branch locally
  - `pub get`
  - in one terminal: `pub serve test --web-compiler=dartdevc`
  - in a second terminal: `pub run test -p chrome --pub-serve=8080 test/unit/platform_independent_unit_test.dart`

## Code Review

@Workiva/web-platform-pp 
fyi @valakis