### PR TITLE
WP-4674 Address or ignore deprecated uses

### DIFF
--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -45,7 +45,7 @@ Future<Null> main() async {
 
   renderGlobalExampleMenu(serverStatus: true);
 
-  // ignore: close_sinks
+  // ignore: close_sinks,deprecated_member_use
   WSocket webSocket;
 
   // Connect (or reconnect) when the connect button is clicked.
@@ -66,9 +66,13 @@ Future<Null> main() async {
     final uri = sockjs ? _sockJSServer : _wsServer;
 
     try {
+      // ignore: deprecated_member_use
       webSocket = await WSocket.connect(uri,
+          // ignore: deprecated_member_use
           useSockJS: sockjs,
+          // ignore: deprecated_member_use
           sockJSTimeout: timeout,
+          // ignore: deprecated_member_use
           sockJSProtocolsWhitelist: protocols);
 
       // Display messages from web socket

--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -53,16 +53,21 @@ void configureWTransportForBrowser(
     @Deprecated(v3Deprecation) List<String> sockJSProtocolsWhitelist}) {
   // Configuring SockJS at this level is deprecated. SockJS configuration should
   // occur on a per-socket basis.
+  // ignore: deprecated_member_use
   if (useSockJS == true) {
     print('Deprecation Warning: Configuring all w_transport sockets to use '
         'SockJS is deprecated. Instead, SockJS usage should be configured on a '
         'per-socket basis via the optional parameters in WSocket.connect().');
   }
 
+  // ignore: deprecated_member_use
   if (useSockJS == true) {
     globalTransportPlatform = new BrowserTransportPlatformWithSockJS(
+        // ignore: deprecated_member_use
         sockJSNoCredentials: sockJSNoCredentials,
+        // ignore: deprecated_member_use
         sockJSDebug: sockJSDebug,
+        // ignore: deprecated_member_use
         sockJSProtocolsWhitelist: sockJSProtocolsWhitelist);
   } else {
     globalTransportPlatform = browserTransportPlatform;

--- a/lib/mock.dart
+++ b/lib/mock.dart
@@ -29,14 +29,14 @@ import 'package:w_transport/src/mocks/mock_transports.dart' show MockTransports;
 export 'package:w_transport/src/http/finalized_request.dart'
     show FinalizedRequest;
 export 'package:w_transport/src/http/mock/base_request.dart'
-    show MockBaseRequest;
+    show MockBaseRequest; // ignore: deprecated_member_use
 export 'package:w_transport/src/http/mock/client.dart' show MockClient;
 export 'package:w_transport/src/http/mock/requests.dart'
     show
-        MockFormRequest,
-        MockJsonRequest,
-        MockPlainTextRequest,
-        MockStreamedRequest;
+        MockFormRequest, // ignore: deprecated_member_use
+        MockJsonRequest, // ignore: deprecated_member_use
+        MockPlainTextRequest, // ignore: deprecated_member_use
+        MockStreamedRequest; // ignore: deprecated_member_use
 export 'package:w_transport/src/http/mock/response.dart'
     show MockResponse, MockStreamedResponse;
 
@@ -52,7 +52,8 @@ export 'package:w_transport/src/mocks/mock_transports.dart'
         WebSocketConnectHandler,
         WebSocketPatternConnectHandler;
 
-export 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
+export 'package:w_transport/src/web_socket/mock/w_socket.dart'
+    show MockWSocket; // ignore: deprecated_member_use
 
 /// Configure w_transport for use in tests, allowing you to easily mock out the
 /// behavior of the w_transport classes.

--- a/lib/src/browser_transport_platform.dart
+++ b/lib/src/browser_transport_platform.dart
@@ -56,11 +56,16 @@ class BrowserTransportPlatform implements TransportPlatform {
     // that for backwards compatibility.
 
     // If useSockJS is enabled, switch to a SockJS WebSocket.
+    // ignore: deprecated_member_use
     if (useSockJS == true) {
       return SockJSWebSocket.connect(uri,
+          // ignore: deprecated_member_use
           debug: sockJSDebug,
+          // ignore: deprecated_member_use
           noCredentials: sockJSNoCredentials,
+          // ignore: deprecated_member_use
           protocolsWhitelist: sockJSProtocolsWhitelist,
+          // ignore: deprecated_member_use
           timeout: sockJSTimeout);
     }
 

--- a/lib/src/browser_transport_platform_with_sockjs.dart
+++ b/lib/src/browser_transport_platform_with_sockjs.dart
@@ -51,6 +51,7 @@ class BrowserTransportPlatformWithSockJS extends BrowserTransportPlatform
     // that for backwards compatibility.
 
     // If useSockJS is for some reason disabled, revert to standard WebSocket.
+    // ignore: deprecated_member_use
     if (useSockJS == false) {
       return BrowserWebSocket.connect(uri,
           headers: headers, protocols: protocols);
@@ -59,10 +60,14 @@ class BrowserTransportPlatformWithSockJS extends BrowserTransportPlatform
     // Otherwise, use the given sockJS params if given and fallback to the
     // settings configured with this TransportPlatform instance.
     return SockJSWebSocket.connect(uri,
+        // ignore: deprecated_member_use
         debug: sockJSDebug ?? _sockJSDebug,
+        // ignore: deprecated_member_use
         noCredentials: sockJSNoCredentials ?? _sockJSNoCredentials,
         protocolsWhitelist:
+            // ignore: deprecated_member_use
             sockJSProtocolsWhitelist ?? _sockJSProtocolsWhitelist,
+        // ignore: deprecated_member_use
         timeout: sockJSTimeout ?? _sockJSTimeout);
   }
 }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Add link to upgrade guide.
 const String v3Deprecation = 'in 4.0.0. ';

--- a/lib/src/http/browser/multipart_request.dart
+++ b/lib/src/http/browser/multipart_request.dart
@@ -33,6 +33,7 @@ class BrowserMultipartRequest extends CommonRequest
     implements MultipartRequest {
   BrowserMultipartRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   BrowserMultipartRequest.fromClient(Client wTransportClient)
       : super.fromClient(wTransportClient, null);
 

--- a/lib/src/http/browser/requests.dart
+++ b/lib/src/http/browser/requests.dart
@@ -26,6 +26,7 @@ export 'package:w_transport/src/http/browser/multipart_request.dart'
 class BrowserFormRequest extends CommonFormRequest with BrowserRequestMixin {
   BrowserFormRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   BrowserFormRequest.fromClient(Client wTransportClient)
       : super.fromClient(wTransportClient, null);
 }
@@ -33,6 +34,7 @@ class BrowserFormRequest extends CommonFormRequest with BrowserRequestMixin {
 class BrowserJsonRequest extends CommonJsonRequest with BrowserRequestMixin {
   BrowserJsonRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   BrowserJsonRequest.fromClient(Client wTransportClient)
       : super.fromClient(wTransportClient, null);
 }
@@ -41,6 +43,7 @@ class BrowserPlainTextRequest extends CommonPlainTextRequest
     with BrowserRequestMixin {
   BrowserPlainTextRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   BrowserPlainTextRequest.fromClient(Client wTransportClient)
       : super.fromClient(wTransportClient, null);
 }
@@ -49,6 +52,7 @@ class BrowserStreamedRequest extends CommonStreamedRequest
     with BrowserRequestMixin {
   BrowserStreamedRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   BrowserStreamedRequest.fromClient(Client wTransportClient)
       : super.fromClient(wTransportClient, null);
 }

--- a/lib/src/http/common/form_request.dart
+++ b/lib/src/http/common/form_request.dart
@@ -27,6 +27,7 @@ import 'package:w_transport/src/transport_platform.dart';
 abstract class CommonFormRequest extends CommonRequest implements FormRequest {
   CommonFormRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   CommonFormRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 

--- a/lib/src/http/common/json_request.dart
+++ b/lib/src/http/common/json_request.dart
@@ -27,6 +27,7 @@ import 'package:w_transport/src/transport_platform.dart';
 abstract class CommonJsonRequest extends CommonRequest implements JsonRequest {
   CommonJsonRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   CommonJsonRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 

--- a/lib/src/http/common/multipart_request.dart
+++ b/lib/src/http/common/multipart_request.dart
@@ -63,6 +63,7 @@ abstract class CommonMultipartRequest extends CommonRequest
 
   CommonMultipartRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   CommonMultipartRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 

--- a/lib/src/http/common/plain_text_request.dart
+++ b/lib/src/http/common/plain_text_request.dart
@@ -26,6 +26,7 @@ import 'package:w_transport/src/transport_platform.dart';
 abstract class CommonPlainTextRequest extends CommonRequest implements Request {
   CommonPlainTextRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   CommonPlainTextRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -43,6 +43,7 @@ abstract class CommonRequest extends Object
     autoRetry = new RequestAutoRetry(this);
   }
 
+  // ignore: deprecated_member_use
   CommonRequest.fromClient(Client wTransportClient, client)
       : this._wTransportClient = wTransportClient,
         this.client = client {
@@ -149,8 +150,9 @@ abstract class CommonRequest extends Object
   /// Whether or not to send the request with credentials.
   bool _withCredentials = false;
 
-  /// [Client] instance from which this request was created. Used in [clone] to
-  /// correctly tie the clone to the same client.
+  /// HttpClient instance from which this request was created. Used in [clone]
+  /// to correctly tie the clone to the same client.
+  // ignore: deprecated_member_use
   Client _wTransportClient;
 
   /// Gets the content length of the request. If the size of the request is not

--- a/lib/src/http/common/streamed_request.dart
+++ b/lib/src/http/common/streamed_request.dart
@@ -26,6 +26,7 @@ abstract class CommonStreamedRequest extends CommonRequest
     implements StreamedRequest {
   CommonStreamedRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   CommonStreamedRequest.fromClient(Client wTransportClient, client)
       : super.fromClient(wTransportClient, client);
 

--- a/lib/src/http/http_client.dart
+++ b/lib/src/http/http_client.dart
@@ -24,6 +24,7 @@ import 'package:w_transport/src/transport_platform.dart';
 ///
 /// On the server, the Dart VM will also be able to take advantage of cached
 /// network connections between requests that share a client.
+// ignore: deprecated_member_use
 abstract class HttpClient extends Client {
   factory HttpClient({TransportPlatform transportPlatform}) {
     // If a transport platform is not explicitly given, fallback to the globally

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 import 'package:w_transport/w_transport.dart';
 
 /// Base class representing an interceptor that can be registered with a
-/// [Client] instance to intercept HTTP requests and responses in order to
+/// HttpClient instance to intercept HTTP requests and responses in order to
 /// modify or augment them prior to dispatch and delivery, respectively.
 class HttpInterceptor {
   Future<RequestPayload> interceptRequest(RequestPayload payload) async {

--- a/lib/src/http/mock/http_client.dart
+++ b/lib/src/http/mock/http_client.dart
@@ -32,6 +32,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   FormRequest newFormRequest() {
     verifyNotClosed();
+    // ignore: deprecated_member_use
     final request = new MockFormRequest.fromClient(this, _transport);
     registerAndDecorateRequest(request);
     return request;
@@ -42,6 +43,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   JsonRequest newJsonRequest() {
     verifyNotClosed();
+    // ignore: deprecated_member_use
     final request = new MockJsonRequest.fromClient(this, _transport);
     registerAndDecorateRequest(request);
     return request;
@@ -52,6 +54,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   MultipartRequest newMultipartRequest() {
     verifyNotClosed();
+    // ignore: deprecated_member_use
     final request = new MockMultipartRequest.fromClient(this, _transport);
     registerAndDecorateRequest(request);
     return request;
@@ -62,6 +65,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   Request newRequest() {
     verifyNotClosed();
+    // ignore: deprecated_member_use
     final request = new MockPlainTextRequest.fromClient(this, _transport);
     registerAndDecorateRequest(request);
     return request;
@@ -72,6 +76,7 @@ class MockHttpClient extends CommonHttpClient implements HttpClient {
   @override
   StreamedRequest newStreamedRequest() {
     verifyNotClosed();
+    // ignore: deprecated_member_use
     final request = new MockStreamedRequest.fromClient(this, _transport);
     registerAndDecorateRequest(request);
     return request;

--- a/lib/src/http/mock/request_mixin.dart
+++ b/lib/src/http/mock/request_mixin.dart
@@ -27,6 +27,7 @@ import 'package:w_transport/src/http/utils.dart' as http_utils;
 import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockHttpInternal;
 
+// ignore: deprecated_member_use
 abstract class MockRequestMixin implements MockBaseRequest, CommonRequest {
   Completer<Null> _canceled = new Completer<Null>();
   bool _mockHandlersRegistered = false;

--- a/lib/src/http/vm/requests.dart
+++ b/lib/src/http/vm/requests.dart
@@ -25,12 +25,14 @@ import 'package:w_transport/src/transport_platform.dart';
 
 class VMFormRequest extends CommonFormRequest with VMRequestMixin {
   VMFormRequest(TransportPlatform transportPlatform) : super(transportPlatform);
+  // ignore: deprecated_member_use
   VMFormRequest.fromClient(Client wTransportClient, HttpClient client)
       : super.fromClient(wTransportClient, client);
 }
 
 class VMJsonRequest extends CommonJsonRequest with VMRequestMixin {
   VMJsonRequest(TransportPlatform transportPlatform) : super(transportPlatform);
+  // ignore: deprecated_member_use
   VMJsonRequest.fromClient(Client wTransportClient, HttpClient client)
       : super.fromClient(wTransportClient, client);
 }
@@ -38,6 +40,7 @@ class VMJsonRequest extends CommonJsonRequest with VMRequestMixin {
 class VMMultipartRequest extends CommonMultipartRequest with VMRequestMixin {
   VMMultipartRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   VMMultipartRequest.fromClient(Client wTransportClient, HttpClient client)
       : super.fromClient(wTransportClient, client);
 }
@@ -45,6 +48,7 @@ class VMMultipartRequest extends CommonMultipartRequest with VMRequestMixin {
 class VMPlainTextRequest extends CommonPlainTextRequest with VMRequestMixin {
   VMPlainTextRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   VMPlainTextRequest.fromClient(Client wTransportClient, HttpClient client)
       : super.fromClient(wTransportClient, client);
 }
@@ -52,6 +56,7 @@ class VMPlainTextRequest extends CommonPlainTextRequest with VMRequestMixin {
 class VMStreamedRequest extends CommonStreamedRequest with VMRequestMixin {
   VMStreamedRequest(TransportPlatform transportPlatform)
       : super(transportPlatform);
+  // ignore: deprecated_member_use
   VMStreamedRequest.fromClient(Client wTransportClient, HttpClient client)
       : super.fromClient(wTransportClient, client);
 }

--- a/lib/src/mocks/mock_http.dart
+++ b/lib/src/mocks/mock_http.dart
@@ -25,6 +25,7 @@ class MockHttp {
 
   void causeFailureOnOpen(BaseRequest request) {
     MockHttpInternal._verifyRequestIsMock(request);
+    // ignore: deprecated_member_use
     final MockBaseRequest mockRequest = request;
     mockRequest.causeFailureOnOpen();
   }
@@ -140,12 +141,15 @@ class MockHttpInternal {
       {};
   static Map<Pattern, Map<String /* method */, PatternRequestHandler>>
       _patternRequestHandlers = {};
+  // ignore: deprecated_member_use
   static List<MockBaseRequest> _pending = [];
 
+  // ignore: deprecated_member_use
   static void cancelMockRequest(MockBaseRequest request) {
     _pending.remove(request);
   }
 
+  // ignore: deprecated_member_use
   static void handleMockRequest(MockBaseRequest request) {
     final matchingExpectations =
         _getMatchingExpectations(request.method, request.uri, request.headers);
@@ -283,6 +287,7 @@ class MockHttpInternal {
   }
 
   static void _verifyRequestIsMock(BaseRequest request) {
+    // ignore: deprecated_member_use
     if (request is! MockBaseRequest) {
       throw new ArgumentError.value(
           'Request must be of type MockBaseRequest. Make sure you configured w_transport for testing.');

--- a/lib/src/mocks/mock_transports.dart
+++ b/lib/src/mocks/mock_transports.dart
@@ -23,11 +23,13 @@ import 'package:w_transport/src/http/base_request.dart' show BaseRequest;
 import 'package:w_transport/src/http/finalized_request.dart'
     show FinalizedRequest;
 import 'package:w_transport/src/http/mock/base_request.dart'
-    show MockBaseRequest;
+    show MockBaseRequest; // ignore: deprecated_member_use
 import 'package:w_transport/src/http/mock/response.dart' show MockResponse;
 import 'package:w_transport/src/http/response.dart' show BaseResponse;
-import 'package:w_transport/src/web_socket/mock/w_socket.dart' show MockWSocket;
-import 'package:w_transport/src/web_socket/w_socket.dart' show WSocket;
+import 'package:w_transport/src/web_socket/mock/w_socket.dart'
+    show MockWSocket; // ignore: deprecated_member_use
+import 'package:w_transport/src/web_socket/w_socket.dart'
+    show WSocket; // ignore: deprecated_member_use
 import 'package:w_transport/src/web_socket/web_socket.dart' show WebSocket;
 import 'package:w_transport/src/web_socket/web_socket_exception.dart'
     show WebSocketException;

--- a/lib/src/mocks/mock_web_socket.dart
+++ b/lib/src/mocks/mock_web_socket.dart
@@ -109,12 +109,14 @@ class MockWebSocketInternal {
       // For backwards compatibility, it is still allowed to pass in a `WSocket`
       // instance for the `connectTo` param. If that happens, return it here and
       // it should function as expected.
+      // ignore: deprecated_member_use
       if (expectation.connectTo is WSocket) return expectation.connectTo;
 
       // The new behavior is to pass in a `MockWebSocketServer` for the
       // `connectTo` param. When this is done, we have to create a mock
       // `WebSocket` instance, return it, and notify the mock server that this
       // new client has connected.
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockWebSocketServer mockWebSocketServer = expectation.connectTo;
       mockWebSocketServer._connectClient(mockWebSocket, uri,
@@ -137,6 +139,7 @@ class MockWebSocketInternal {
       if (result is Future) {
         result = await result;
       }
+      // ignore: deprecated_member_use
       if (result is! WSocket && result is! MockWebSocketServer) {
         throw new ArgumentError('Mock WebSocket handlers must return an '
             'instance of MockWSocket or MockWebSocketServer.');
@@ -145,18 +148,22 @@ class MockWebSocketInternal {
       // For backwards compatibility, it is still allowed to return a `WSocket`
       // instance from the handler. If that happens, return it here and it
       // should function as expected.
+      // ignore: deprecated_member_use
       if (result is WSocket) return result;
 
       // The new behavior is to return a `MockWebSocketServer` from the handler.
       // When this is done, we have to create a mock `WebSocket` instance,
       // return it, and notify the mock server that this new client has
       // connected.
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockWebSocketServer mockWebSocketServer = result;
       mockWebSocketServer._connectClient(mockWebSocket, uri,
           headers: headers, protocols: protocols);
       return mockWebSocket;
     }
+
+    return null;
   }
 
   static bool hasHandlerForWebSocket(Uri uri) {
@@ -174,6 +181,7 @@ class MockWebSocketInternal {
       throw new ArgumentError('Either connectTo OR reject must be set.');
     }
     if (connectTo != null &&
+        // ignore: deprecated_member_use
         connectTo is! MockWSocket &&
         connectTo is! MockWebSocketServer) {
       throw new ArgumentError(

--- a/lib/src/mocks/mock_web_socket_server.dart
+++ b/lib/src/mocks/mock_web_socket_server.dart
@@ -5,6 +5,7 @@ class MockWebSocketConnection {
   final Iterable<String> protocols;
   final Uri uri;
 
+  // ignore: deprecated_member_use
   final MockWSocket _connectedClient;
 
   MockWebSocketConnection._(this._connectedClient, this.uri,
@@ -19,15 +20,18 @@ class MockWebSocketConnection {
   }
 
   void onData(callback(dynamic data)) {
+    // ignore: deprecated_member_use
     _connectedClient.onOutgoing(callback);
   }
 
   void send(Object data) {
+    // ignore: deprecated_member_use
     _connectedClient.addIncoming(data);
   }
 }
 
 class MockWebSocketServer {
+  // ignore: deprecated_member_use
   List<MockWSocket> _connectedClients = [];
 
   StreamController<MockWebSocketConnection> _onClientConnected =
@@ -41,6 +45,7 @@ class MockWebSocketServer {
     await Future.wait(futures);
   }
 
+  // ignore: deprecated_member_use
   void _connectClient(MockWSocket client, Uri uri,
       {Map<String, dynamic> headers, Iterable<String> protocols}) {
     _connectedClients.add(client);

--- a/lib/src/transport_platform.dart
+++ b/lib/src/transport_platform.dart
@@ -45,31 +45,41 @@ class MockAwareTransportPlatform {
   static HttpClient newHttpClient(TransportPlatform realTransportPlatform) =>
       new MockHttpClient(realTransportPlatform);
 
+  // ignore: deprecated_member_use
   /// Construct a new [MockFormRequest] instance that implements
   /// [FormRequest].
   static FormRequest newFormRequest(TransportPlatform realTransportPlatform) =>
+      // ignore: deprecated_member_use
       new MockFormRequest(realTransportPlatform);
 
+  // ignore: deprecated_member_use
   /// Construct a new [MockJsonRequest] instance that implements
   /// [JsonRequest].
   static JsonRequest newJsonRequest(TransportPlatform realTransportPlatform) =>
+      // ignore: deprecated_member_use
       new MockJsonRequest(realTransportPlatform);
 
+  // ignore: deprecated_member_use
   /// Construct a new [MockMultipartRequest] instance that implements
   /// [MultipartRequest].
   static MultipartRequest newMultipartRequest(
           TransportPlatform realTransportPlatform) =>
+      // ignore: deprecated_member_use
       new MockMultipartRequest(realTransportPlatform);
 
+  // ignore: deprecated_member_use
   /// Construct a new [MockPlainTextRequest] instance that implements
   /// [Request].
   static Request newRequest(TransportPlatform realTransportPlatform) =>
+      // ignore: deprecated_member_use
       new MockPlainTextRequest(realTransportPlatform);
 
+  // ignore: deprecated_member_use
   /// Construct a new [MockStreamedRequest] instance that implements
   /// [StreamedRequest].
   static StreamedRequest newStreamedRequest(
           TransportPlatform realTransportPlatform) =>
+      // ignore: deprecated_member_use
       new MockStreamedRequest(realTransportPlatform);
 
   /// Construct a new [MockWebSocket] instance that implements [WebSocket].
@@ -84,16 +94,22 @@ class MockAwareTransportPlatform {
       @Deprecated(v3Deprecation) bool useSockJS}) {
     if (MockTransportsInternal.isInstalled &&
         MockWebSocketInternal.hasHandlerForWebSocket(uri)) {
+      // ignore: deprecated_member_use
       return MockWSocket.connect(uri, headers: headers, protocols: protocols);
     } else if (MockTransportsInternal.fallThrough &&
         realTransportPlatform != null) {
       return realTransportPlatform.newWebSocket(uri,
           headers: headers,
           protocols: protocols,
+          // ignore: deprecated_member_use
           sockJSDebug: sockJSDebug,
+          // ignore: deprecated_member_use
           sockJSNoCredentials: sockJSNoCredentials,
+          // ignore: deprecated_member_use
           sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+          // ignore: deprecated_member_use
           sockJSTimeout: sockJSTimeout,
+          // ignore: deprecated_member_use
           useSockJS: useSockJS);
     } else {
       throw new TransportPlatformMissing.webSocketFailed(uri);

--- a/lib/src/web_socket/common/web_socket.dart
+++ b/lib/src/web_socket/common/web_socket.dart
@@ -152,6 +152,7 @@ abstract class CommonWebSocket extends Stream implements WebSocket {
   @override
   StreamSubscription listen(void onData(dynamic event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    // ignore: cancel_subscriptions
     final sub = _incoming.stream
         .listen(onData, onError: onError, cancelOnError: cancelOnError);
     _incomingSubscription = new WSocketSubscription(sub, onDone, onCancel: () {

--- a/lib/src/web_socket/mock/web_socket.dart
+++ b/lib/src/web_socket/mock/web_socket.dart
@@ -58,7 +58,11 @@ abstract class MockWebSocket implements WebSocket {
 }
 
 class _MockWebSocket extends CommonWebSocket
-    implements MockWebSocket, MockWSocket, WebSocket {
+    implements
+        MockWebSocket,
+        // ignore: deprecated_member_use
+        MockWSocket,
+        WebSocket {
   /// List of "onOutgoing" callbacks that have been registered. Any time a piece
   /// of data is added to the mock [WSocket], all callbacks in this list will be
   /// called with said data, allowing them to react and mock out the server.

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -34,7 +34,7 @@ import 'package:w_transport/src/web_socket/w_socket.dart';
 /// This class mirrors the native Dart WebSocket API from the dart:io library.
 /// The benefit is that it's platform agnostic and can be used on the server or
 /// in the browser - so you can write libraries or APIs that can run in either
-/// place just by building them on [WSocket].
+/// place just by building them on [WebSocket].
 ///
 /// To establish a connection, use the static [connect] method:
 ///
@@ -79,6 +79,7 @@ import 'package:w_transport/src/web_socket/w_socket.dart';
 ///     // registering an "onDone()" handler also works
 ///     webSocket.listen((_) {}, onDone: () { ... });
 ///
+// ignore: deprecated_member_use
 abstract class WebSocket extends WSocket implements Stream, StreamSink {
   /// Create a new WebSocket connection. The given [uri] must use the scheme
   /// `ws` or `wss`.
@@ -108,20 +109,30 @@ abstract class WebSocket extends WSocket implements Stream, StreamSink {
       return MockAwareTransportPlatform.newWebSocket(transportPlatform, uri,
           headers: headers,
           protocols: protocols,
+          // ignore: deprecated_member_use
           sockJSDebug: sockJSDebug,
+          // ignore: deprecated_member_use
           sockJSNoCredentials: sockJSNoCredentials,
+          // ignore: deprecated_member_use
           sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+          // ignore: deprecated_member_use
           sockJSTimeout: sockJSTimeout,
+          // ignore: deprecated_member_use
           useSockJS: useSockJS);
     } else if (transportPlatform != null) {
       // Otherwise, return a real instance using the given transport platform.
       return transportPlatform.newWebSocket(uri,
           headers: headers,
           protocols: protocols,
+          // ignore: deprecated_member_use
           sockJSDebug: sockJSDebug,
+          // ignore: deprecated_member_use
           sockJSNoCredentials: sockJSNoCredentials,
+          // ignore: deprecated_member_use
           sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
+          // ignore: deprecated_member_use
           sockJSTimeout: sockJSTimeout,
+          // ignore: deprecated_member_use
           useSockJS: useSockJS);
     } else {
       // If transports are not mocked and a transport platform is not available

--- a/lib/src/web_socket/web_socket_exception.dart
+++ b/lib/src/web_socket/web_socket_exception.dart
@@ -15,6 +15,7 @@
 import 'package:w_transport/src/web_socket/w_socket_exception.dart';
 
 /// Represents an exception in the connection process of a Web Socket.
+// ignore: deprecated_member_use
 class WebSocketException extends WSocketException {
   WebSocketException([String message]) : super(message);
   @override

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -99,7 +99,8 @@ export 'package:w_transport/src/transport_platform.dart'
 export 'package:w_transport/src/http/auto_retry.dart'
     show RetryBackOff, RetryBackOffMethod;
 export 'package:w_transport/src/http/base_request.dart' show BaseRequest;
-export 'package:w_transport/src/http/client.dart' show Client;
+export 'package:w_transport/src/http/client.dart'
+    show Client; // ignore: deprecated_member_use
 export 'package:w_transport/src/http/finalized_request.dart'
     show FinalizedRequest;
 export 'package:w_transport/src/http/http.dart' show Http;
@@ -121,11 +122,12 @@ export 'package:w_transport/src/http/response_format_exception.dart'
     show ResponseFormatException;
 
 // WebSocket
-export 'package:w_transport/src/web_socket/w_socket.dart' show WSocket;
+export 'package:w_transport/src/web_socket/w_socket.dart'
+    show WSocket; // ignore: deprecated_member_use
 export 'package:w_transport/src/web_socket/w_socket_close_event.dart'
-    show WSocketCloseEvent;
+    show WSocketCloseEvent; // ignore: deprecated_member_use
 export 'package:w_transport/src/web_socket/w_socket_exception.dart'
-    show WSocketException;
+    show WSocketException; // ignore: deprecated_member_use
 export 'package:w_transport/src/web_socket/web_socket_exception.dart'
     show WebSocketException;
 export 'package:w_transport/src/web_socket/web_socket.dart' show WebSocket;

--- a/test/integration/http/client/suite.dart
+++ b/test/integration/http/client/suite.dart
@@ -23,6 +23,7 @@ void runHttpTransportClientSuite(
     [transport.TransportPlatform transportPlatform]) {
   group('Client', () {
     _runHttpClientSuite(
+        // ignore: deprecated_member_use
         () => new transport.Client(transportPlatform: transportPlatform));
   });
 
@@ -32,7 +33,9 @@ void runHttpTransportClientSuite(
   });
 }
 
+// ignore: deprecated_member_use
 void _runHttpClientSuite(transport.Client getClient()) {
+  // ignore: deprecated_member_use
   transport.Client client;
 
   setUp(() {

--- a/test/integration/platforms/browser_transport_platform_test.dart
+++ b/test/integration/platforms/browser_transport_platform_test.dart
@@ -45,6 +45,7 @@ void main() {
       transport.globalTransportPlatform = browserTransportPlatform;
 
       // Properly constructs browser implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<BrowserHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<BrowserHttpClient>());
       expect(
@@ -63,6 +64,7 @@ void main() {
           await transport.WebSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<BrowserWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(wSocket, new isInstanceOf<BrowserWebSocket>());
       await wSocket.close();
@@ -85,6 +87,7 @@ void main() {
       final webSocket = await transport.WebSocket.connect(pingUri);
       expect(webSocket, new isInstanceOf<SockJSWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(pingUri);
       expect(wSocket, new isInstanceOf<SockJSWebSocket>());
       await wSocket.close();
@@ -113,6 +116,7 @@ void main() {
       final webSocket = await transport.WebSocket.connect(pingUri);
       expect(webSocket, new isInstanceOf<SockJSWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(pingUri);
       expect(wSocket, new isInstanceOf<SockJSWebSocket>());
       await wSocket.close();
@@ -125,10 +129,13 @@ void main() {
 
       // Properly constructs Browser implementation of WebSocket
       final webSocket = await transport.WebSocket
+          // ignore: deprecated_member_use
           .connect(IntegrationPaths.pingUri, useSockJS: false);
       expect(webSocket, new isInstanceOf<BrowserWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket
+          // ignore: deprecated_member_use
           .connect(IntegrationPaths.pingUri, useSockJS: false);
       expect(wSocket, new isInstanceOf<BrowserWebSocket>());
       await wSocket.close();
@@ -138,6 +145,7 @@ void main() {
       configureWTransportForBrowser();
 
       // Properly constructs browser implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<BrowserHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<BrowserHttpClient>());
       expect(
@@ -156,12 +164,14 @@ void main() {
           await transport.WebSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<BrowserWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(wSocket, new isInstanceOf<BrowserWebSocket>());
       await wSocket.close();
     });
 
     test('configureWTransportForBrowser(useSockJS: true) custom', () async {
+      // ignore: deprecated_member_use
       configureWTransportForBrowser(useSockJS: true);
 
       BrowserTransportPlatformWithSockJS btpwsj =
@@ -177,6 +187,7 @@ void main() {
       final webSocket = await transport.WebSocket.connect(pingUri);
       expect(webSocket, new isInstanceOf<SockJSWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(pingUri);
       expect(wSocket, new isInstanceOf<SockJSWebSocket>());
       await wSocket.close();
@@ -184,9 +195,13 @@ void main() {
 
     test('configureWTransportForBrowser(useSockJS: true) custom', () async {
       configureWTransportForBrowser(
+          // ignore: deprecated_member_use
           useSockJS: true,
+          // ignore: deprecated_member_use
           sockJSDebug: true,
+          // ignore: deprecated_member_use
           sockJSNoCredentials: true,
+          // ignore: deprecated_member_use
           sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
 
       BrowserTransportPlatformWithSockJS btpwsj =
@@ -203,6 +218,7 @@ void main() {
       final webSocket = await transport.WebSocket.connect(pingUri);
       expect(webSocket, new isInstanceOf<SockJSWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(pingUri);
       expect(wSocket, new isInstanceOf<SockJSWebSocket>());
       await wSocket.close();
@@ -709,7 +725,9 @@ void main() {
           // This verifies the ability to override the transport platform's
           // "useSockJS" value when constructing a single WebSocket instance.
           final singleSockJS = await transport.WebSocket.connect(pingUri,
-              transportPlatform: browserTransportPlatform, useSockJS: true);
+              transportPlatform: browserTransportPlatform,
+              // ignore: deprecated_member_use
+              useSockJS: true);
           expect(singleSockJS, new isInstanceOf<SockJSWebSocket>());
           await singleSockJS.close();
         });

--- a/test/integration/platforms/mock_aware_transport_platform.dart
+++ b/test/integration/platforms/mock_aware_transport_platform.dart
@@ -35,14 +35,22 @@ void main() {
       MockTransports.install();
 
       // Properly constructs mock-aware implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<MockHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<MockHttpClient>());
+      // ignore: deprecated_member_use
       expect(new transport.FormRequest(), new isInstanceOf<MockFormRequest>());
+      // ignore: deprecated_member_use
       expect(new transport.JsonRequest(), new isInstanceOf<MockJsonRequest>());
-      expect(new transport.MultipartRequest(),
+      expect(
+          new transport.MultipartRequest(),
+          // ignore: deprecated_member_use
           new isInstanceOf<MockMultipartRequest>());
+      // ignore: deprecated_member_use
       expect(new transport.Request(), new isInstanceOf<MockPlainTextRequest>());
-      expect(new transport.StreamedRequest(),
+      expect(
+          new transport.StreamedRequest(),
+          // ignore: deprecated_member_use
           new isInstanceOf<MockStreamedRequest>());
 
       // Properly constructs a mock-aware implementation of WebSocket
@@ -55,6 +63,7 @@ void main() {
       await webSocket.close();
       MockTransports.webSocket
           .expect(IntegrationPaths.pingUri, connectTo: mockWebSocketServer);
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<MockWebSocket>());
       await wSocket.close();
@@ -68,14 +77,22 @@ void main() {
       configureWTransportForTest();
 
       // Properly constructs mock-aware implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<MockHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<MockHttpClient>());
+      // ignore: deprecated_member_use
       expect(new transport.FormRequest(), new isInstanceOf<MockFormRequest>());
+      // ignore: deprecated_member_use
       expect(new transport.JsonRequest(), new isInstanceOf<MockJsonRequest>());
-      expect(new transport.MultipartRequest(),
+      expect(
+          new transport.MultipartRequest(),
+          // ignore: deprecated_member_use
           new isInstanceOf<MockMultipartRequest>());
+      // ignore: deprecated_member_use
       expect(new transport.Request(), new isInstanceOf<MockPlainTextRequest>());
-      expect(new transport.StreamedRequest(),
+      expect(
+          new transport.StreamedRequest(),
+          // ignore: deprecated_member_use
           new isInstanceOf<MockStreamedRequest>());
 
       // Properly constructs a mock-aware implementation of WebSocket
@@ -88,6 +105,7 @@ void main() {
       await webSocket.close();
       MockTransports.webSocket
           .expect(IntegrationPaths.pingUri, connectTo: mockWebSocketServer);
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<MockWebSocket>());
       await wSocket.close();

--- a/test/integration/platforms/vm_transport_platform_test.dart
+++ b/test/integration/platforms/vm_transport_platform_test.dart
@@ -42,6 +42,7 @@ void main() {
       transport.globalTransportPlatform = vmTransportPlatform;
 
       // Properly constructs VM implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<VMHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<VMHttpClient>());
       expect(new transport.FormRequest(), new isInstanceOf<VMFormRequest>());
@@ -57,6 +58,7 @@ void main() {
           await transport.WebSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<VMWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(wSocket, new isInstanceOf<VMWebSocket>());
       await wSocket.close();
@@ -66,6 +68,7 @@ void main() {
       configureWTransportForVM();
 
       // Properly constructs VM implementations of HTTP classes
+      // ignore: deprecated_member_use
       expect(new transport.Client(), new isInstanceOf<VMHttpClient>());
       expect(new transport.HttpClient(), new isInstanceOf<VMHttpClient>());
       expect(new transport.FormRequest(), new isInstanceOf<VMFormRequest>());
@@ -81,6 +84,7 @@ void main() {
           await transport.WebSocket.connect(IntegrationPaths.pingUri);
       expect(webSocket, new isInstanceOf<VMWebSocket>());
       await webSocket.close();
+      // ignore: deprecated_member_use
       final wSocket = await transport.WSocket.connect(IntegrationPaths.pingUri);
       expect(wSocket, new isInstanceOf<VMWebSocket>());
       await wSocket.close();

--- a/test/integration/ws/mock_test.dart
+++ b/test/integration/ws/mock_test.dart
@@ -113,8 +113,10 @@ void main() {
 
       MockTransports.webSocket.when(IntegrationPaths.closeUri,
           handler: (Uri uri, {protocols, headers}) async {
+        // ignore: deprecated_member_use
         final webSocket = new MockWSocket();
 
+        // ignore: deprecated_member_use
         webSocket.onOutgoing((data) {
           if (data.startsWith('close')) {
             final parts = data.split(':');
@@ -135,15 +137,19 @@ void main() {
 
       MockTransports.webSocket.when(IntegrationPaths.echoUri,
           handler: (Uri uri, {protocols, headers}) async {
+        // ignore: deprecated_member_use
         final webSocket = new MockWSocket();
+        // ignore: deprecated_member_use
         webSocket.onOutgoing(webSocket.addIncoming);
         return webSocket;
       });
 
       MockTransports.webSocket.when(IntegrationPaths.pingUri,
           handler: (Uri uri, {protocols, headers}) async {
+        // ignore: deprecated_member_use
         final webSocket = new MockWSocket();
 
+        // ignore: deprecated_member_use
         webSocket.onOutgoing((data) async {
           data = data.replaceAll('ping', '');
           int numPongs = 1;
@@ -152,6 +158,7 @@ void main() {
           } catch (_) {}
           for (int i = 0; i < numPongs; i++) {
             await new Future.delayed(new Duration(milliseconds: 5));
+            // ignore: deprecated_member_use
             webSocket.addIncoming('pong');
           }
         });

--- a/test/integration/ws/sockjs_test.dart
+++ b/test/integration/ws/sockjs_test.dart
@@ -50,16 +50,22 @@ void main() {
 
   group(wsDeprecatedNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
+        // ignore: deprecated_member_use
         useSockJS: true,
+        // ignore: deprecated_member_use
         sockJSNoCredentials: true,
+        // ignore: deprecated_member_use
         sockJSProtocolsWhitelist: ['websocket'],
         transportPlatform: browserTransportPlatform));
   });
 
   group(xhrDeprecatedNaming.toString(), () {
     sockJSSuite((Uri uri) => transport.WebSocket.connect(uri,
+        // ignore: deprecated_member_use
         useSockJS: true,
+        // ignore: deprecated_member_use
         sockJSNoCredentials: true,
+        // ignore: deprecated_member_use
         sockJSProtocolsWhitelist: ['xhr-streaming'],
         transportPlatform: browserTransportPlatform));
   });

--- a/test/unit/http/browser_utils_test.dart
+++ b/test/unit/http/browser_utils_test.dart
@@ -85,6 +85,7 @@ void main() {
         await eventController.close();
         await c.future;
         expect(eventCount, equals(4));
+        await subscription.cancel();
       });
     });
   });

--- a/test/unit/http/client_test.dart
+++ b/test/unit/http/client_test.dart
@@ -79,6 +79,7 @@ class AsyncInt extends transport.HttpInterceptor {
   }
 }
 
+// ignore: deprecated_member_use
 Iterable<transport.BaseRequest> createAllRequestTypes(transport.Client client) {
   return <transport.BaseRequest>[
     client.newFormRequest(),
@@ -105,6 +106,7 @@ void main() {
     });
 
     group('Client', () {
+      // ignore: deprecated_member_use
       _runHttpClientSuite(() => new transport.Client());
     });
 
@@ -114,7 +116,9 @@ void main() {
   });
 }
 
+// ignore: deprecated_member_use
 void _runHttpClientSuite(transport.Client getClient()) {
+  // ignore: deprecated_member_use
   transport.Client client;
 
   setUp(() {
@@ -315,6 +319,6 @@ void _runHttpClientSuite(transport.Client getClient()) {
   test('close()', () async {
     final future = client.newRequest().get(uri: Uri.parse('/test'));
     client.close();
-    expect(future, throws);
+    expect(future, throwsA(new isInstanceOf<transport.RequestException>()));
   });
 }

--- a/test/unit/http/form_request_test.dart
+++ b/test/unit/http/form_request_test.dart
@@ -78,7 +78,7 @@ void main() {
         final uri = Uri.parse('/test');
 
         final request = new transport.FormRequest();
-        expect(request.post(uri: uri, body: 'invalid'), throws);
+        expect(request.post(uri: uri, body: 'invalid'), throwsArgumentError);
       });
 
       test('body should be unmodifiable once sent', () async {

--- a/test/unit/http/json_request_test.dart
+++ b/test/unit/http/json_request_test.dart
@@ -57,7 +57,7 @@ void main() {
         final request = new transport.JsonRequest();
         expect(() {
           request.body = new Stream.fromIterable([]);
-        }, throws);
+        }, throwsA(new isInstanceOf<JsonUnsupportedObjectError>()));
       });
 
       test('setting fields incrementally', () {
@@ -107,7 +107,8 @@ void main() {
         final uri = Uri.parse('/test');
 
         final request = new transport.JsonRequest();
-        expect(request.post(uri: uri, body: UTF8), throws);
+        expect(request.post(uri: uri, body: UTF8),
+            throwsA(new isInstanceOf<JsonUnsupportedObjectError>()));
       });
 
       test('body should be unmodifiable once sent', () async {

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -109,15 +109,21 @@ void main() {
 
       final exponentialBackOff =
           new transport.RetryBackOff.exponential(interval);
+      // ignore: deprecated_member_use
       expect(exponentialBackOff.duration, equals(interval));
+      // ignore: deprecated_member_use
       expect(exponentialBackOff.duration, equals(exponentialBackOff.interval));
 
       final fixedBackOff = new transport.RetryBackOff.fixed(interval);
+      // ignore: deprecated_member_use
       expect(fixedBackOff.duration, equals(interval));
+      // ignore: deprecated_member_use
       expect(fixedBackOff.duration, equals(exponentialBackOff.interval));
 
       final noBackOff = new transport.RetryBackOff.none();
+      // ignore: deprecated_member_use
       expect(noBackOff.duration, isNull);
+      // ignore: deprecated_member_use
       expect(noBackOff.duration, equals(noBackOff.interval));
     });
   });
@@ -433,7 +439,7 @@ void _runCommonRequestSuiteFor(
           .expect('GET', requestUri, respondWith: new MockResponse.notFound());
       final request = requestFactory();
       final future = request.get(uri: requestUri);
-      expect(future, throws);
+      expect(future, throwsA(new isInstanceOf<transport.RequestException>()));
       await future.catchError((_) {});
       expect(request.isDone, isTrue);
     });
@@ -525,7 +531,8 @@ void _runCommonRequestSuiteFor(
         expect(exception, isNotNull);
         expect(exception.toString(), contains('mock failure'));
       };
-      expect(request.get(uri: requestUri), throws);
+      expect(request.get(uri: requestUri),
+          throwsA(new isInstanceOf<transport.RequestException>()));
     });
 
     test('responseInterceptor allows replacement of BaseResponse', () async {
@@ -583,6 +590,7 @@ void _runCommonRequestSuiteFor(
       final request = requestFactory();
       final future = request.get(uri: requestUri);
       await new Future.delayed(new Duration(milliseconds: 250));
+      // ignore: deprecated_member_use
       MockTransports.http.completeRequest(request);
       await future;
     });
@@ -593,6 +601,7 @@ void _runCommonRequestSuiteFor(
         ..timeoutThreshold = new Duration(milliseconds: 500);
       final future = request.get(uri: requestUri);
       await new Future.delayed(new Duration(milliseconds: 250));
+      // ignore: deprecated_member_use
       MockTransports.http.completeRequest(request);
       await future;
     });
@@ -782,7 +791,8 @@ void _runAutoRetryTestSuiteFor(
           ..enabled = true
           ..maxRetries = 2;
 
-        expect(request.get(uri: requestUri), throws);
+        expect(request.get(uri: requestUri),
+            throwsA(new isInstanceOf<transport.RequestException>()));
         await request.done;
         expect(request.autoRetry.numAttempts, equals(2));
         expect(request.autoRetry.failures.length, equals(2));
@@ -798,7 +808,8 @@ void _runAutoRetryTestSuiteFor(
           ..enabled = true
           ..maxRetries = 2;
 
-        expect(request.post(uri: requestUri), throws);
+        expect(request.post(uri: requestUri),
+            throwsA(new isInstanceOf<transport.RequestException>()));
         await request.done;
         expect(request.autoRetry.numAttempts, equals(1));
         expect(request.autoRetry.failures.length, equals(1));
@@ -815,7 +826,8 @@ void _runAutoRetryTestSuiteFor(
           ..enabled = true
           ..maxRetries = 2;
 
-        expect(request.get(uri: requestUri), throws);
+        expect(request.get(uri: requestUri),
+            throwsA(new isInstanceOf<transport.RequestException>()));
         await request.done;
         expect(request.autoRetry.numAttempts, equals(1));
         expect(request.autoRetry.failures.length, equals(1));
@@ -835,7 +847,8 @@ void _runAutoRetryTestSuiteFor(
               (request, transport.BaseResponse response, willRetry) async =>
                   response.headers['x-retry'] == 'yes';
 
-        expect(request.get(uri: requestUri), throws);
+        expect(request.get(uri: requestUri),
+            throwsA(new isInstanceOf<transport.RequestException>()));
         await request.done;
         expect(request.autoRetry.numAttempts, equals(1));
         expect(request.autoRetry.failures.length, equals(1));
@@ -852,7 +865,8 @@ void _runAutoRetryTestSuiteFor(
           if (shouldSucceed) {
             await request.get(uri: requestUri);
           } else {
-            expect(request.get(uri: requestUri), throws);
+            expect(request.get(uri: requestUri),
+                throwsA(new isInstanceOf<transport.RequestException>()));
           }
           await request.done;
           expect(request.autoRetry.numAttempts, equals(num + 1));
@@ -894,7 +908,8 @@ void _runAutoRetryTestSuiteFor(
           if (shouldSucceed) {
             await request.send(method, uri: requestUri);
           } else {
-            expect(request.send(method, uri: requestUri), throws);
+            expect(request.send(method, uri: requestUri),
+                throwsA(new isInstanceOf<transport.RequestException>()));
           }
 
           await request.done;

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -471,6 +471,7 @@ void main() {
         sub.pause();
         sub.resume();
         await done.future;
+        await sub.cancel();
       });
     });
   });

--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -42,6 +42,7 @@ void main() {
     });
 
     test('MockClient extends MockHttpClient', () {
+      // ignore: deprecated_member_use
       expect(new MockClient(null), new isInstanceOf<MockHttpClient>());
     });
 
@@ -49,13 +50,15 @@ void main() {
       test('causeFailureOnOpen() should cause request to throw', () async {
         final request = new transport.Request();
         MockTransports.http.causeFailureOnOpen(request);
-        expect(request.get(uri: requestUri), throws);
+        expect(request.get(uri: requestUri),
+            throwsA(new isInstanceOf<transport.RequestException>()));
       });
 
       test('verifies that requests are mock requests before controlling them',
           () {
         transport.BaseRequest request;
         expect(() {
+          // ignore: deprecated_member_use
           MockTransports.http.completeRequest(request);
         }, throwsArgumentError);
       });
@@ -63,6 +66,7 @@ void main() {
       group('completeRequest()', () {
         test('completes a request with 200 OK by default', () async {
           final request = new transport.Request();
+          // ignore: deprecated_member_use
           MockTransports.http.completeRequest(request);
           expect((await request.get(uri: requestUri)).status, equals(200));
         });
@@ -70,6 +74,7 @@ void main() {
         test('can complete a request with custom response', () async {
           final request = new transport.Request();
           final response = new MockResponse(202);
+          // ignore: deprecated_member_use
           MockTransports.http.completeRequest(request, response: response);
           expect((await request.get(uri: requestUri)).status, equals(202));
         });
@@ -178,13 +183,16 @@ void main() {
       group('failRequest()', () {
         test('causes request to throw', () async {
           final request = new transport.Request();
+          // ignore: deprecated_member_use
           MockTransports.http.failRequest(request);
-          expect(request.get(uri: requestUri), throws);
+          expect(request.get(uri: requestUri),
+              throwsA(new isInstanceOf<transport.RequestException>()));
         });
 
         test('can include a custom exception', () async {
           final request = new transport.Request();
           MockTransports.http
+              // ignore: deprecated_member_use
               .failRequest(request, error: new Exception('Custom exception'));
           expect(request.get(uri: requestUri), throwsA(predicate((error) {
             return error.toString().contains('Custom exception');
@@ -194,6 +202,7 @@ void main() {
         test('can include a custom response', () async {
           final request = new transport.Request();
           final response = new MockResponse.internalServerError();
+          // ignore: deprecated_member_use
           MockTransports.http.failRequest(request, response: response);
           expect(request.get(uri: requestUri), throwsA(predicate((error) {
             return error is transport.RequestException &&
@@ -214,6 +223,7 @@ void main() {
         final request = new transport.Request();
         // ignore: unawaited_futures
         request.get(uri: Uri.parse('/other'));
+        // ignore: deprecated_member_use
         MockPlainTextRequest mockRequest = request;
         await mockRequest.onSent;
         expect(MockTransports.http.numPendingRequests, equals(1));
@@ -225,6 +235,7 @@ void main() {
         final request2 = new transport.Request();
         // ignore: unawaited_futures
         request2.delete(uri: requestUri);
+        // ignore: deprecated_member_use
         MockPlainTextRequest mockRequest2 = request2;
         await mockRequest2.onSent;
 
@@ -232,6 +243,7 @@ void main() {
         final request3 = new transport.Request();
         // ignore: unawaited_futures
         request3.get(uri: Uri.parse('/expected'));
+        // ignore: deprecated_member_use
         MockPlainTextRequest mockRequest3 = request3;
         await mockRequest3.onSent;
 
@@ -250,6 +262,7 @@ void main() {
           final request = new transport.Request();
           // ignore: unawaited_futures
           request.get(uri: requestUri);
+          // ignore: deprecated_member_use
           MockPlainTextRequest mockRequest = request;
           await mockRequest.onSent;
           expect(() {
@@ -333,7 +346,8 @@ void main() {
             () async {
           MockTransports.http
               .when(requestUri, (_) async => throw new Exception());
-          expect(transport.Http.get(requestUri), throws);
+          expect(transport.Http.get(requestUri),
+              throwsA(new isInstanceOf<transport.RequestException>()));
         });
 
         test('registers a handler that can be canceled', () async {
@@ -429,7 +443,8 @@ void main() {
             () async {
           MockTransports.http.whenPattern(
               requestUri.toString(), (_a, _b) async => throw new Exception());
-          expect(transport.Http.get(requestUri), throws);
+          expect(transport.Http.get(requestUri),
+              throwsA(new isInstanceOf<transport.RequestException>()));
         });
 
         test(

--- a/test/unit/mocks/mock_web_socket_test.dart
+++ b/test/unit/mocks/mock_web_socket_test.dart
@@ -43,6 +43,7 @@ void main() {
     });
 
     test('MockWebSocket extends MockWSocket', () {
+      // ignore: deprecated_member_use
       expect(new MockWebSocket(), new isInstanceOf<MockWSocket>());
     });
 
@@ -50,14 +51,18 @@ void main() {
       group('expect()', () {
         test('expected web socket connection completes automatically',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           MockTransports.webSocket.expect(webSocketUri, connectTo: webSocket);
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
         });
 
         test('expected web socket connection rejected', () async {
           MockTransports.webSocket.expect(webSocketUri, reject: true);
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
@@ -65,6 +70,7 @@ void main() {
         });
 
         test('unexpected web socket connection throws', () async {
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(new isInstanceOf<transport.TransportPlatformMissing>()));
         });
@@ -72,7 +78,9 @@ void main() {
         test('supports connectTo OR reject, but not both', () {
           expect(() {
             MockTransports.webSocket.expect(webSocketUri,
-                connectTo: new MockWSocket(), reject: true);
+                // ignore: deprecated_member_use
+                connectTo: new MockWSocket(),
+                reject: true);
           }, throwsArgumentError);
         });
 
@@ -93,16 +101,20 @@ void main() {
       group('expectPattern()', () {
         test('expected web socket connection completes automatically',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           MockTransports.webSocket
               .expectPattern(webSocketUri.toString(), connectTo: webSocket);
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
         });
 
         test('expected web socket connection rejected', () async {
           MockTransports.webSocket
               .expectPattern(webSocketUri.toString(), reject: true);
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
@@ -112,7 +124,9 @@ void main() {
         test('supports connectTo OR reject, but not both', () {
           expect(() {
             MockTransports.webSocket.expectPattern(webSocketUri.toString(),
-                connectTo: new MockWSocket(), reject: true);
+                // ignore: deprecated_member_use
+                connectTo: new MockWSocket(),
+                reject: true);
           }, throwsArgumentError);
         });
 
@@ -132,25 +146,32 @@ void main() {
       });
 
       test('reset() should clear all expectations and handlers', () async {
+        // ignore: deprecated_member_use
         Future<transport.WSocket> handler(Uri uri,
                 {Map<String, dynamic> headers,
                 Iterable<String> protocols}) async =>
+            // ignore: deprecated_member_use
             new MockWSocket();
+        // ignore: deprecated_member_use
         Future<transport.WSocket> patternHandler(Uri uri,
                 {Map<String, dynamic> headers,
                 Match match,
                 Iterable<String> protocols}) async =>
+            // ignore: deprecated_member_use
             new MockWSocket();
         MockTransports.webSocket.when(webSocketUri, handler: handler);
         MockTransports.webSocket
             .whenPattern(webSocketUri.toString(), handler: patternHandler);
         MockTransports.webSocket
+            // ignore: deprecated_member_use
             .expect(webSocketUri, connectTo: new MockWSocket());
         MockTransports.webSocket.expectPattern(webSocketUri.toString(),
+            // ignore: deprecated_member_use
             connectTo: new MockWSocket());
 
         MockTransports.webSocket.reset();
 
+        // ignore: deprecated_member_use
         expect(transport.WSocket.connect(webSocketUri), throws);
       });
 
@@ -158,7 +179,9 @@ void main() {
         test(
             'registers a handler for all web socket connections with matching URI',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
+          // ignore: deprecated_member_use
           Future<transport.WSocket> handler(Uri uri,
                   {Map<String, dynamic> headers,
                   Iterable<String> protocols}) async =>
@@ -167,11 +190,16 @@ void main() {
 
           // Multiple matching connections succeed.
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
 
           // Non-matching connection fails.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(Uri.parse('/other')), throws);
         });
 
@@ -180,16 +208,19 @@ void main() {
           MockTransports.webSocket.when(webSocketUri, reject: true);
 
           // Multiple matching connections work as expected.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
           })));
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
           })));
 
           // Non-matching connection fails correctly.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(Uri.parse('/other')),
               throwsA(new isInstanceOf<transport.TransportPlatformMissing>()));
         });
@@ -197,6 +228,7 @@ void main() {
         test('supports handler OR reject, but not both', () {
           expect(() {
             MockTransports.webSocket.when(webSocketUri,
+                // ignore: deprecated_member_use
                 handler: (uri, {protocols, headers}) async => new MockWSocket(),
                 reject: true);
           }, throwsArgumentError);
@@ -216,22 +248,28 @@ void main() {
                       {Map<String, dynamic> headers,
                       Iterable<String> protocols}) async =>
                   'invalid');
+          // ignore: deprecated_member_use
           expect(MockWSocket.connect(webSocketUri), throwsArgumentError);
         });
 
         test('registers a handler that can be canceled', () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final handler = MockTransports.webSocket.when(webSocketUri,
               handler: (uri, {protocols, headers}) async => webSocket);
 
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
           handler.cancel();
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri), throwsStateError);
         });
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final oldHandler =
               MockTransports.webSocket.when(webSocketUri, reject: true);
@@ -242,10 +280,13 @@ void main() {
             oldHandler.cancel();
           }, returnsNormally);
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final oldHandler = MockTransports.webSocket.when(webSocketUri,
               handler: (uri, {protocols, headers}) async => webSocket);
@@ -255,6 +296,7 @@ void main() {
             oldHandler.cancel();
           }, returnsNormally);
 
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri), throwsStateError);
           await webSocket.close();
         });
@@ -264,7 +306,9 @@ void main() {
         test(
             'registers a handler for all web socket connections with matching URI',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
+          // ignore: deprecated_member_use
           Future<transport.WSocket> handler(Uri uri,
                   {Map<String, dynamic> headers,
                   Match match,
@@ -275,11 +319,16 @@ void main() {
 
           // Multiple matching connections succeed.
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
 
           // Non-matching connection fails.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(Uri.parse('/other')), throws);
         });
 
@@ -289,16 +338,19 @@ void main() {
               .whenPattern(webSocketUri.toString(), reject: true);
 
           // Multiple matching connections work as expected.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
           })));
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri),
               throwsA(predicate((error) {
             return error.toString().contains('rejected');
           })));
 
           // Non-matching connection fails correctly.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(Uri.parse('/other')),
               throwsA(new isInstanceOf<transport.TransportPlatformMissing>()));
         });
@@ -307,6 +359,7 @@ void main() {
           expect(() {
             MockTransports.webSocket.whenPattern(webSocketUri.toString(),
                 handler: (uri, {protocols, headers, match}) async =>
+                    // ignore: deprecated_member_use
                     new MockWSocket(),
                 reject: true);
           }, throwsArgumentError);
@@ -327,6 +380,7 @@ void main() {
                       Match match,
                       Iterable<String> protocols}) async =>
                   'invalid');
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri), throwsArgumentError);
         });
 
@@ -334,7 +388,9 @@ void main() {
             'registers a handler with a pattern that catches any connection with a matching URI',
             () async {
           final uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
+          // ignore: deprecated_member_use
           Future<transport.WSocket> handler(Uri uri,
                   {Map<String, dynamic> headers,
                   Match match,
@@ -344,14 +400,17 @@ void main() {
 
           // Multiple matching connections succeed.
           expect(
+              // ignore: deprecated_member_use
               await transport.WSocket.connect(Uri.parse('ws://google.com/ws')),
               equals(webSocket));
           expect(
+              // ignore: deprecated_member_use
               await transport.WSocket
                   .connect(Uri.parse('ws://github.com/ws/listen')),
               equals(webSocket));
 
           // Non-matching connection fails.
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(Uri.parse('/other')), throws);
         });
 
@@ -360,16 +419,19 @@ void main() {
             () async {
           final uriPattern = new RegExp('ws:\/\/(google|github)\.com\/ws.*');
           Match uriMatch;
+          // ignore: deprecated_member_use
           Future<transport.WSocket> handler(Uri uri,
               {Map<String, dynamic> headers,
               Match match,
               Iterable<String> protocols}) async {
             uriMatch = match;
+            // ignore: deprecated_member_use
             return new MockWSocket();
           }
 
           MockTransports.webSocket.whenPattern(uriPattern, handler: handler);
 
+          // ignore: deprecated_member_use
           await transport.WSocket
               .connect(Uri.parse('ws://github.com/ws/listen'));
           expect(uriMatch.group(0), equals('ws://github.com/ws/listen'));
@@ -377,19 +439,24 @@ void main() {
         });
 
         test('registers a handler that can be canceled', () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final handler = MockTransports.webSocket.whenPattern(
               webSocketUri.toString(),
               handler: (uri, {protocols, headers, match}) async => webSocket);
 
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
           handler.cancel();
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri), throwsStateError);
         });
 
         test('canceling a handler does nothing if handler no longer exists',
             () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final oldHandler = MockTransports.webSocket
               .whenPattern(webSocketUri.toString(), reject: true);
@@ -400,10 +467,13 @@ void main() {
             oldHandler.cancel();
           }, returnsNormally);
           expect(
-              await transport.WSocket.connect(webSocketUri), equals(webSocket));
+              // ignore: deprecated_member_use
+              await transport.WSocket.connect(webSocketUri),
+              equals(webSocket));
         });
 
         test('canceling a handler does nothing if handler was reset', () async {
+          // ignore: deprecated_member_use
           final webSocket = new MockWSocket();
           final oldHandler = MockTransports.webSocket.whenPattern(
               webSocketUri.toString(),
@@ -414,6 +484,7 @@ void main() {
             oldHandler.cancel();
           }, returnsNormally);
 
+          // ignore: deprecated_member_use
           expect(transport.WSocket.connect(webSocketUri), throwsStateError);
           await webSocket.close();
         });
@@ -455,6 +526,7 @@ void main() {
 
         MockTransports.webSocket
             .expect(webSocketUri, connectTo: mockWebSocketServer);
+        // ignore: deprecated_member_use
         final webSocket = await transport.WSocket.connect(webSocketUri);
         await webSocket.close();
         await c.future;

--- a/test/unit/ws/web_socket_exception_test.dart
+++ b/test/unit/ws/web_socket_exception_test.dart
@@ -27,6 +27,7 @@ void main() {
 
   group(naming.toString(), () {
     test('WSocketException should support toString()', () {
+      // ignore: deprecated_member_use
       expect(new WSocketException('test').toString(),
           contains('WSocketException:'));
     });
@@ -38,7 +39,9 @@ void main() {
 
     test('WebSocketException extends WSocketException', () {
       expect(
-          new WebSocketException('test'), new isInstanceOf<WSocketException>());
+          new WebSocketException('test'),
+          // ignore: deprecated_member_use
+          new isInstanceOf<WSocketException>());
     });
   });
 }

--- a/test/unit/ws/web_socket_test.dart
+++ b/test/unit/ws/web_socket_test.dart
@@ -29,7 +29,9 @@ void main() {
 
   group(naming.toString(), () {
     group('WSocket', () {
+      // ignore: deprecated_member_use
       _runWebSocketSuite((Uri uri) => transport.WSocket.connect(uri));
+      // ignore: deprecated_member_use
       _runLegacyWebSocketSuite((Uri uri) => transport.WSocket.connect(uri));
     });
 
@@ -40,6 +42,7 @@ void main() {
   });
 }
 
+// ignore: deprecated_member_use
 void _runWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
   MockWebSocketServer mockServer;
   final webSocketUri = Uri.parse('ws://mock.com/ws');
@@ -248,6 +251,7 @@ void _runWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
   });
 }
 
+// ignore: deprecated_member_use
 void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
   group('legacy', () {
     final webSocketUri = Uri.parse('ws://mock.com/ws');
@@ -259,11 +263,14 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
 
     test('message events should be discarded prior to a subscription',
         () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
 
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('1');
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('2');
       await nextTick();
 
@@ -272,10 +279,13 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
         messages.add(data);
       });
 
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('3');
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('4');
       await nextTick();
 
+      // ignore: deprecated_member_use
       mockWebSocket.triggerServerClose();
       await webSocket.done;
       expect(messages, orderedEquals(['3', '4']));
@@ -286,6 +296,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     test(
         'the first event should be received if a subscription is made immediately',
         () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
@@ -294,6 +305,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
       webSocket.listen((data) {
         c.complete(data);
       });
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('first');
 
       expect(await c.future, equals('first'));
@@ -303,12 +315,14 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
 
     test('all event streams should respect pause() and resume() signals',
         () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
       final messages = <String>[];
 
       // no subscription yet, messages should be discarded
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('1');
       await nextTick();
 
@@ -316,16 +330,19 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
       final sub = webSocket.listen((data) {
         messages.add(data);
       });
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('2');
       await nextTick();
 
       // pause the subscription, messages should be discarded
       sub.pause();
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('3');
       await nextTick();
 
       // resume the subscription, messages should be recorded again
       sub.resume();
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('4');
       await nextTick();
 
@@ -336,6 +353,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('onData() handler should be reassignable', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
@@ -347,6 +365,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
       final sub = webSocket.listen((data) {
         origHandlerMessages.add(data);
       });
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('orig');
       await nextTick();
 
@@ -354,6 +373,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
       sub.onData((data) {
         newHandlerMessages.add(data);
       });
+      // ignore: deprecated_member_use
       mockWebSocket.addIncoming('new');
       await nextTick();
 
@@ -365,6 +385,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('onDone() handler should be reassignable', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
@@ -376,6 +397,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
         c.complete();
       });
 
+      // ignore: deprecated_member_use
       mockWebSocket.triggerServerClose();
       await c.future;
       await sub.cancel();
@@ -384,11 +406,13 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('add() should send data to underlying web socket', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
 
       final c = new Completer<String>();
+      // ignore: deprecated_member_use
       mockWebSocket.onOutgoing(c.complete);
 
       webSocket.add('message');
@@ -399,11 +423,13 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('addStream() should send data to underlying web socket', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
 
       final controller = new StreamController<dynamic>();
+      // ignore: deprecated_member_use
       mockWebSocket.onOutgoing(controller.add);
 
       await webSocket.addStream(new Stream.fromIterable(['one', 'two']));
@@ -418,6 +444,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
 
     test('addStream() should cause the web socket to close when erorr is added',
         () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
@@ -438,6 +465,7 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('addError() should cause the web socket to close', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
@@ -451,10 +479,12 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
 
     // TODO: remove this test once triggerServerError has been removed
     test('DEPRECATED: error should close the socket', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
 
+      // ignore: deprecated_member_use
       mockWebSocket.triggerServerError(new Exception('Server Exception'));
       await webSocket.done;
 
@@ -463,9 +493,11 @@ void _runLegacyWebSocketSuite(Future<transport.WSocket> getWebSocket(Uri uri)) {
     });
 
     test('server closing the connection should close the socket', () async {
+      // ignore: deprecated_member_use
       final mockWebSocket = new MockWSocket();
       MockTransports.webSocket.expect(webSocketUri, connectTo: mockWebSocket);
       final webSocket = await getWebSocket(webSocketUri);
+      // ignore: deprecated_member_use
       mockWebSocket.triggerServerClose(1000, 'closed');
       await webSocket.done;
       expect(webSocket.closeCode, equals(1000));


### PR DESCRIPTION
## Issue

There were a bunch of hints from using deprecated members, but most of them are usages of our own deprecated members for the sake of backwards-compatibility.

## Solution

- Switch to non-deprecated alternatives for usages of deprecated members from other packages
- Ignore our own usages (we can address these in the next major)
- Fix a couple of lints that slipped through the cracks

## Testing
- [ ] CI passes

## Code Review
@Workiva/web-platform-pp 