### PR TITLE
WP-4685 Release w_transport 3.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.5
+version: 3.0.6
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4672 Dart dev compiler compatibility](https://github.com/Workiva/w_transport/pull/278)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.5...version-bump-w_transport-3-0-6
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.5...3.0.6