### PR TITLE
WP-4750 Add a global WebSocket monitor (3.x)

### DIFF
--- a/lib/src/browser_transport_platform.dart
+++ b/lib/src/browser_transport_platform.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;

--- a/lib/src/browser_transport_platform_with_sockjs.dart
+++ b/lib/src/browser_transport_platform_with_sockjs.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
 import 'package:w_transport/src/browser_transport_platform.dart';

--- a/lib/src/global_transport_platform.dart
+++ b/lib/src/global_transport_platform.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:w_transport/src/transport_platform.dart';
 
 /// The globally configured transport platform. Any transport class that is not

--- a/lib/src/mocks/mock_web_socket_server.dart
+++ b/lib/src/mocks/mock_web_socket_server.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 part of w_transport.src.mocks.mock_transports;
 
 class MockWebSocketConnection {

--- a/lib/src/transport_platform.dart
+++ b/lib/src/transport_platform.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;

--- a/lib/src/vm_transport_platform.dart
+++ b/lib/src/vm_transport_platform.dart
@@ -1,3 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;

--- a/lib/src/web_socket/browser/web_socket.dart
+++ b/lib/src/web_socket/browser/web_socket.dart
@@ -17,6 +17,7 @@ import 'dart:html' as html;
 import 'dart:typed_data';
 
 import 'package:w_transport/src/web_socket/common/web_socket.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 import 'package:w_transport/src/web_socket/web_socket.dart';
 import 'package:w_transport/src/web_socket/web_socket_exception.dart';
 
@@ -55,12 +56,18 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
     // an error if the socket moves straight to the closed state.
     final connected = new Completer<Null>();
     // ignore: unawaited_futures
-    webSocket.onOpen.first.then((_) => connected.complete());
+    webSocket.onOpen.first.then((_) {
+      connected.complete();
+      emitWebSocketConnectEvent(
+          newWebSocketConnectEvent(url: uri.toString(), wasSuccessful: true));
+    });
     // ignore: unawaited_futures
     closedFuture.then((_) {
       if (!connected.isCompleted) {
         connected
             .completeError(new WebSocketException('Could not connect to $uri'));
+        emitWebSocketConnectEvent(newWebSocketConnectEvent(
+            url: uri.toString(), wasSuccessful: false));
       }
     });
 

--- a/lib/src/web_socket/global_web_socket_monitor.dart
+++ b/lib/src/web_socket/global_web_socket_monitor.dart
@@ -1,0 +1,69 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart' show required;
+
+List<GlobalWebSocketMonitor> _monitors = [];
+
+void emitWebSocketConnectEvent(WebSocketConnectEvent connectEvent) {
+  for (final monitor in _monitors) {
+    monitor._didAttemptToConnect.add(connectEvent);
+  }
+}
+
+GlobalWebSocketMonitor newGlobalWebSocketMonitor() =>
+    new GlobalWebSocketMonitor._();
+
+WebSocketConnectEvent newWebSocketConnectEvent(
+        {@required String url,
+        @required bool wasSuccessful,
+        String sockJsSelectedProtocol,
+        List<String> sockJsProtocolsWhitelist}) =>
+    new WebSocketConnectEvent._(
+        url: url,
+        wasSuccessful: wasSuccessful,
+        sockJsProtocolsWhitelist: sockJsProtocolsWhitelist,
+        sockJsSelectedProtocol: sockJsSelectedProtocol);
+
+class GlobalWebSocketMonitor {
+  StreamController<WebSocketConnectEvent> _didAttemptToConnect =
+      new StreamController<WebSocketConnectEvent>.broadcast();
+
+  GlobalWebSocketMonitor._() {
+    _monitors.add(this);
+  }
+
+  Stream<WebSocketConnectEvent> get didAttemptToConnect =>
+      _didAttemptToConnect.stream;
+
+  Future<Null> close() async {
+    _monitors.remove(this);
+    await _didAttemptToConnect.close();
+  }
+}
+
+class WebSocketConnectEvent {
+  final List<String> sockJsProtocolsWhitelist;
+  final String sockJsSelectedProtocol;
+  final String url;
+  final bool wasSuccessful;
+
+  WebSocketConnectEvent._(
+      {@required this.url,
+      @required this.wasSuccessful,
+      this.sockJsProtocolsWhitelist,
+      this.sockJsSelectedProtocol});
+}

--- a/lib/src/web_socket/vm/web_socket.dart
+++ b/lib/src/web_socket/vm/web_socket.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:w_transport/src/web_socket/common/web_socket.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 import 'package:w_transport/src/web_socket/web_socket.dart';
 import 'package:w_transport/src/web_socket/web_socket_exception.dart';
 
@@ -38,11 +39,17 @@ class VMWebSocket extends CommonWebSocket implements WebSocket {
     // Note: closing this sink is handled by VMWSocket
     // ignore: close_sinks
     io.WebSocket webSocket;
+    bool wasSuccessful;
     try {
       webSocket = await io.WebSocket
           .connect(uri.toString(), headers: headers, protocols: protocols);
+      wasSuccessful = true;
     } on io.SocketException catch (e) {
+      wasSuccessful = false;
       throw new WebSocketException(e.toString());
+    } finally {
+      emitWebSocketConnectEvent(newWebSocketConnectEvent(
+          url: uri.toString(), wasSuccessful: wasSuccessful));
     }
 
     return new VMWebSocket._(webSocket);

--- a/lib/src/web_socket/w_socket.dart
+++ b/lib/src/web_socket/w_socket.dart
@@ -21,6 +21,7 @@
 import 'dart:async';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 import 'package:w_transport/src/web_socket/web_socket.dart';
 import 'package:w_transport/src/transport_platform.dart';
 
@@ -105,6 +106,13 @@ abstract class WSocket implements Stream, StreamSink {
           sockJSProtocolsWhitelist: sockJSProtocolsWhitelist,
           sockJSTimeout: sockJSTimeout,
           useSockJS: useSockJS);
+
+  /// Returns a monitor that provides streams of events for all WebSockets
+  /// constructed via w_transport.
+  ///
+  /// These streams may be useful for reporting analytics/metrics.
+  static GlobalWebSocketMonitor getGlobalEventMonitor() =>
+      newGlobalWebSocketMonitor();
 
   /// The close code set when the WebSocket connection is closed. If there is
   /// no close code available this property will be `null`.

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -25,6 +25,7 @@ import 'package:w_transport/src/global_transport_platform.dart';
 import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
+import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 import 'package:w_transport/src/web_socket/w_socket.dart';
 
 /// A two-way communication object for WebSocket clients. Establishes
@@ -141,6 +142,13 @@ abstract class WebSocket extends WSocket implements Stream, StreamSink {
       throw new TransportPlatformMissing.webSocketFailed(uri);
     }
   }
+
+  /// Returns a monitor that provides streams of events for all WebSockets
+  /// constructed via w_transport.
+  ///
+  /// These streams may be useful for reporting analytics/metrics.
+  static GlobalWebSocketMonitor getGlobalEventMonitor() =>
+      newGlobalWebSocketMonitor();
 
   /// The close code set when the WebSocket connection is closed. If there is
   /// no close code available this property will be `null`.

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -131,6 +131,8 @@ export 'package:w_transport/src/web_socket/w_socket_exception.dart'
 export 'package:w_transport/src/web_socket/web_socket_exception.dart'
     show WebSocketException;
 export 'package:w_transport/src/web_socket/web_socket.dart' show WebSocket;
+export 'package:w_transport/src/web_socket/global_web_socket_monitor.dart'
+    show GlobalWebSocketMonitor, WebSocketConnectEvent;
 
 // Third-party
 export 'package:http_parser/http_parser.dart' show MediaType;

--- a/test/integration/browser_integration_test.dart
+++ b/test/integration/browser_integration_test.dart
@@ -15,6 +15,11 @@
 @TestOn('browser')
 import 'package:test/test.dart';
 
+import 'global_web_socket_monitor/browser_test.dart'
+    as global_web_socket_monitor_browser;
+import 'global_web_socket_monitor/sockjs_test.dart'
+    as global_web_socket_monitor_sockjs;
+
 import 'http/client/browser_test.dart' as http_client_browser;
 import 'http/common_request/browser_test.dart' as http_common_request_browser;
 import 'http/form_request/browser_test.dart' as http_form_request_browser;
@@ -34,6 +39,9 @@ import 'ws/browser_test.dart' as ws_browser;
 import 'ws/sockjs_test.dart' as ws_sockjs;
 
 void main() {
+  global_web_socket_monitor_browser.main();
+  global_web_socket_monitor_sockjs.main();
+
   http_client_browser.main();
   http_common_request_browser.main();
   http_form_request_browser.main();

--- a/test/integration/global_web_socket_monitor/browser_test.dart
+++ b/test/integration/global_web_socket_monitor/browser_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/browser.dart';
+import 'package:w_transport/w_transport.dart' as transport;
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..platform = platformBrowser
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(naming.toString(), () {
+    // ignore: deprecated_member_use
+    Future<transport.WebSocket> connect(Uri uri) => transport.WebSocket
+        .connect(uri, transportPlatform: browserTransportPlatform);
+
+    runCommonGlobalWebSocketMonitorIntegrationTests(connect);
+
+    test('didAttemptToConnect events should not include sockJS info', () async {
+      var monitor = transport.WebSocket.getGlobalEventMonitor();
+      var events = <transport.WebSocketConnectEvent>[];
+      monitor.didAttemptToConnect.listen(events.add);
+
+      var webSocket = await connect(IntegrationPaths.echoUri);
+      await webSocket.close();
+
+      await connect(IntegrationPaths.fourOhFourUri).catchError((_) {});
+
+      await monitor.close();
+
+      expect(events.length, equals(2));
+
+      expect(events[0].url, equals(IntegrationPaths.echoUri.toString()));
+      expect(events[0].wasSuccessful, isTrue);
+      expect(events[0].sockJsProtocolsWhitelist, isNull);
+      expect(events[0].sockJsSelectedProtocol, isNull);
+
+      expect(events[1].url, equals(IntegrationPaths.fourOhFourUri.toString()));
+      expect(events[1].wasSuccessful, isFalse);
+      expect(events[1].sockJsProtocolsWhitelist, isNull);
+      expect(events[1].sockJsSelectedProtocol, isNull);
+    });
+  });
+}

--- a/test/integration/global_web_socket_monitor/common.dart
+++ b/test/integration/global_web_socket_monitor/common.dart
@@ -1,0 +1,78 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart' as transport;
+
+import '../integration_paths.dart';
+
+void runCommonGlobalWebSocketMonitorIntegrationTests(
+    Future<transport.WebSocket> connect(Uri uri),
+    {int port}) {
+  var closeUri = IntegrationPaths.closeUri;
+  var echoUri = IntegrationPaths.echoUri;
+  var fourOhFourUri = IntegrationPaths.fourOhFourUri;
+  var pingUri = IntegrationPaths.pingUri;
+  if (port != null) {
+    closeUri = closeUri.replace(port: port);
+    echoUri = echoUri.replace(port: port);
+    pingUri = pingUri.replace(port: port);
+  }
+
+  test('should support multiple monitors, each of which can be closed',
+      () async {
+    // First connection attempt - no monitors.
+    var webSocket1 = await connect(closeUri);
+    await webSocket1.close();
+
+    var monitor1 = transport.WebSocket.getGlobalEventMonitor();
+    var monitor1Events = <transport.WebSocketConnectEvent>[];
+    monitor1.didAttemptToConnect.listen(monitor1Events.add);
+
+    // Second connection attempt - monitor 1 should receive it.
+    var webSocket2 = await connect(echoUri);
+    await webSocket2.close();
+
+    var monitor2 = transport.WebSocket.getGlobalEventMonitor();
+    var monitor2Events = <transport.WebSocketConnectEvent>[];
+    monitor2.didAttemptToConnect.listen(monitor2Events.add);
+
+    // Third connection attempt - monitors 1 & 2 should both receive it.
+    var webSocket3 = await connect(pingUri);
+    await webSocket3.close();
+
+    await monitor2.close();
+
+    // Fourth connection attempt - only monitor 1 should receive it.
+    await connect(fourOhFourUri).catchError((_) {});
+
+    await monitor1.close();
+
+    expect(monitor1Events.length, equals(3));
+    expect(monitor2Events.length, equals(1));
+
+    expect(monitor1Events[0].url, equals(echoUri.toString()));
+    expect(monitor1Events[0].wasSuccessful, isTrue);
+
+    expect(monitor1Events[1].url, equals(pingUri.toString()));
+    expect(monitor1Events[1].wasSuccessful, isTrue);
+    expect(monitor2Events[0].url, equals(pingUri.toString()));
+    expect(monitor2Events[0].wasSuccessful, isTrue);
+
+    expect(monitor1Events[2].url, equals(fourOhFourUri.toString()));
+    expect(monitor1Events[2].wasSuccessful, isFalse);
+  });
+}

--- a/test/integration/global_web_socket_monitor/sockjs_test.dart
+++ b/test/integration/global_web_socket_monitor/sockjs_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/browser.dart';
+import 'package:w_transport/w_transport.dart' as transport;
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+const int sockjsPort = 8026;
+
+void main() {
+  final wsDeprecatedNaming = new Naming()
+    ..platform = platformBrowserSockjsWSDeprecated
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  final xhrDeprecatedNaming = new Naming()
+    ..platform = platformBrowserSockjsXhrDeprecated
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  final wsNaming = new Naming()
+    ..platform = platformBrowserSockjsWS
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  final xhrNaming = new Naming()
+    ..platform = platformBrowserSockjsXhr
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(wsDeprecatedNaming.toString(), () {
+    var protocolsWhitelist = ['websocket'];
+
+    sockJSSuite(
+        (Uri uri) => transport.WebSocket.connect(uri,
+            // ignore: deprecated_member_use
+            useSockJS: true,
+            // ignore: deprecated_member_use
+            sockJSNoCredentials: true,
+            // ignore: deprecated_member_use
+            sockJSProtocolsWhitelist: protocolsWhitelist,
+            transportPlatform: browserTransportPlatform),
+        protocolsWhitelist);
+  });
+
+  group(xhrDeprecatedNaming.toString(), () {
+    var protocolsWhitelist = ['xhr-streaming'];
+
+    sockJSSuite(
+        (Uri uri) => transport.WebSocket.connect(uri,
+            // ignore: deprecated_member_use
+            useSockJS: true,
+            // ignore: deprecated_member_use
+            sockJSNoCredentials: true,
+            // ignore: deprecated_member_use
+            sockJSProtocolsWhitelist: protocolsWhitelist,
+            transportPlatform: browserTransportPlatform),
+        protocolsWhitelist);
+  });
+
+  group(wsNaming.toString(), () {
+    var protocolsWhitelist = ['websocket'];
+
+    sockJSSuite(
+        (Uri uri) => transport.WebSocket.connect(uri,
+            transportPlatform: new BrowserTransportPlatformWithSockJS(
+                sockJSNoCredentials: true,
+                sockJSProtocolsWhitelist: protocolsWhitelist)),
+        protocolsWhitelist);
+  });
+
+  group(xhrNaming.toString(), () {
+    var protocolsWhitelist = ['xhr-streaming'];
+
+    sockJSSuite(
+        (Uri uri) => transport.WebSocket.connect(uri,
+            transportPlatform: new BrowserTransportPlatformWithSockJS(
+                sockJSNoCredentials: true,
+                sockJSProtocolsWhitelist: protocolsWhitelist)),
+        protocolsWhitelist);
+  });
+}
+
+void sockJSSuite(Future<transport.WebSocket> connect(Uri uri),
+    List<String> protocolsWhitelist) {
+  runCommonGlobalWebSocketMonitorIntegrationTests(connect, port: sockjsPort);
+
+  var echoUri = IntegrationPaths.echoUri.replace(port: sockjsPort);
+  var fourOhFourUri = IntegrationPaths.fourOhFourUri;
+
+  test('didAttemptToConnect events should include sockJS info', () async {
+    var monitor = transport.WebSocket.getGlobalEventMonitor();
+    var events = <transport.WebSocketConnectEvent>[];
+    monitor.didAttemptToConnect.listen(events.add);
+
+    var webSocket = await connect(echoUri);
+    await webSocket.close();
+
+    await connect(fourOhFourUri).catchError((_) {});
+
+    await monitor.close();
+
+    expect(events.length, equals(2));
+
+    expect(events[0].url, equals(echoUri.toString()));
+    expect(events[0].wasSuccessful, isTrue);
+    expect(events[0].sockJsProtocolsWhitelist, equals(protocolsWhitelist));
+    expect(events[0].sockJsSelectedProtocol, equals(protocolsWhitelist.last));
+
+    expect(events[1].url, equals(fourOhFourUri.toString()));
+    expect(events[1].wasSuccessful, isFalse);
+    expect(events[1].sockJsProtocolsWhitelist, equals(protocolsWhitelist));
+    expect(events[1].sockJsSelectedProtocol, isNull);
+  });
+}

--- a/test/integration/global_web_socket_monitor/vm_test.dart
+++ b/test/integration/global_web_socket_monitor/vm_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:w_transport/vm.dart';
+import 'package:w_transport/w_transport.dart' as transport;
+
+import '../../naming.dart';
+import '../integration_paths.dart';
+import 'common.dart';
+
+void main() {
+  Naming naming = new Naming()
+    ..platform = platformVM
+    ..testType = testTypeIntegration
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(naming.toString(), () {
+    // ignore: deprecated_member_use
+    Future<transport.WebSocket> connect(Uri uri) => transport.WebSocket
+        .connect(uri, transportPlatform: vmTransportPlatform);
+
+    runCommonGlobalWebSocketMonitorIntegrationTests(connect);
+
+    test('didAttemptToConnect events should not include sockJS info', () async {
+      var monitor = transport.WebSocket.getGlobalEventMonitor();
+      var events = <transport.WebSocketConnectEvent>[];
+      monitor.didAttemptToConnect.listen(events.add);
+
+      var webSocket = await connect(IntegrationPaths.echoUri);
+      await webSocket.close();
+
+      await connect(IntegrationPaths.fourOhFourUri).catchError((_) {});
+
+      await monitor.close();
+
+      expect(events.length, equals(2));
+
+      expect(events[0].url, equals(IntegrationPaths.echoUri.toString()));
+      expect(events[0].wasSuccessful, isTrue);
+      expect(events[0].sockJsProtocolsWhitelist, isNull);
+      expect(events[0].sockJsSelectedProtocol, isNull);
+
+      expect(events[1].url, equals(IntegrationPaths.fourOhFourUri.toString()));
+      expect(events[1].wasSuccessful, isFalse);
+      expect(events[1].sockJsProtocolsWhitelist, isNull);
+      expect(events[1].sockJsSelectedProtocol, isNull);
+    });
+  });
+}

--- a/test/integration/vm_integration_test.dart
+++ b/test/integration/vm_integration_test.dart
@@ -15,6 +15,8 @@
 @TestOn('vm')
 import 'package:test/test.dart';
 
+import 'global_web_socket_monitor/vm_test.dart' as global_web_socket_monitor_vm;
+
 import 'http/client/vm_test.dart' as http_client_vm;
 import 'http/common_request/vm_test.dart' as http_common_request_vm;
 import 'http/form_request/vm_test.dart' as http_form_request_vm;
@@ -30,6 +32,8 @@ import 'platforms/vm_transport_platform_test.dart'
 import 'ws/vm_test.dart' as ws_vm;
 
 void main() {
+  global_web_socket_monitor_vm.main();
+
   http_client_vm.main();
   http_common_request_vm.main();
   http_form_request_vm.main();

--- a/test/naming.dart
+++ b/test/naming.dart
@@ -33,6 +33,7 @@ const String topicHttp = 'HTTP';
 const String topicMocks = 'Mocks';
 const String topicTransportPlatform = 'Transport Platform';
 const String topicWebSocket = 'WS';
+const String topicGlobalWebSocketMonitor = 'GlobalWebSocketMonitor';
 
 class Naming {
   String platform;

--- a/test/unit/platform_independent_unit_test.dart
+++ b/test/unit/platform_independent_unit_test.dart
@@ -37,6 +37,8 @@ import 'mocks/mock_http_test.dart' as mock_http_test;
 import 'mocks/mock_response_test.dart' as mock_response_test;
 import 'mocks/mock_web_socket_test.dart' as mock_web_socket_test;
 
+import 'ws/global_web_socket_monitor_test.dart'
+    as ws_global_web_socket_monitor_test;
 import 'ws/web_socket_exception_test.dart' as ws_w_socket_exception_test;
 import 'ws/w_socket_subscription_test.dart' as ws_w_socket_subscription_test;
 import 'ws/web_socket_test.dart' as ws_web_socket_test;
@@ -63,6 +65,7 @@ void main() {
   mock_response_test.main();
   mock_web_socket_test.main();
 
+  ws_global_web_socket_monitor_test.main();
   ws_w_socket_exception_test.main();
   ws_w_socket_subscription_test.main();
   ws_web_socket_test.main();

--- a/test/unit/ws/global_web_socket_monitor_test.dart
+++ b/test/unit/ws/global_web_socket_monitor_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm || browser')
+import 'package:test/test.dart';
+import 'package:w_transport/w_transport.dart' as transport;
+
+import '../../naming.dart';
+
+void main() {
+  final naming = new Naming()
+    ..testType = testTypeUnit
+    ..topic = topicGlobalWebSocketMonitor;
+
+  group(naming.toString(), () {
+    test(
+        'getGlobalWebSocketMonitor() returns correctly from WSocket & WebSocket',
+        () async {
+      // ignore: deprecated_member_use
+      final wSocketMonitor = transport.WSocket.getGlobalEventMonitor();
+      final webSocketMonitor = transport.WebSocket.getGlobalEventMonitor();
+
+      expect(
+          wSocketMonitor, new isInstanceOf<transport.GlobalWebSocketMonitor>());
+      expect(webSocketMonitor,
+          new isInstanceOf<transport.GlobalWebSocketMonitor>());
+
+      await wSocketMonitor.close();
+      await webSocketMonitor.close();
+    });
+  });
+}


### PR DESCRIPTION
## Description

Same as https://github.com/Workiva/w_transport/pull/272, but for the master-line (3.x).

## Testing

- [ ] CI passes
- [ ] Additional testing instructions will be passed to @jayudey-wf 

## Code Review

@Workiva/web-platform-pp 