### PR TITLE
WP-4630 Release w_transport 2.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.9.9
+version: 2.10.0
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4632 Global WebSocket monitor](https://github.com/Workiva/w_transport/pull/272)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.9.9...version-bump-w_transport-2-10-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.9.9...2.10.0