### PR TITLE
WP-4686 Release w_transport 3.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.0.6
+version: 3.1.0
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4674 Address or ignore deprecated uses](https://github.com/Workiva/w_transport/pull/279)
* [WP-4750 Add a global WebSocket monitor (3.x)](https://github.com/Workiva/w_transport/pull/281)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.0.6...version-bump-w_transport-3-1-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.0.6...3.1.0