### PR TITLE
WP-4787 Add explicit dependency on meta (2.x)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ environment:
 dependencies:
   fluri: ^1.2.2
   http_parser: '>=1.0.0 <4.0.0'
+  meta: ^1.1.0
   mime: ^0.9.3
   sockjs_client:
     git:


### PR DESCRIPTION
## Issue

`pub publish --dry-run` shows this warning:

```
* line 3, column 1 of lib/src/web_socket/global_web_socket_monitor.dart: This package doesn't depend on meta.
  import 'package:meta/meta.dart' show required;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Solution

Add explicit dependency on the `meta` package.

## Testing

- [ ] CI passes
- [ ] `pub publish --dry-run` does not show the `meta` package warning

## Code Review

@Workiva/web-platform-pp 