### PR TITLE
WP-4788 WP-4788 Release w_transport 2.10.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 2.10.0
+version: 2.10.1
 description: >
   Platform-agnostic transport library for sending and receiving data over HTTP
   and WebSocket. HTTP support includes plain-text, JSON, form-data, and


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4787 Add explicit dependency on meta (2.x)](https://github.com/Workiva/w_transport/pull/286)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/2.10.0...version-bump-w_transport-2-10-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/2.10.0...2.10.1