### PR TITLE
WP-4757 Release w_transport 3.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.1.0
+version: 3.1.1
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4759 Add explicit dependency on meta](https://github.com/Workiva/w_transport/pull/284)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.1.0...version-bump-w_transport-3-1-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.1.0...3.1.1