### PR TITLE
WP-5202 Switch mock-aware requests to real requests before finalizing them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,35 @@
 language: dart
 dart:
   - 1.24.2
-with_content_shell: true
+addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
 before_install:
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - sleep 3
+  - sleep 3 # give xvfb some time to start
 script:
   - npm install
   - pub get --packages-dir

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -741,21 +741,21 @@ abstract class CommonRequest extends Object
       checkForTimeout();
     }
 
-    // No further changes should be made to the request at this point.
-    final finalizedRequest = await finalizeRequest(body);
-    checkForCancellation();
-    checkForTimeout();
-
     // If this is a mock-aware request without an expectation or handler setup
     // to process it, switch to a real request.
     if (isMockAware &&
         MockTransportsInternal.fallThrough &&
-        !MockHttpInternal.hasHandlerForRequest(finalizedRequest.method,
-            finalizedRequest.uri, finalizedRequest.headers)) {
+        !MockHttpInternal.hasHandlerForRequest(
+            this.method, this.uri, this.headers)) {
       return switchToRealRequest(streamResponse: streamResponse);
     }
 
     // Otherwise, carry on with the send logic and the mocks will do the rest.
+
+    // No further changes should be made to the request at this point.
+    final finalizedRequest = await finalizeRequest(body);
+    checkForCancellation();
+    checkForTimeout();
 
     BaseResponse response;
     bool responseInterceptorThrew = false;

--- a/test/integration/platforms/browser_transport_platform_test.dart
+++ b/test/integration/platforms/browser_transport_platform_test.dart
@@ -14,6 +14,7 @@
 
 @TestOn('browser')
 import 'dart:async';
+import 'dart:html' as html;
 
 import 'package:test/test.dart';
 import 'package:w_transport/browser.dart';
@@ -665,7 +666,8 @@ void main() {
 
           final multipartRequest = new transport.MultipartRequest(
               transportPlatform: browserTransportPlatform)
-            ..fields['foo'] = 'bar';
+            ..fields['foo'] = 'bar'
+            ..files['blob'] = new html.Blob([]);
           await multipartRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final request = new transport.Request(
@@ -691,7 +693,8 @@ void main() {
           await clientJsonRequest.get(uri: IntegrationPaths.pingEndpointUri);
 
           final clientMultipartRequest = httpClient.newMultipartRequest()
-            ..fields['foo'] = 'bar';
+            ..fields['foo'] = 'bar'
+            ..files['blob'] = new html.Blob([]);
           await clientMultipartRequest.get(
               uri: IntegrationPaths.pingEndpointUri);
 


### PR DESCRIPTION
## Problem

When MockTransports are installed with `fallThrough` enabled, we check to see if each request is mock-aware and if it would be handled by an expectation or a mock handler. If it wouldn't be, we switch it to a real request so that it doesn't get stuck (i.e. "fall-through").

Currently, we finalize the request prior to making this check. It turns out that this can have an adverse effect on `MultipartRequests` due to their divergent browser and mock implementations. In the browser, the `MultipartRequest` files map accepts `dart:html.File` and `dart:html.Blob` instances, but those types cannot be imported in any platform other than the browser. As a result, attempting to finalize the mock-aware `MultipartRequest` will fail if either a `File` or `Blob` instance is attached because it does not recognize them.

## Solution

The solution is to switch to a real request (if applicable) _prior_ to finalizing the request, which will avoid the issue altogether if the request isn't destined to be handled by a mock handler or expectation anyway.

## Testing

- [ ] CI passes (applicable test has been updated – you can verify by checking out 76e6488 and running the tests without the fix)

## Code Review

@Workiva/web-platform-pp 