### PR TITLE
WP-4790 Release w_transport 3.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.1.1
+version: 3.1.2
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-5202 Switch mock-aware requests to real requests before finalizing them](https://github.com/Workiva/w_transport/pull/290)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.1.1...Workiva:release_w_transport_3_1_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.1.1...3.1.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)