### PR TITLE
WP-5472 Add dependency_validator CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
   - pub get --packages-dir
   - pub run dart_dev format --check
   - pub run dart_dev analyze
+  - pub run dependency_validator -i browser,coverage,dart_style
   - pub run dart_dev test --integration
   - pub run dart_dev coverage --integration --no-html
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
   coverage: ^0.7.9
   dart_dev: ^1.7.7
   dart_style: ^1.0.6
+  dependency_validator: ^1.0.0
   http_server: ^0.9.6
   mockito: ^2.0.2
   react: ^0.6.1


### PR DESCRIPTION
## Changes

Adds `dependency_validator` as a dev dep and runs its check during CI.

## Testing

- [ ] CI passes

## Code Review

@Workiva/web-platform-pp @jacehensley-wf 