### PR TITLE
WP-5637 Add rule for `aviary.yaml` to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @Workiva/app-frameworks
+*               @Workiva/app-frameworks
+/aviary.yaml    @Workiva/app-frameworks @Workiva/it-security-pp


### PR DESCRIPTION
## Description

Adds a rule specifically for `aviary.yaml` so that the InfoSec team can make changes to that file on their own if need be.

## Testing

- [ ] CI passes

## Code Review

@Workiva/app-frameworks 