### PR TITLE
WP-5203 Release w_transport 3.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.1.2
+version: 3.2.0
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-5326 Remove unused dependencies.](https://github.com/Workiva/w_transport/pull/292)
* [WP-5472 Add dependency_validator CI check](https://github.com/Workiva/w_transport/pull/293)
* [WP-5627 Add CODEOWNERS file](https://github.com/Workiva/w_transport/pull/294)
* [WP-5637 Add rule for `aviary.yaml` to CODEOWNERS](https://github.com/Workiva/w_transport/pull/295)
* [WP-5258 Automatically use sockjs_client_wrapper if possible.](https://github.com/Workiva/w_transport/pull/296)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.1.2...Workiva:release_w_transport_3_2_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.1.2...3.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)