### PR TITLE
Require sockjs_client_wrapper ^1.0.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
     git:
       url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.2
-  sockjs_client_wrapper: ^1.0.1
+  sockjs_client_wrapper: ^1.0.3
 
 dev_dependencies:
   browser: ^0.10.0+2


### PR DESCRIPTION
## Description

Update pubspec to require `sockjs_client_wrapper ^1.0.3` because:
- 1.0.2 fixed overly verbose logging
- 1.0.3 introduced compatibility with DDC & Dart 2

This will ensure that consumers who require the latest w_transport will also get the these fixes without having to depend directly on `sockjs_client_wrapper`.

## Testing
- [ ] CI passes

## Code Review
@Workiva/app-frameworks 
