### PR TITLE
WP-5854 Release w_transport 3.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.1
+version: 3.2.2
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [WP-6212 Update HttpRequestTypes.md](https://github.com/Workiva/w_transport/pull/301)
* [Require sockjs_client_wrapper ^1.0.3](https://github.com/Workiva/w_transport/pull/304)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.1...Workiva:release_w_transport_3_2_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.1...3.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)