### PR TITLE
Release w_transport 3.2.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.2
+version: 3.2.3
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [BUILDTOOLS-2329: Update Dockerfile to mirror smithy.yaml](https://github.com/Workiva/w_transport/pull/303)
* [WP-6539 Dart 2 and Dart Dev Compiler compatibility](https://github.com/Workiva/w_transport/pull/306)
* [WP-6541 Changelog for 3.2.2 and 3.2.3](https://github.com/Workiva/w_transport/pull/307)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.2...Workiva:release_w_transport_3_2_3
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.2...3.2.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)