### PR TITLE
Release w_transport 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.2.4](https://github.com/Workiva/w_transport/compare/3.2.3...3.2.4)
+_May 16th, 2018_
+
+- **Bug Fix:** The browser implementation of `MultipartRequest` was previously
+  adding every field to the `FormData` twice - this has been fixed.
+
 ## [3.2.3](https://github.com/Workiva/w_transport/compare/3.2.2...3.2.3)
 _April 25th, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.3
+version: 3.2.4
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [AF-326 Bump outdated lower bounds](https://github.com/Workiva/w_transport/pull/309)
* [AF-157 don't add repeated data](https://github.com/Workiva/w_transport/pull/310)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.3...Workiva:release_w_transport_3_2_4
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.3...3.2.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)