### PR TITLE
AF-341 Scope over_react transformer to `examples/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [3.2.5](https://github.com/Workiva/w_transport/compare/3.2.4...3.2.5)
+_May 17th, 2018_
+
+- **Bug Fix:** The previous version introduced a new transformer for the
+  w_transport examples, but did not properly scope it to the `examples/`
+  directory. This led to the following error during a `pub get` for
+  some consumers:
+
+    ```
+    Precompiling dependencies...
+    Loading source assets...
+    Error on line 1, column 1 of https://pub.dartlang.org/api/packages/w_transport: Error loading transformer "over_react": package "over_react" is not a dependency.
+    ```
+
+    This has been fixed. If you're still seeing this error, run
+    `pub upgrade w_transport` to make sure you have the latest.
+
 ## [3.2.4](https://github.com/Workiva/w_transport/compare/3.2.3...3.2.4)
 _May 16th, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,8 @@ dev_dependencies:
   uuid: ^0.5.3
 
 transformers:
-- over_react
+- over_react:
+    $include: example/**.dart
 - test/pub_serve:
     $include: test/**_test.dart
 


### PR DESCRIPTION
## Problem

The previous release introduced a new transformer without properly scoping it to the `examples/` directory, resulting in this error for some consumers:

```
Precompiling dependencies...
Loading source assets...
Error on line 1, column 1 of https://pub.dartlang.org/api/packages/w_transport: Error loading transformer "over_react": package "over_react" is not a dependency.
```

## Solution

Scope the transformer to the `examples/` directory so that it is not also required for consumers of this package.

## Testing

- [ ] Verify that the above error is reproducible in a package that consumers `w_transport` and then verify that the error is fixed by overriding the `w_transport` dependency to this branch.

## Code Review

@Workiva/app-frameworks 