### PR TITLE
Release w_transport 3.2.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.4
+version: 3.2.5
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [AF-341 Scope over_react transformer to `examples/`](https://github.com/Workiva/w_transport/pull/312)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.4...Workiva:release_w_transport_3_2_5
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.4...3.2.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)