### PR TITLE
AF-1573 Raise `sockjs_client_wrapper` minimum to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.2.6](https://github.com/Workiva/w_transport/compare/3.2.5...3.2.6)
+_July 3rd, 2018_
+
+- **Dependency:** Upgraded minimum `sockjs_client_wrapper` version to 1.0.4 in
+  order to pull in SockJS v1.1.5.
+
 ## [3.2.5](https://github.com/Workiva/w_transport/compare/3.2.4...3.2.5)
 _May 17th, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
     git:
       url: git://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.3
-  sockjs_client_wrapper: ^1.0.3
+  sockjs_client_wrapper: ^1.0.4
 
 dev_dependencies:
   browser: ^0.10.0+2


### PR DESCRIPTION
## Description
`sockjs_client_wrapper` v1.0.4 includes an important bug fix, so the minimum is being raised here to ensure consumers get it.

## Testing 
- [ ] CI passes

## Code Review
@Workiva/app-frameworks 