### PR TITLE
AF-345 Release w_transport 3.2.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.5
+version: 3.2.6
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pulls Included in Release:
* [af_new_drydock_image](https://github.com/Workiva/w_transport/pull/314)
* [AF-1573 Raise `sockjs_client_wrapper` minimum to 1.0.4](https://github.com/Workiva/w_transport/pull/316)
* [AF-1690 Copy content-type/length on mock-aware fall-through](https://github.com/Workiva/w_transport/pull/317)


Requested by: @sebastianmalysa-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.5...Workiva:release_w_transport_3_2_6
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.5...3.2.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)