### PR TITLE
AF-1708 Release w_transport 3.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.2.7](https://github.com/Workiva/w_transport/compare/3.2.6...3.2.7)
+_October 10th, 2018_
+
+- **Improvement:** Dart 2 compatible!
+
 ## [3.2.6](https://github.com/Workiva/w_transport/compare/3.2.5...3.2.6)
 _July 19th, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.6
+version: 3.2.7
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.


### PR DESCRIPTION

Pull Requests included in release:
* [AF-1711 Update changelog for v3.2.6](https://github.com/Workiva/w_transport/pull/319)
* [update build](https://github.com/Workiva/w_transport/pull/321)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.2.6...Workiva:release_w_transport_3.2.7
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.2.6...3.2.7

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)