### PR TITLE
 AF-2812 Release w_transport 3.2.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.2.7
+version: 3.2.8
 
 description: >
   Transport library for sending HTTP requests and opening WebSockets.
@@ -36,7 +36,7 @@ dev_dependencies:
   build_test: ">=0.9.0 <1.0.0"
   build_web_compilers: ">=0.2.0 <1.0.0"
   coverage: ">=0.10.0 <0.13.0"
-  dart_dev: ^2.0.0-beta
+  dart_dev: ^2.0.0
   dart_style: ^1.0.8
   dependency_validator: ^1.2.1
   http_server: ^0.9.6


### PR DESCRIPTION
Consume the stable 2.0.0 release of dart_dev.

@Workiva/app-frameworks 