### PR TITLE
DO NOT MERGE: Upgrade to build_web_compilers 2.x and fix test setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 dart:
   - 1.24.3
   - stable
+  - dev
 
 before_script:
   - npm install
@@ -22,5 +23,5 @@ script:
 #  - cd example && pub get && dartanalyzer .; cd ..
   - pub run dart_dev dart2-only -- format --check
   - pub run dependency_validator -i build_runner,build_test,build_web_compilers,coverage,dart_style --exclude-dir=example
-  - pub run dart_dev dart1-only -- test -P integration -P travis
-  - pub run dart_dev dart2-only -- test -P integration -P travis -P dart2
+  - pub run dart_dev dart1-only -- test -P travis
+  - pub run dart_dev dart2-only -- test -P travis -P dart2

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,13 @@
+targets:
+  $default:
+    sources:
+      - "lib/**"
+      - "test/**"
+    builders:
+      build_web_compilers|entrypoint:
+        generate_for:
+          exclude:
+            - "test/integration/**/vm_test.dart*"
+          include:
+            - "test/integration/**.browser_test.dart"
+            - "test/unit/**.browser_test.dart"

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -24,25 +24,14 @@ platforms:
   - chrome
   - vm
 
-paths:
-  - test/unit/http
-  - test/unit/mocks
-  - test/unit/ws
+# The SockJS integration test server sometimes gets overloaded and rejects
+# connections. To mitigate this, retries are enabled and concurrency set to 1.
+retry: 3
+concurrency: 1
 
 presets:
   dart2:
     exclude_tags: "no-dart2"
 
-  integration:
-    concurrency: 1
-    paths:
-      - test/integration/global_web_socket_monitor
-      - test/integration/http
-      - test/integration/platforms
-      - test/integration/ws
-
   travis:
     reporter: expanded
-    # The SockJS integration test server sometimes gets overloaded and rejects
-    # connections. Retries are enabled during CI to mitigate these failures.
-    retry: 3

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,8 +3,11 @@ version: 0.0.0
 private: true
 
 dev_dependencies:
+  build_runner: '>=1.5.0 <2.0.0'
+  build_web_compilers: '>=1.2.0 <3.0.0'
   collection: ^1.14.6
-  over_react: ^1.30.2
+  dart_dev: ^2.0.0
+  over_react: '>=1.30.2 <3.0.0'
   w_transport:
     path: ../
 

--- a/example/web/common/global_example_menu_component.dart
+++ b/example/web/common/global_example_menu_component.dart
@@ -147,7 +147,7 @@ class GlobalExampleMenuComponent extends UiStatefulComponent<
 class GlobalExampleMenuProps extends _$GlobalExampleMenuProps
     with _$GlobalExampleMenuPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForGlobalExampleMenuProps;
+  static const PropsMeta meta = _$metaForGlobalExampleMenuProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
@@ -155,5 +155,5 @@ class GlobalExampleMenuProps extends _$GlobalExampleMenuProps
 class GlobalExampleMenuState extends _$GlobalExampleMenuState
     with _$GlobalExampleMenuStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForGlobalExampleMenuState;
+  static const StateMeta meta = _$metaForGlobalExampleMenuState;
 }

--- a/example/web/http/cross_origin_file_transfer/components/app_component.dart
+++ b/example/web/http/cross_origin_file_transfer/components/app_component.dart
@@ -115,12 +115,12 @@ enum AppPage {
 // ignore: mixin_of_non_class, undefined_class
 class AppProps extends _$AppProps with _$AppPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForAppProps;
+  static const PropsMeta meta = _$metaForAppProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
 // ignore: mixin_of_non_class, undefined_class
 class AppState extends _$AppState with _$AppStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForAppState;
+  static const StateMeta meta = _$metaForAppState;
 }

--- a/example/web/http/cross_origin_file_transfer/components/download_page.dart
+++ b/example/web/http/cross_origin_file_transfer/components/download_page.dart
@@ -230,7 +230,7 @@ class DownloadPageComponent
 class DownloadPageProps extends _$DownloadPageProps
     with _$DownloadPagePropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForDownloadPageProps;
+  static const PropsMeta meta = _$metaForDownloadPageProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
@@ -238,5 +238,5 @@ class DownloadPageProps extends _$DownloadPageProps
 class DownloadPageState extends _$DownloadPageState
     with _$DownloadPageStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForDownloadPageState;
+  static const StateMeta meta = _$metaForDownloadPageState;
 }

--- a/example/web/http/cross_origin_file_transfer/components/drop_zone_component.dart
+++ b/example/web/http/cross_origin_file_transfer/components/drop_zone_component.dart
@@ -201,12 +201,12 @@ class DropZoneComponent
 // ignore: mixin_of_non_class, undefined_class
 class DropZoneProps extends _$DropZoneProps with _$DropZonePropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForDropZoneProps;
+  static const PropsMeta meta = _$metaForDropZoneProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
 // ignore: mixin_of_non_class, undefined_class
 class DropZoneState extends _$DropZoneState with _$DropZoneStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForDropZoneState;
+  static const StateMeta meta = _$metaForDropZoneState;
 }

--- a/example/web/http/cross_origin_file_transfer/components/file_transfer_list_component.dart
+++ b/example/web/http/cross_origin_file_transfer/components/file_transfer_list_component.dart
@@ -77,5 +77,5 @@ class FileTransferListComponent extends UiComponent<FileTransferListProps> {
 class FileTransferListProps extends _$FileTransferListProps
     with _$FileTransferListPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForFileTransferListProps;
+  static const PropsMeta meta = _$metaForFileTransferListProps;
 }

--- a/example/web/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
+++ b/example/web/http/cross_origin_file_transfer/components/file_transfer_list_item_component.dart
@@ -170,7 +170,7 @@ enum FileTransferItemStatus {
 class FileTransferListItemProps extends _$FileTransferListItemProps
     with _$FileTransferListItemPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForFileTransferListItemProps;
+  static const PropsMeta meta = _$metaForFileTransferListItemProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
@@ -178,5 +178,5 @@ class FileTransferListItemProps extends _$FileTransferListItemProps
 class FileTransferListItemState extends _$FileTransferListItemState
     with _$FileTransferListItemStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForFileTransferListItemState;
+  static const StateMeta meta = _$metaForFileTransferListItemState;
 }

--- a/example/web/http/cross_origin_file_transfer/components/upload_page.dart
+++ b/example/web/http/cross_origin_file_transfer/components/upload_page.dart
@@ -107,7 +107,7 @@ class UploadPageComponent
 class UploadPageProps extends _$UploadPageProps
     with _$UploadPagePropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForUploadPageProps;
+  static const PropsMeta meta = _$metaForUploadPageProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
@@ -115,5 +115,5 @@ class UploadPageProps extends _$UploadPageProps
 class UploadPageState extends _$UploadPageState
     with _$UploadPageStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForUploadPageState;
+  static const StateMeta meta = _$metaForUploadPageState;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
 dev_dependencies:
   build_runner: ">=0.6.0 <2.0.0"
   build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.8

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -45,17 +45,6 @@ Future<Null> main(List<String> args) async {
   config.format.paths = directories;
 
   config.test
-    ..unitTests = [
-      'test/unit/http',
-      'test/unit/mocks',
-      'test/unit/ws',
-    ]
-    ..integrationTests = [
-      'test/integration/global_web_socket_monitor',
-      'test/integration/http',
-      'test/integration/platforms',
-      'test/integration/ws',
-    ]
     ..platforms = ['vm', 'chrome']
     ..pubServe = true
     ..before = [_streamServer, _streamSockJSServer]
@@ -75,14 +64,6 @@ List<String> _serverOutput;
 
 /// Output from the SockJS server.
 List<String> _sockJSServerOutput;
-
-Future<Null> _serveExamples() {
-  io.Process.runSync('pub', ['get'], workingDirectory: 'example');
-  io.Process.start('pub', ['serve', '--port=9000'],
-      workingDirectory: 'example');
-
-  return new Completer<Null>().future;
-}
 
 /// Start the server needed for integration tests and examples and stream the
 /// server output as it arrives. The output will be mixed in with output from


### PR DESCRIPTION
**Upgrading to build_web_compilers 2.x requires Dart 2.4 because it includes a js-interop fix. Do not merge until 2.4 has been released to stable.**

## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We want to upgrade to the latest build packages and make sure w_transport works with the kernel-based DDC. Additionally, it appears that during our dart2 update to this repo, we prevented a subset of test from running. 

## Changes
  <!-- What this PR changes to fix the problem. -->
- Upgrade to `build_web_compilers` 2.x
  - Added a `build.yaml` to properly limit the inputs to the `build_web_compilers|entrypoint` builder
- Simplify test config to ensure all tests run
- Update Travis CI config to also run against the dart2 dev channel

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
