### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
+++ b/tool/server/handlers/example/http/cross_origin_file_transfer_handlers.dart
@@ -125,8 +125,8 @@ class UploadHandler extends Handler {
     final contentType =
         ContentType.parse(request.headers.value('content-type'));
     final boundary = contentType.parameters['boundary'];
-    final stream = request
-        .transform(new MimeMultipartTransformer(boundary))
+    final stream = new MimeMultipartTransformer(boundary)
+        .bind(request)
         .map(HttpMultipartFormData.parse);
 
     await for (HttpMultipartFormData formData in stream) {

--- a/tool/server/handlers/test/http/upload.dart
+++ b/tool/server/handlers/test/http/upload.dart
@@ -31,8 +31,8 @@ class UploadHandler extends Handler {
     final contentType =
         ContentType.parse(request.headers.value('content-type'));
     final boundary = contentType.parameters['boundary'];
-    final stream = request
-        .transform(new MimeMultipartTransformer(boundary))
+    final stream = new MimeMultipartTransformer(boundary)
+        .bind(request)
         .map(HttpMultipartFormData.parse);
 
     await for (HttpMultipartFormData formData in stream) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900
