### PR TITLE
DART SDK UPGRADE: 2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.7.0
 WORKDIR /build/
 ADD pubspec.yaml /build/
 RUN pub get


### PR DESCRIPTION
This is one of many automated PRs with the goal of testing the upgrade to Dart SDK 2.7.0 across all Workiva packages.

The full list of PRs can be found here:
https://github.com/pulls?utf8=%E2%9C%93&q=%22DART+SDK+UPGRADE%3A+2.7.0%22+is%3Apr+is%3Aopen+user%3AWorkiva

**This PR does not need to be merged.** But, if any failures/issues are found as a result of this SDK upgrade, we may reach out to the maintainers of this repo in order to get them fixed.

If you have any questions, please reach out in [`#support-client-plat`](https://workiva.slack.com/archives/CEDM9RH1N).
