### PR TITLE
Preparations for React 17 compatibility, fix master build

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,3 +1,5 @@
+custom_html_template_path: test/html_test_template.html
+
 platforms:
   - chrome
   - vm

--- a/example/common/global_example_menu.dart
+++ b/example/common/global_example_menu.dart
@@ -1,6 +1,6 @@
-import 'package:over_react/over_react.dart';
 import 'dart:html';
 
+import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
 
 import './global_example_menu_component.dart';

--- a/example/http/cross_origin_credentials/client.dart
+++ b/example/http/cross_origin_credentials/client.dart
@@ -14,7 +14,6 @@
 
 import 'dart:async';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu.dart';
@@ -25,7 +24,6 @@ import './status.dart' as status;
 
 /// Setup the example application.
 Future<Null> main() async {
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(includeServerStatus: true);
   await dom.setupControlBindings();

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -14,7 +14,7 @@
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
+import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -24,7 +24,6 @@ import './components/app_component.dart';
 
 void main() {
   // Setup and bootstrap the react app
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(includeServerStatus: true);
   Element container = querySelector('#app');

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -15,7 +15,6 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -53,7 +52,6 @@ void showFileContents(String contents) {
 }
 
 void main() {
-  setClientConfiguration();
   configureWTransportForBrowser();
 
   renderGlobalExampleMenu();

--- a/example/index.dart
+++ b/example/index.dart
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import './common/global_example_menu.dart';
 import './common/loading_component.dart';
 
 void main() {
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(nav: false, includeServerStatus: true);
   removeLoadingOverlay();

--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -42,7 +41,6 @@ CheckboxInputElement _sockJSXhrPolling = querySelector('#sockjs-xhr-polling');
 CheckboxInputElement _useSockJS = querySelector('#sockjs');
 
 Future<Null> main() async {
-  setClientConfiguration();
   configureWTransportForBrowser();
 
   renderGlobalExampleMenu(includeServerStatus: true);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   dependency_validator: ^1.4.1
   http_server: ^0.9.8+3
   mockito: ^4.1.1
-  over_react: ^3.4.1
+  over_react: ">=3.12.0 <5.0.0"
   test: ^1.9.1
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^0.10.9
-  build_web_compilers: ^2.5.1
+  build_test: ^1.0.9
+  build_web_compilers: ^2.6.1
   collection: ^1.14.6
   dart_dev: ^3.3.1
   dart_style: ^1.3.1
@@ -28,6 +28,6 @@ dev_dependencies:
   http_server: ^0.9.8+3
   mockito: ^4.1.1
   over_react: ">=3.12.0 <5.0.0"
-  test: ^1.9.1
+  test: ^1.15.2
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2

--- a/test/html_test_template.html
+++ b/test/html_test_template.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{testName}} Test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
+
+    {{testScript}}
+    <script src="packages/test/dart.js"></script>
+  </head>
+  <body>
+    // ...
+  </body>
+</html>
+

--- a/test/html_test_template.html
+++ b/test/html_test_template.html
@@ -5,7 +5,6 @@
     <script>
         // Workaround to Chrome 86 DDC issues:
         // https://github.com/dart-lang/sdk/issues/43193
-
         if (typeof window.MemoryInfo == "undefined") {
           if (typeof window.performance.memory != "undefined") {
             window.MemoryInfo = function () {};
@@ -13,12 +12,9 @@
           }
         }
     </script>
-
     {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
-  <body>
-    // ...
-  </body>
+  <body></body>
 </html>
 

--- a/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
+++ b/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>global_web_socket_monitor sockjs_wrapper_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/integration/platforms/browser_transport_platform_test.html
+++ b/test/integration/platforms/browser_transport_platform_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>browser_transport_platform_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
     <link rel="x-dart-test"  href="browser_transport_platform_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/integration/ws/sockjs_wrapper_test.html
+++ b/test/integration/ws/sockjs_wrapper_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>websocket sockjs_wrapper_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -21,7 +21,6 @@ import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
-import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/w_transport.dart' as transport;
 
 import 'package:w_transport/src/http/utils.dart' as http_utils;


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review, merge and release.

## Motivation
React 17 was released at the end of October and came with some exciting benefits. For the full list, see the [ReactJS blog post](https://reactjs.org/blog/2020/10/20/react-v17.html).

For Workiva, upgrading so promptly is even more exciting because it:
1. supports our Material-UI (MUI) effort. [MUI will support React 17](https://github.com/mui-org/material-ui/blob/next/CHANGELOG.md#500-alpha15) in their next major release. This major is the one that Client Platform will use as the corner stone for the MUI effort. Therefore, to be compatible, Workiva should adopt React 17 as well.
1. helps with the [Microfrontends effort](https://wiki.atl.workiva.net/display/CP/Microfrontends). This is primarily because React 17 updated how event delegation works and made it safer to embed React trees within each other. These changes, along with others, provide more options when implementing a Microfrontends architecture by making React more compatible with the ShadowDOM.

Wdesk is currently using ReactJS `16.13.1`, and the Client Platform team has been working to upgrade our Dart wrappers to be compatible with the latest major version of ReactJS (`17.x`). Now that major releases of the `react` (`6.0.0`) and `over_react` (`4.0.0`) packages are ready to release, __its time to begin making the entire Workiva front-end ecosystem compatible!__

## Changes
This upgrade will be fundamentally simpler than the React 16 upgrade and will be much easier in comparison.

All changes/fixes will be handled by Client Platform before repo owners are requested for review(s).

1. Raise the upper bounds of the `react` / `over_react` dependencies to allow the new major release versions to be pulled in once all downstream dependencies are also compatible.
1. Fix any CI failures.
1. Find and address any other code affected by breaking changes or known edge cases, which may not have been caught by CI.
    - [x] [Event delegation changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation)
    - [x] [use(Layout)Effect cleanup timing changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing)
    - [x] [`onScroll` events no longer bubble](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#aligning-with-browsers)

# Additional changes
- Add Chrome 86 DDC workaround to fix master CI
- Update some dev deps
- Fix some deprecation warnings and misc hints

### Release Notes
Make this library compatible with ReactJS 17.

## QA Instructions
> [React 17 Testing PR](https://github.com/Workiva/w_transport/pull/342)

- [x] Verify all breaking changes to be addressed have been checked off in the Changes section
- [x] Using the React 17 testing PR also made into this repo:
    - [x] Verify CI passed
    - [ ] Manually test areas without functional test coverage.

## References
> [More information about React 17](https://reactjs.org/blog/2020/10/20/react-v17.html)
>
> [The 6.0.0 react-dart release](https://github.com/cleandart/react-dart/pull/285)
>
> [The 4.0.0 over_react release](https://github.com/Workiva/over_react/pull/647)


[_Created by Sourcegraph campaign `Workiva/react_17_rollout`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/react_17_rollout)