### PR TITLE
DO NOT MERGE React 17 Testing

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,3 +1,5 @@
+custom_html_template_path: test/html_test_template.html
+
 platforms:
   - chrome
   - vm

--- a/example/common/global_example_menu.dart
+++ b/example/common/global_example_menu.dart
@@ -1,6 +1,6 @@
-import 'package:over_react/over_react.dart';
 import 'dart:html';
 
+import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
 
 import './global_example_menu_component.dart';

--- a/example/http/cross_origin_credentials/client.dart
+++ b/example/http/cross_origin_credentials/client.dart
@@ -14,7 +14,6 @@
 
 import 'dart:async';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu.dart';
@@ -25,7 +24,6 @@ import './status.dart' as status;
 
 /// Setup the example application.
 Future<Null> main() async {
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(includeServerStatus: true);
   await dom.setupControlBindings();

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -14,7 +14,7 @@
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
+import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -24,7 +24,6 @@ import './components/app_component.dart';
 
 void main() {
   // Setup and bootstrap the react app
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(includeServerStatus: true);
   Element container = querySelector('#app');

--- a/example/http/simple_client/client.dart
+++ b/example/http/simple_client/client.dart
@@ -15,7 +15,6 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -53,7 +52,6 @@ void showFileContents(String contents) {
 }
 
 void main() {
-  setClientConfiguration();
   configureWTransportForBrowser();
 
   renderGlobalExampleMenu();

--- a/example/index.dart
+++ b/example/index.dart
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import './common/global_example_menu.dart';
 import './common/loading_component.dart';
 
 void main() {
-  setClientConfiguration();
   configureWTransportForBrowser();
   renderGlobalExampleMenu(nav: false, includeServerStatus: true);
   removeLoadingOverlay();

--- a/example/web_socket/echo/client.dart
+++ b/example/web_socket/echo/client.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
 import 'package:w_transport/w_transport.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
@@ -42,7 +41,6 @@ CheckboxInputElement _sockJSXhrPolling = querySelector('#sockjs-xhr-polling');
 CheckboxInputElement _useSockJS = querySelector('#sockjs');
 
 Future<Null> main() async {
-  setClientConfiguration();
   configureWTransportForBrowser();
 
   renderGlobalExampleMenu(includeServerStatus: true);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,3 +31,13 @@ dev_dependencies:
   test: ^1.9.1
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: 6.0.0-wip
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: release_over_react_4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,16 +19,16 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^0.10.9
-  build_web_compilers: ^2.5.1
+  build_test: ^1.0.9
+  build_web_compilers: ^2.6.1
   collection: ^1.14.6
   dart_dev: ^3.3.1
   dart_style: ^1.3.1
   dependency_validator: ^1.4.1
   http_server: ^0.9.8+3
   mockito: ^4.1.1
-  over_react: ^3.4.1
-  test: ^1.9.1
+  over_react: ">=3.12.0 <5.0.0"
+  test: ^1.15.2
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2
 

--- a/test/html_test_template.html
+++ b/test/html_test_template.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{testName}} Test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
+
+    {{testScript}}
+    <script src="packages/test/dart.js"></script>
+  </head>
+  <body>
+    // ...
+  </body>
+</html>
+

--- a/test/html_test_template.html
+++ b/test/html_test_template.html
@@ -5,7 +5,6 @@
     <script>
         // Workaround to Chrome 86 DDC issues:
         // https://github.com/dart-lang/sdk/issues/43193
-
         if (typeof window.MemoryInfo == "undefined") {
           if (typeof window.performance.memory != "undefined") {
             window.MemoryInfo = function () {};
@@ -13,12 +12,9 @@
           }
         }
     </script>
-
     {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
-  <body>
-    // ...
-  </body>
+  <body></body>
 </html>
 

--- a/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
+++ b/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>global_web_socket_monitor sockjs_wrapper_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/integration/platforms/browser_transport_platform_test.html
+++ b/test/integration/platforms/browser_transport_platform_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>browser_transport_platform_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
     <link rel="x-dart-test"  href="browser_transport_platform_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/integration/ws/sockjs_wrapper_test.html
+++ b/test/integration/ws/sockjs_wrapper_test.html
@@ -2,6 +2,16 @@
 <html>
   <head>
     <title>websocket sockjs_wrapper_test</title>
+    <script>
+        // Workaround to Chrome 86 DDC issues:
+        // https://github.com/dart-lang/sdk/issues/43193
+        if (typeof window.MemoryInfo == "undefined") {
+          if (typeof window.performance.memory != "undefined") {
+            window.MemoryInfo = function () {};
+            window.MemoryInfo.prototype = window.performance.memory.__proto__;
+          }
+        }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -21,7 +21,6 @@ import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_transport/mock.dart';
-import 'package:w_transport/src/http/auto_retry.dart';
 import 'package:w_transport/w_transport.dart' as transport;
 
 import 'package:w_transport/src/http/utils.dart' as http_utils;


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review and testing.

## Motivation
We need a branch that forces ReactJS 17 compatible versions of `react` and `over_react` so that CI checks and manual smoke testing can be performed with ReactJS 17 running "under the hood".

## Changes
_All of the changes from the analogous master PR that opened up the upper bounds of the `react` and `over_react` dependencies, plus adding necessary dependency overrides to ensure that ReactJS 17 compatible versions of `react` and `over_react` dependencies are being used.

## Review
Please review: @greglittlefield-wf @aaronlademann-wf @joebingham-wk @sydneyjodon-wk

### QA Checklist
- [ ] Passing CI
    - [ ] Verify that the `pubspec.lock` artifact(s) in the CI builds contain the following dependency override refs:
      - `react`: `6.0.0-wip`
      - `over_react`: `release_over_react_4.0.0`
      - `web_skin_dart`: check the pubspec override _(if applicable)_

> [More information about React 17](https://reactjs.org/blog/2020/10/20/react-v17.html)
> [The 6.0.0 react-dart release](https://github.com/cleandart/react-dart/pull/285)
> [The 4.0.0 over_react release](https://github.com/Workiva/over_react/pull/647)


[_Created by Sourcegraph campaign `Workiva/react_17_testing`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/react_17_testing)