### PR TITLE
Update OverReact syntax to support Dart 2.9+

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   dependency_validator: ^1.4.1
   http_server: ^0.9.8+3
   mockito: ^4.1.1
-  over_react: ">=3.12.0 <5.0.0"
+  over_react: ^4.1.0
   test: ^1.15.2
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2


### PR DESCRIPTION
## Motivation
In order to enable Workiva to transition to Dart >=2.9.0 with ease, a slight update to OverReact factory syntax
is required.

__Important:__
1. Remember to update your snippets in order to prevent accidental regressions in boilerplate. [Here](https://github.com/Workiva/over_react/blob/master/snippets/README.md)
is the reference for OverReact snippets.
1. To prevent incompatible boilerplate from being introduced, a react-boilerplate core-check has been activated. This
core check will fail if the incompatible mixin based boilerplate is introduced again to a project that has migrated already.

> For more information on why this migration is important, see [this wiki update](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=182026853).

__NOTE:__ Only the mixin based boilerplate factories will be migrated. In other words, if your factory is still
using the `@Factory` annotation, it will not be migrated to the Dart 2.9-compatible boilerplate and must first
be [migrated to the mixin based syntax](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md#upgrading-existing-code).
For additional reference, [here](https://github.com/Workiva/web_skin_dart/blob/master/doc/Component2-Migration-Guide.md)
are the instructions to migrate for projects depedent on Web Skin Dart.

## Changes
Below are two examples of the minor tweaks that will occur. For a reference of all the small changes that will occur
(including to the `connect` syntax), refer to option #2 [here](https://jsfiddle.net/greglittlefieldwf/onemhutb/show).
Note that `ignore` comments are not included in those examples.

1. Switch factory declarations to use the new syntax.
    ```diff
    UiFactory<FooProps> Foo = 
    -    _$Foo; // ignore: undefined_identifier, invalid_assignment
    +   castUiFactory(_$Foo); // ignore: undefined_identifier
    ```
1. For functional components, use the private config instead of the public one.
    ```diff
    UiFactory<FooProps> Foo = uiFunction(
      (props) {
        return 'Foo';
      },
    -  $FooConfig, // ignore: undefined_identifier
    +  _$FooConfig, // ignore: undefined_identifier
    );
    ```
1. Bump minimum over_react version to be compatible with the new syntax.

## Release Notes
Migrate mixin based factories to the Dart 2.9-compatible boilerplate.

## QA
These changes are not expected to require any special form of QA. As long as CI performs analysis on Dart code and runs a Dart build,
a passing CI is sufficient to merge these changes.

For more information or questions, reach out to us in the #support-ui-platform Slack channel.


[_Created by Sourcegraph campaign `Workiva/dart2_9_boilerplate_migration`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/dart2_9_boilerplate_migration)