### PR TITLE
Allow Flutter VM and Flutter Web from the same codebase

### DIFF
--- a/lib/src/flutter/flutter.dart
+++ b/lib/src/flutter/flutter.dart
@@ -1,0 +1,2 @@
+/// Stubbed to facilitate conditional platform-specific imports
+void configureWTransportForFlutter() {}

--- a/lib/src/flutter/flutter_browser.dart
+++ b/lib/src/flutter/flutter_browser.dart
@@ -1,0 +1,44 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Transport for the browser. Exposes a single configuration method that must
+/// be called before instantiating any of the transport classes.
+///
+///     import 'package:w_transport/browser.dart'
+///         show configureWTransportForBrowser;
+///
+///     void main() {
+///       configureWTransportForBrowser();
+///     }
+///
+/// If you'd like WebSocket to fall back to XHR-streaming if native WebSockets
+/// are not available, w_transport can be configured to use a SockJS client.
+///
+///     import 'package:w_transport/browser.dart'
+///         show configureWTransportForBrowser;
+///
+///     void main() {
+///       configureWTransportForBrowser(
+///           useSockJS: true,
+///           sockJSProtocolsWhitelist: ['websocket', 'xhr-streaming']);
+///     }
+library w_transport.flutter_browser;
+
+import 'package:w_transport/src/browser_transport_platform.dart';
+import 'package:w_transport/src/global_transport_platform.dart';
+
+/// Configures w_transport for use in the browser via dart:html.
+void configureWTransportForFlutter() {
+  globalTransportPlatform = browserTransportPlatform;
+}

--- a/lib/src/flutter/flutter_vm.dart
+++ b/lib/src/flutter/flutter_vm.dart
@@ -1,0 +1,32 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Transport for the server. This exposes a single configuration method that
+/// must be called before instantiating any of the transport classes.
+///
+///     import 'package:w_transport/vm.dart'
+///         show configureWTransportForVM;
+///
+///     void main() {
+///       configureWTransportForVM();
+///     }
+library w_transport.flutter_vm;
+
+import 'package:w_transport/src/global_transport_platform.dart';
+import 'package:w_transport/src/vm_transport_platform.dart';
+
+/// Configure w_transport for use on the server via dart:io.
+void configureWTransportForFlutter() {
+  globalTransportPlatform = vmTransportPlatform;
+}

--- a/lib/w_transport_flutter.dart
+++ b/lib/w_transport_flutter.dart
@@ -1,0 +1,19 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library w_transport.w_transport_flutter;
+
+export 'package:w_transport/src/flutter/flutter.dart'
+    if (dart.library.io) 'package:w_transport/src/flutter/flutter_vm.dart'
+    if (dart.library.js) 'package:w_transport/src/flutter/flutter_browser.dart';


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Importing w_transport for VM to use in Flutter is not sufficient to allow Flutter Mobile and Flutter Web at the same time.  Added conditional imports - see https://dart.dev/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files.

fyi @robbecker-wf @evanweible-wf - should we just make this the default style for importing w_transport instead of a flutter-specific entrypoint?

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
