### PR TITLE
Be robust to empty contentType header on response

### DIFF
--- a/lib/src/http/utils.dart
+++ b/lib/src/http/utils.dart
@@ -182,8 +182,9 @@ String mapToQuery(Map<String, Object> map, {Encoding encoding}) {
 MediaType parseContentTypeFromHeaders(Map<String, String> headers) {
   // Ensure the headers are case-insensitive.
   headers = CaseInsensitiveMap<String>.from(headers);
-  if (headers['content-type'] != null) {
-    return MediaType.parse(headers['content-type']);
+  var contentType = headers['content-type'];
+  if (contentType != null && contentType.trim().isNotEmpty) {
+    return MediaType.parse(contentType);
   }
   return MediaType('application', 'octet-stream');
 }

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -328,6 +328,16 @@ void main() {
         expect(ct.parameters, containsPair('charset', 'utf-8'));
       });
 
+      test(
+          'parseContentTypeFromHeaders() with whitespace falls back to default',
+          () {
+        final headers = <String, String>{'content-type': ' '};
+        final ct = http_utils.parseContentTypeFromHeaders(headers);
+        expect(ct.mimeType, equals('application/octet-stream'),
+            reason:
+                'application/octet-stream content-type should be assumed if header is missing.');
+      });
+
       test('parseEncodingFromContentType()', () {
         MediaType ct;
         ct = MediaType('text', 'plain', {'charset': utf8.name});

--- a/test/unit/http/utils_test.dart
+++ b/test/unit/http/utils_test.dart
@@ -335,7 +335,7 @@ void main() {
         final ct = http_utils.parseContentTypeFromHeaders(headers);
         expect(ct.mimeType, equals('application/octet-stream'),
             reason:
-                'application/octet-stream content-type should be assumed if header is missing.');
+                'application/octet-stream content-type should be assumed if header is empty.');
       });
 
       test('parseEncodingFromContentType()', () {


### PR DESCRIPTION
## Motivation
<a href="https://jira.atl.workiva.net/browse/SUPP-49667">[SUPP-49667] IDML not importing to Wdesk - Workiva JIRA</a> investigation was hampered by the fact that some logs were dropped (`Dropped batch that failed to report.` - https://github.com/Workiva/app_intelligence_dart/blob/6a4f67903a8e29daf63a43972fc52e046e9439cf/lib/src/common/reporters/collection_gateway/batched_processor.dart#L144). Those logs (e.g. `index=kinesis-harbour-prod source=app-int* level=warning message="Dropped batch that failed to report." exception.type=*logging*`) seem to be dropped because the response didn't have a proper contentType header (it seems to be just blank).

## Changes
If the contentType header on a response is empty or whitespace, fall back to the default (octet-stream).

#### Release Notes
If the contentType header on a response is empty or whitespace, fall back to the default (octet-stream).

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [x] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
