### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   fluri: ^1.2.6
   http_parser: ^3.1.3
-  meta: ^1.1.8
+  meta: ^1.2.2
   mime: ^0.9.6+3
   sockjs_client:
     git:
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^1.0.9
+  build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.6.1
   collection: ^1.14.6
   dart_dev: ^3.3.1
@@ -28,6 +28,6 @@ dev_dependencies:
   http_server: ^0.9.8+3
   mockito: ^4.1.1
   over_react: ">=3.12.0 <5.0.0"
-  test: ^1.15.2
+  test: ^1.15.7
   uuid: ^2.0.4
   workiva_analysis_options: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ">=0.10.9 <2.0.0"
+  build_test: ^1.0.9
   build_web_compilers: ^2.6.1
   collection: ^1.14.6
   dart_dev: ^3.3.1


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)