### PR TITLE
Material-UI Migration Preparations

### DIFF
--- a/example/common/global_example_menu.dart
+++ b/example/common/global_example_menu.dart
@@ -2,6 +2,7 @@ import 'dart:html';
 
 import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 
 import './global_example_menu_component.dart';
 
@@ -16,5 +17,6 @@ void renderGlobalExampleMenu(
   final menu = (GlobalExampleMenu()
     ..nav = nav
     ..includeServerStatus = includeServerStatus)();
-  react_dom.render(ErrorBoundary()(menu), container);
+  react_dom.render(
+      ErrorBoundary()((ThemeProvider()..theme = wkTheme)(menu)), container);
 }

--- a/example/http/cross_origin_credentials/index.html
+++ b/example/http/cross_origin_credentials/index.html
@@ -41,6 +41,7 @@ limitations under the License.
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/http/cross_origin_file_transfer/client.dart
+++ b/example/http/cross_origin_file_transfer/client.dart
@@ -16,6 +16,7 @@ import 'dart:html';
 
 import 'package:over_react/components.dart' show ErrorBoundary;
 import 'package:over_react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 import 'package:w_transport/browser.dart' show configureWTransportForBrowser;
 
 import '../../common/global_example_menu.dart';
@@ -27,6 +28,7 @@ void main() {
   configureWTransportForBrowser();
   renderGlobalExampleMenu(includeServerStatus: true);
   Element container = querySelector('#app');
-  react_dom.render(ErrorBoundary()(App()()), container);
+  react_dom.render(
+      ErrorBoundary()((ThemeProvider()..theme = wkTheme)(App()())), container);
   removeLoadingOverlay();
 }

--- a/example/http/cross_origin_file_transfer/index.html
+++ b/example/http/cross_origin_file_transfer/index.html
@@ -38,6 +38,7 @@ limitations under the License.
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/http/simple_client/index.html
+++ b/example/http/simple_client/index.html
@@ -48,6 +48,7 @@ limitations under the License.
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/index.html
+++ b/example/index.html
@@ -46,6 +46,7 @@ limitations under the License.
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="index.dart.js"></script>
     
 </body>

--- a/example/web_socket/echo/index.html
+++ b/example/web_socket/echo/index.html
@@ -78,6 +78,7 @@ limitations under the License.
 <!--<script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>-->
 <script src="packages/react/react.js"></script>
 <script src="packages/react/react_dom.js"></script>
+<script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 <script defer src="client.dart.js"></script>
 
 </body>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
   http_parser: ^3.1.3
   meta: ^1.2.2
   mime: ^0.9.6+3
+  react_material_ui:
+    hosted:
+      name: react_material_ui
+      url: https://pub.workiva.org
+    version: ^1.1.1
   sockjs_client:
     git:
       url: git://github.com/Workiva/sockjs-dart-client.git


### PR DESCRIPTION
## Motivation
[MUI component migrations](https://wiki.atl.workiva.net/display/CP/Material+Design) will begin soon, and there are a few housekeeping items that are necessary for a smooth rollout across the Workiva ecosystem.

A member of Client Platform will reach out when this PR is ready for team review.

If you have any questions about this PR, reach out to us in the [#support-mui-migration](https://workiva.slack.com/app_redirect?channel=support-mui-migration) Slack channel!

## Changes
This PR includes automated changes to ensure that the consumption of upstream dependencies that have migrated at least one Web Skin Dart component to MUI doesn't result in unexpected failures in this package or unexpected styling regressions in any of the standalone apps within this repo.

This is accomplished by:

1. Adding the JS MUI `<script>` tag to all HTML files used in this repo where React components are being rendered on the page
1. Adding `react_material_ui` as a dependency so that the `<script>` tags added do not cause 404 errors
1. Adding `react_material_ui` to the `dependency_validator` ignore list(s)
1. Wrapping top-level React trees (e.g. `react_dom.render` calls) in a `ThemeProvider` that sets the theme to our Workiva theme. This guards against components consumed from upstream dependencies being styled inconsistently.

The initial commit is automatically applied by a codemod and follow up commits may be made to:
- Fix tests

### Release Notes
Prepare for MUI component migrations

## QA Instructions
- [ ] CI Passes
- [ ] The app does not throw runtime exceptions when navigating to places where the top-level `react_dom.render` calls are relevant
  _(only necessary if functional tests run in CI does not navigate to all the views where the `react_dom.render` calls are used.)_

[_Created by Sourcegraph batch change `Workiva/mui_migration_rmui_prep2`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/mui_migration_rmui_prep2)