### PR TITLE
RM-109516 Release w_transport 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.2](https://github.com/Workiva/w_transport/compare/3.3.2...3.3.1)
+- Change sockjs-dart-client dependency to use HTTPS URL instead.
+
 ## [3.2.7](https://github.com/Workiva/w_transport/compare/3.2.6...3.2.7)
 _October 10th, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.3.1
+version: 3.3.2
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   mime: ^0.9.6+3
   sockjs_client:
     git:
-      url: git://github.com/Workiva/sockjs-dart-client.git
+      url: https://github.com/Workiva/sockjs-dart-client.git
       ref: 0.3.5
   sockjs_client_wrapper: ^1.0.14
 


### PR DESCRIPTION
## Motivation
GitHub is removing support for `git://` URLs and is currently testing blocking them in brownouts.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

We use this scheme for sockjs-dart-client, and need to switch it to move forward.

## Changes
Change sockjs-dart-client dependency to use HTTPS URL instead.

#### Release Notes

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
