### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   collection: ^1.14.6
   dart_dev: ^3.3.1
   dart_style: ^1.3.1
-  dependency_validator: ^1.4.1
+  dependency_validator: ^2.0.0
   http_server: ^0.9.8+3
   mockito: ^4.1.1
   over_react: ">=3.12.0 <5.0.0"


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)