### PR TITLE
RM-109516 Release w_transport 4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 3.3.1
+version: 4.0.0
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION

Pull Requests included in release:
* Major changes:
	* [V4: remove `sockjs_client` and some deprecated APIs](https://github.com/Workiva/w_transport/pull/339)
* Patch changes:
	* [DE-690: Delete docs.yml file created for Dev Portal.](https://github.com/Workiva/w_transport/pull/348)
	* [Widen Dependency Ranges Blocking Dart 2.13](https://github.com/Workiva/w_transport/pull/351)
	* [Raise the Dart SDK minimum to at least 2.11.0](https://github.com/Workiva/w_transport/pull/354)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/3.3.1...Workiva:release_w_transport_4.0.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/3.3.1...4.0.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5627043406413824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5627043406413824/?pull_number=359&repo_name=Workiva%2Fw_transport)