### PR TITLE
CPLAT-16481: Improve storage of pattern-matched mock HTTP request handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.0.0](https://github.com/Workiva/w_transport/compare/4.0.0...4.0.1)
+## [4.0.1](https://github.com/Workiva/w_transport/compare/4.0.0...4.0.1)
 
 - **Improvement:** Implement equality for `RegExp` to ensure 2 mock request
 handlers with the same pattern and regex settings are stored in a common map.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0](https://github.com/Workiva/w_transport/compare/4.0.0...4.0.1)
+
+- **Improvement:** Implement equality for `RegExp` to ensure 2 mock request
+handlers with the same pattern and regex settings are stored in a common map.
+
 ## [4.0.0](https://github.com/Workiva/w_transport/compare/3.2.8...4.0.0)
 
 This is a major release with breaking changes.

--- a/lib/src/mocks/mock_http.dart
+++ b/lib/src/mocks/mock_http.dart
@@ -301,6 +301,12 @@ class MockHttpInternal {
   }
 }
 
+/// An implementation of [Pattern] that ensures 2 [RegExp]s with the same pattern
+/// and settings are treated as equal.
+///
+/// This allows us to store [Pattern]s in the keys of a [Map] with [RegExp]s
+/// behaving as a developer might expect. That is, 2 equal [RegExp]s, though
+/// perhaps not identical instances, will be interchangeable when used as keys.
 class _Pattern implements Pattern {
   final Pattern _pattern;
 

--- a/lib/src/mocks/mock_http.dart
+++ b/lib/src/mocks/mock_http.dart
@@ -122,6 +122,9 @@ class MockHttp {
           handlers[methodKey] != null &&
           handlers[methodKey] == handler) {
         MockHttpInternal._patternRequestHandlers[uriPattern].remove(methodKey);
+        if (MockHttpInternal._patternRequestHandlers[uriPattern].isEmpty) {
+          MockHttpInternal._patternRequestHandlers.remove(uriPattern);
+        }
       }
     });
   }

--- a/lib/src/mocks/mock_transports.dart
+++ b/lib/src/mocks/mock_transports.dart
@@ -17,6 +17,7 @@ library w_transport.src.mocks.mock_transports;
 import 'dart:async';
 
 import 'package:http_parser/http_parser.dart' show CaseInsensitiveMap;
+import 'package:quiver/core.dart';
 
 import 'package:w_transport/src/constants.dart' show v3Deprecation;
 import 'package:w_transport/src/http/base_request.dart' show BaseRequest;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   http_parser: ^3.1.3
   meta: ^1.2.2
   mime: ^0.9.6+3
+  quiver: ^2.1.5
   sockjs_client_wrapper: ^1.0.14
 
 dev_dependencies:

--- a/test/unit/mocks/mock_http_test.dart
+++ b/test/unit/mocks/mock_http_test.dart
@@ -477,6 +477,32 @@ void main() {
           expect(matches[1].group(1), equals('github'));
         });
 
+        test('registering handlers with identical RegExp patterns should work',
+            () async {
+          final pattern = 'https:\/\/(google|github)\.com';
+
+          Match getMatch;
+          MockTransports.http.whenPattern(RegExp(pattern), (_, match) async {
+            getMatch = match;
+            return MockResponse.ok();
+          }, method: 'GET');
+
+          Match postMatch;
+          MockTransports.http.whenPattern(RegExp(pattern), (_, match) async {
+            postMatch = match;
+            return MockResponse.ok();
+          }, method: 'POST');
+
+          await transport.Http.get(Uri.parse('https://google.com'));
+          await transport.Http.post(Uri.parse('https://github.com'));
+
+          expect(getMatch.group(0), equals('https://google.com'));
+          expect(getMatch.group(1), equals('google'));
+
+          expect(postMatch.group(0), equals('https://github.com'));
+          expect(postMatch.group(1), equals('github'));
+        });
+
         test('registers a handler that can be canceled', () async {
           final ok = MockResponse.ok();
           final handler = MockTransports.http


### PR DESCRIPTION
## Motivation
We currently store pattern matching mock http request handlers in a `Map<Pattern, Map<String /* method */, PatternRequestHandler>>`. The key can be a RegExp. Two equivalent RegExp are not identical. Here's a quick example to demonstrate how this behaves:

```dart
void main() {
  final keyA = RegExp(r'https://fake.com/a/([bc]+)/d');
  final keyB = RegExp(r'https://fake.com/a/([bc]+)/d');
  final myMap = <Pattern, int>{};
  myMap[keyA] = 0;
  myMap[keyB] = 1;
  print(myMap.keys.length); // 2
  print(keyA == keyB); // false
}
```

This is usually OK. We run into an issue though if the consumer registers a pattern once, cancels it, and then registers it a second time with a newly constructed RegExp. In that case the previous pattern is still in the handler map, but it's value is an empty map of handlers. Here's a quick example:

```dart
final uriPattern = RegExp(r'https://fake.com/a/([bc]+)/d');
final mockHandler = MockTransports.http.whenPattern(uriPattern, _someHandler);

// The _patternRequestHandlers map will look something like this:
// {
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {
//.     '*': _someOtherHandler,
//.   }
// }

// later:
mockHandler.cancel();

// The _patternRequestHandlers map will look something like this:
// {
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {},
// }

// later yet:
final uriPattern = RegExp(r'https://fake.com/a/([bc]+)/d');
final mockHandler = MockTransports.http.whenPattern(uriPattern, _someOtherHandler);

// The _patternRequestHandlers map will look something like this:
// {
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {},
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {
//.     '*': _someOtherHandler,
//.   }
// }
```

Unfortunately, leaving the original RegExp key behind causes a problem in the _getMatchingHandler method. Specifically that method looks for the first key in the _patternRequestHandlers map that will match a URI. You can see in my example above that might be a key with a value that is an empty map. When this happens it fails to find an actual handler for the request and the request is left in a pending state.

Another situation in which this falls down is when registering handlers for multiple methods using the same regex pattern but not the same RegExp instances. Here's an example:


```dart
final uriPattern = RegExp( r'https://fake.com/a/([bc]+)/d');
final mockHandler = MockTransports.http.whenPattern(uriPattern, _getHandler, method: 'GET');

// The _patternRequestHandlers map will look something like this:
// {
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {
//.     'GET': _getHandler,
//.   }
// }

// later:
final uriPattern = RegExp( r'https://fake.com/a/([bc]+)/d');
final mockHandler = MockTransports.http.whenPattern(uriPattern, _postHandler, method: 'POST');

// The _patternRequestHandlers map will look something like this:
// {
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {
//.     'GET': _getHandler,
//.   },
//.   RegExp(r'https://fake.com/a/([bc]+)/d'): {
//.     'POST': _postHandler,
//.   }
// }
```

Unfortunately, because the same regex pattern appears in 2 keys in the map, when we look for the first pattern that matches a request it will maybe be the one with the GET handler but if the request is a POST we won't recognize there is a handler registered for it.

## Changes
- I've updated the cancel method on the MockHttpHandler that is returned to remove the key if the associated handler map is empty.
- I've introduced a `_Pattern` class that implements equality for 2 RegExp objects so they will be treated as the same key in our map of mock HTTP request handlers.

#### Release Notes
Remove URI pattern from mock http handlers map when the last handler is canceled.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
