### PR TITLE
Utilize the SockJS timeout option to configure the InfoReceiver.

### DIFF
--- a/lib/src/web_socket/browser/sockjs_wrapper.dart
+++ b/lib/src/web_socket/browser/sockjs_wrapper.dart
@@ -66,7 +66,7 @@ class SockJSWrapperWebSocket extends CommonWebSocket implements WebSocket {
 
     // TODO: pass `debug`, `noCredentials`, and `timeout` through when possible.
     final client = SockJSClient(sockjsUri,
-        options: SockJSOptions(transports: protocolsWhitelist));
+        options: SockJSOptions(transports: protocolsWhitelist, timeout: timeout.inMilliseconds));
 
     // Listen for and store the close event. This will determine whether or
     // not the socket connected successfully, and will also be used later


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

I hope to update SockJS to allow the handshake to take longer than 8s by a configuration option. https://github.com/Workiva/sockjs_client_wrapper/pull/45 https://github.com/sockjs/sockjs-client/pull/594

## Changes
  <!-- What this PR changes to fix the problem. -->

Call SockJS with the connect timeout. 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
