### PR TITLE
Fix JSON decoding when charset isn't specified on VM to use UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.1.1] (https://github.com/Workiva/w_transport/compare/4.1.0...4.1.1)
+## [4.1.3] (https://github.com/Workiva/w_transport/compare/4.1.2...4.1.3)
 
 - **Improvement** JSON content will always decode as utf-8. Previously it would
 fall back to the encoding specified for the body, or to ISO-8859-1, which was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.1.1] (https://github.com/Workiva/w_transport/compare/4.1.0...4.1.1)
+
+- **Improvement** JSON content will always decode as utf-8. Previously it would
+fall back to the encoding specified for the body, or to ISO-8859-1, which was
+the old fallback value. There is no longer any fallback value, per rfc7231, but 
+it uses the media type value, which for JSON is by default UTF-8.
+
 ## [4.1.0](https://github.com/Workiva/w_transport/compare/4.0.8...4.1.0)
 
 - **Improvement:** `AutoRetryConfig` gained the `increaseTimeoutOnRetry` flag.

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -118,7 +118,6 @@ class HttpBody extends BaseHttpBody {
   }
 
   /// Returns this request/response body as a String.
-  ///
   String asString() => _asString(encoding);
 
   String _asString(Encoding charset) {

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -118,12 +118,15 @@ class HttpBody extends BaseHttpBody {
   }
 
   /// Returns this request/response body as a String.
-  String asString() {
+  ///
+  String asString() => _asString(encoding);
+
+  String _asString(Encoding charset) {
     if (_body == null) {
       try {
-        _body = encoding.decode(_bytes);
+        _body = charset.decode(_bytes);
       } on FormatException {
-        throw ResponseFormatException(contentType, encoding, bytes: _bytes);
+        throw ResponseFormatException(contentType, charset, bytes: _bytes);
       }
     }
     return _body;
@@ -137,7 +140,7 @@ class HttpBody extends BaseHttpBody {
   /// than the generic fallback from the response. Throws a [FormatException] if this
   /// request/response body cannot be decoded to text or if the text is not
   /// valid JSON.
-  dynamic asJson() => json.decode((_encoding ?? utf8).decode(asBytes()));
+  dynamic asJson() => json.decode(_asString(_encoding ?? utf8));
 }
 
 /// Representation of an HTTP request body or an HTTP response body where the

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -17,7 +17,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart' show MediaType;
-
 import 'package:w_transport/src/http/response_format_exception.dart';
 import 'package:w_transport/src/http/utils.dart' as http_utils;
 
@@ -132,10 +131,11 @@ class HttpBody extends BaseHttpBody {
   /// Returns this request/response body as a JSON object - either a `Map` or a
   /// `List`.
   ///
-  /// This attempts to read this request/response body as a `String` and decode
-  /// it to a JSON object. Throws a [FormatException] if this request/response
-  /// body cannot be decoded to text or if the text is not valid JSON.
-  dynamic asJson() => json.decode(asString());
+  /// This attempts to read this request/response body as a UTF-8 String and
+  /// decode it to a JSON object. Throws a [FormatException] if this
+  /// request/response body cannot be decoded to text or if the text is not
+  /// valid JSON.
+  dynamic asJson() => json.decode(utf8.decode(asBytes()));
 }
 
 /// Representation of an HTTP request body or an HTTP response body where the

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -132,8 +132,9 @@ class HttpBody extends BaseHttpBody {
   /// Returns this request/response body as a JSON object - either a `Map` or a
   /// `List`.
   ///
-  /// This attempts to read this request/response body as a UTF-8 String and
-  /// decode it to a JSON object. Throws a [FormatException] if this
+  /// This attempts to read this request/response body as a String and decode it
+  /// to a JSON object. If no encoding is specified, it will use UTF-8, rather
+  /// than the generic fallback from the response. Throws a [FormatException] if this
   /// request/response body cannot be decoded to text or if the text is not
   /// valid JSON.
   dynamic asJson() => json.decode((_encoding ?? utf8).decode(asBytes()));

--- a/lib/src/http/http_body.dart
+++ b/lib/src/http/http_body.dart
@@ -69,7 +69,7 @@ class HttpBody extends BaseHttpBody {
       {Encoding encoding, Encoding fallbackEncoding}) {
     _encoding =
         encoding ?? http_utils.parseEncodingFromContentType(contentType);
-    _fallbackEncoding = fallbackEncoding;
+    _fallbackEncoding = fallbackEncoding ?? utf8;
     _bytes = Uint8List.fromList(bytes ?? []);
   }
 
@@ -91,7 +91,7 @@ class HttpBody extends BaseHttpBody {
       {Encoding encoding, Encoding fallbackEncoding}) {
     _encoding =
         encoding ?? http_utils.parseEncodingFromContentType(contentType);
-    _fallbackEncoding = fallbackEncoding;
+    _fallbackEncoding = fallbackEncoding ?? utf8;
     _body = body ?? '';
   }
 

--- a/lib/src/http/response.dart
+++ b/lib/src/http/response.dart
@@ -17,7 +17,6 @@ import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart'
     show CaseInsensitiveMap, MediaType;
-
 import 'package:w_transport/src/http/http_body.dart';
 import 'package:w_transport/src/http/utils.dart' as http_utils;
 
@@ -54,8 +53,12 @@ abstract class BaseResponse {
 
   /// Encoding that will be used to decode the response body. This encoding is
   /// selected based on [contentType]'s `charset` parameter. If `charset` is not
-  /// given or the encoding name is unrecognized, [latin1] is used by
-  /// default ([RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html)).
+  /// given or the encoding name is unrecognized, [latin1] is used by default
+  /// ([RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html)).
+  // TODO: That default has been superceded ([RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#appendix-B))
+  // and there is no longer a default, it should use the charset of the media type.
+  // But we don't have the media type's encoding, so leaving this for the moment. The most
+  // important media type for this is JSON, which we hard-code to utf-8.
   Encoding get encoding => _encoding;
 
   /// Headers sent with the response to the HTTP request.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
On the VM, JSON responses that do not specify a charset are decoded using latin1/ISO-8859-1. The fallback to latin1 is obsolete behavior, and we should now fall back to the default for the media type. For JSON this is utf-8. On the web, this already behaves correctly, so this should improve consistentency. 

## Changes
  <!-- What this PR changes to fix the problem. -->
Hard-code the asJson method on HttpBody to decode as utf-8 from bytes, rather than from string.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
