### PR TITLE
FEA-900: Widen ranges on `fluri` and `http_parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## [4.1.4] (https://github.com/Workiva/w_transport/compare/4.1.3...4.1.4)
+
+- Widen ranges on `fluri` and `http_parser`
+
 ## [4.1.3] (https://github.com/Workiva/w_transport/compare/4.1.2...4.1.3)
 
 - **Improvement** JSON content will always decode as utf-8. Previously it would
 fall back to the encoding specified for the body, or to ISO-8859-1, which was
-the old fallback value. There is no longer any fallback value, per rfc7231, but 
+the old fallback value. There is no longer any fallback value, per rfc7231, but
 it uses the media type value, which for JSON is by default UTF-8.
 
 ## [4.1.0](https://github.com/Workiva/w_transport/compare/4.0.8...4.1.0)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  fluri: ^1.2.6
-  http_parser: ^3.1.3
+  fluri: '>=1.3.0 <3.0.0'
+  http_parser: '>=3.1.4 <5.0.0'
   meta: ^1.2.2
   mime: '>=0.9.6+3 <2.0.0'
   quiver: '>=2.1.5 <4.0.0'


### PR DESCRIPTION
## Motivation
Widening `http_parser` will allow downstream resolution to newer versions of other packages.

## Changes
- Widen `fluri` and `http_parser` dependency ranges
  - Both major versions are null-safe migrations only and should otherwise be backwards compat.