### PR TITLE
FEA-1542: Suggest using `.streamGet()` for binary responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.1.6] (https://github.com/Workiva/w_transport/compare/4.1.5...4.1.6)
+
+- **Docs:** Suggest using `.streamGet()` over `.get()` for binary responses that
+will be read as bytes (via `body.asBytes()`).
+
 ## [4.1.4] (https://github.com/Workiva/w_transport/compare/4.1.3...4.1.4)
 
 - Widen ranges on `fluri` and `http_parser`

--- a/docs/guides/HttpSendRequestReceiveResponseHandleFailure.md
+++ b/docs/guides/HttpSendRequestReceiveResponseHandleFailure.md
@@ -133,6 +133,12 @@ var response = await transport.Http.get(Uri.parse('/file'));
 Uint8List body = response.body.asBytes();
 ```
 
+> Note: In the browser, requests are sent via XHR and non-streamed responses are
+> received as text rather than as a blob. In cases where you're expecting a
+> binary response format and plan to read that response via `.asBytes()`,
+> prefer using `streamGet()` instead. This will result in the response being
+> received as a blob so that no encoding is necessary when calling `.asBytes()`.
+
 #### Response Body: Text
 The response's `content-type` header is inspected for a `charset` parameter. If
 found and if valid, the corresponding encoding will be used to decode the

--- a/lib/src/http/request_dispatchers.dart
+++ b/lib/src/http/request_dispatchers.dart
@@ -39,6 +39,10 @@ abstract class RequestDispatchers {
   ///
   /// If [headers] are given, they will be merged with the set of headers
   /// already defined on the [BaseRequest].
+  ///
+  /// **Note:** For now, prefer [streamGet] for responses that could be binary
+  /// in order to avoid encoding issues when reading the body as bytes (we hope
+  /// to lift this restriction in the future).
   Future<Response> get({Map<String, String> headers, Uri uri});
 
   /// Send a HEAD request.


### PR DESCRIPTION
We've had a few instances where downloading binary files with w_transport's `.get()` method leads to a confusing encoding error. This can typically be solved either by having the server set the correct encoding in the content-type header, or by using `.streamGet()` and reading the response with `body.asBytes()` to avoid encoding altogether. Suggest the latter approach in our documentation.