### PR TITLE
FEA-2422: Allow setting a default timeout for all requests

### DIFF
--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -107,7 +107,7 @@ abstract class BaseRequest implements FluriMixin, RequestDispatchers {
   /// Amount of time to wait for the request to finish before canceling it and
   /// considering it "timed out" (results in a [RequestException] being thrown).
   ///
-  /// If null, no timeout threshold will be enforced.
+  /// If null, a default timeout threshold will be enforced.
   Duration timeoutThreshold;
 
   /// [RequestProgress] stream for this HTTP request's upload.

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -111,7 +111,7 @@ abstract class BaseRequest implements FluriMixin, RequestDispatchers {
   /// Amount of time to wait for the request to finish before canceling it and
   /// considering it "timed out" (results in a [RequestException] being thrown).
   ///
-  /// If null, a default timeout threshold will be enforced.
+  /// If null, a default timeout threshold (if set) will be enforced.
   Duration? timeoutThreshold;
 
   /// [RequestProgress] stream for this HTTP request's upload.

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -31,7 +31,7 @@ typedef ResponseInterceptor = Future<BaseResponse> Function(
     [RequestException error]);
 
 /// Specifies the default timeout for any request without an explicit one.
-Duration defaultTimeoutThreshold = Duration(minutes: 5);
+Duration defaultTimeoutThreshold;
 
 /// A common API that applies to all request types. The piece that is missing is
 /// that which is specific to the request body. Setting the request body differs

--- a/lib/src/http/base_request.dart
+++ b/lib/src/http/base_request.dart
@@ -30,6 +30,9 @@ typedef ResponseInterceptor = Future<BaseResponse> Function(
     FinalizedRequest request, BaseResponse response,
     [RequestException error]);
 
+/// Specifies the default timeout for any request without an explicit one.
+Duration defaultTimeoutThreshold = Duration(minutes: 5);
+
 /// A common API that applies to all request types. The piece that is missing is
 /// that which is specific to the request body. Setting the request body differs
 /// based on the type of request being sent (plain-text, JSON, form, multipart,

--- a/lib/src/http/client.dart
+++ b/lib/src/http/client.dart
@@ -55,7 +55,7 @@ abstract class Client {
   /// before canceling it and considering it "timed out" (results in a
   /// [RequestException] being thrown).
   ///
-  /// If null, no timeout threshold will be enforced.
+  /// If null, a default threshold will be enforced.
   Duration timeoutThreshold;
 
   /// Whether or not to send requests from this client with credentials. Only

--- a/lib/src/http/common/http_client.dart
+++ b/lib/src/http/common/http_client.dart
@@ -38,7 +38,7 @@ abstract class CommonHttpClient implements HttpClient {
   /// Amount of time to wait for the request to finish before canceling it and
   /// considering it "timed out" (results in a [RequestException] being thrown).
   ///
-  /// If null, no timeout threshold will be enforced.
+  /// If null, a default threshold will be enforced.
   @override
   Duration timeoutThreshold;
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -770,7 +770,10 @@ abstract class CommonRequest extends Object
       if (timeoutThreshold == null && defaultTimeoutThreshold != null) {
         timeoutThreshold = defaultTimeoutThreshold;
       }
-      final timeout = Timer(autoRetry.timeoutThreshold!, _timeoutRequest);
+      Timer? timeout;
+      if (timeoutThreshold != null) {
+        timeout = Timer(timeoutThreshold!, _timeoutRequest);
+      }
 
       // Attempt to fetch the response.
       // ignore: unawaited_futures
@@ -812,7 +815,7 @@ abstract class CommonRequest extends Object
       response = maybeResponse!;
 
       // Response has been received, so the timeout timer can be canceled.
-      timeout.cancel();
+      timeout?.cancel();
 
       if (response.status != 0 &&
           response.status != 304 &&

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -35,6 +35,8 @@ import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
 
+Duration defaultTimeoutThreshold = Duration(minutes: 5);
+
 abstract class CommonRequest extends Object
     with FluriMixin
     implements BaseRequest, RequestDispatchers {
@@ -769,7 +771,7 @@ abstract class CommonRequest extends Object
 
       // Enforce a timeout threshold.
       if (timeoutThreshold == null) {
-        timeoutThreshold = Duration(seconds: 60);
+        timeoutThreshold = defaultTimeoutThreshold;
       }
       final timeout = Timer(autoRetry.timeoutThreshold, _timeoutRequest);
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -767,8 +767,8 @@ abstract class CommonRequest extends Object
       checkForTimeout();
       final responseCompleter = Completer<BaseResponse>();
 
-      // Enforce a timeout threshold.
-      if (timeoutThreshold == null) {
+      // Enforce a timeout threshold if specified.
+      if (timeoutThreshold == null && defaultTimeoutThreshold != null) {
         timeoutThreshold = defaultTimeoutThreshold;
       }
       final timeout = Timer(autoRetry.timeoutThreshold, _timeoutRequest);

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -100,7 +100,7 @@ abstract class CommonRequest extends Object
   /// Amount of time to wait for the request to finish before canceling it and
   /// considering it "timed out" (results in a [RequestException] being thrown).
   ///
-  /// If null, no timeout threshold will be enforced.
+  /// If null, a default threshold will be enforced.
   @override
   Duration timeoutThreshold;
 
@@ -767,11 +767,11 @@ abstract class CommonRequest extends Object
       checkForTimeout();
       final responseCompleter = Completer<BaseResponse>();
 
-      // Enforce a timeout threshold if set.
-      Timer timeout;
-      if (timeoutThreshold != null) {
-        timeout = Timer(autoRetry.timeoutThreshold, _timeoutRequest);
+      // Enforce a timeout threshold.
+      if (timeoutThreshold == null) {
+        timeoutThreshold = Duration(seconds: 60);
       }
+      final timeout = Timer(autoRetry.timeoutThreshold, _timeoutRequest);
 
       // Attempt to fetch the response.
       // ignore: unawaited_futures

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -100,7 +100,7 @@ abstract class CommonRequest extends Object
   /// Amount of time to wait for the request to finish before canceling it and
   /// considering it "timed out" (results in a [RequestException] being thrown).
   ///
-  /// If null, a default threshold will be enforced.
+  /// If null, a default threshold (if set) will be enforced.
   @override
   Duration? timeoutThreshold;
 
@@ -767,12 +767,13 @@ abstract class CommonRequest extends Object
       final maybeResponseCompleter = Completer<BaseResponse?>();
 
       // Enforce a timeout threshold if specified.
+      // Note that autoRetry.timeoutThreshold internally references timeoutThreshold
       if (timeoutThreshold == null && defaultTimeoutThreshold != null) {
         timeoutThreshold = defaultTimeoutThreshold;
       }
       Timer? timeout;
-      if (timeoutThreshold != null) {
-        timeout = Timer(timeoutThreshold!, _timeoutRequest);
+      if (autoRetry.timeoutThreshold != null) {
+        timeout = Timer(autoRetry.timeoutThreshold!, _timeoutRequest);
       }
 
       // Attempt to fetch the response.

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -35,8 +35,6 @@ import 'package:w_transport/src/mocks/mock_transports.dart'
     show MockTransportsInternal;
 import 'package:w_transport/src/transport_platform.dart';
 
-Duration defaultTimeoutThreshold = Duration(minutes: 5);
-
 abstract class CommonRequest extends Object
     with FluriMixin
     implements BaseRequest, RequestDispatchers {

--- a/lib/w_transport.dart
+++ b/lib/w_transport.dart
@@ -98,7 +98,8 @@ export 'package:w_transport/src/transport_platform.dart'
 // HTTP
 export 'package:w_transport/src/http/auto_retry.dart'
     show RetryBackOff, RetryBackOffMethod;
-export 'package:w_transport/src/http/base_request.dart' show BaseRequest;
+export 'package:w_transport/src/http/base_request.dart'
+    show BaseRequest, defaultTimeoutThreshold;
 export 'package:w_transport/src/http/client.dart'
     show Client; // ignore: deprecated_member_use_from_same_package
 export 'package:w_transport/src/http/finalized_request.dart'

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -417,6 +417,21 @@ void _runCommonRequestSuiteFor(String name,
             error.error is TimeoutException;
       })));
     });
+
+    test('defaultTimeoutThreshold cancels the request if exceeded', () async {
+      final prevTimeout = transport.defaultTimeoutThreshold;
+      try {
+        transport.defaultTimeoutThreshold = Duration(milliseconds: 250);
+        final request = requestFactory();
+        expect(request.get(uri: IntegrationPaths.timeoutEndpointUri),
+            throwsA(predicate((error) {
+          return error is transport.RequestException &&
+              error.error is TimeoutException;
+        })));
+      } finally {
+        transport.defaultTimeoutThreshold = prevTimeout;
+      }
+    });
   });
 }
 

--- a/test/integration/http/common_request/suite.dart
+++ b/test/integration/http/common_request/suite.dart
@@ -423,7 +423,7 @@ void _runCommonRequestSuiteFor(String name,
       try {
         transport.defaultTimeoutThreshold = Duration(milliseconds: 250);
         final request = requestFactory();
-        expect(request.get(uri: IntegrationPaths.timeoutEndpointUri),
+        await expectLater(request.get(uri: IntegrationPaths.timeoutEndpointUri),
             throwsA(predicate((error) {
           return error is transport.RequestException &&
               error.error is TimeoutException;


### PR DESCRIPTION
# [FEA-2422](https://jira.atl.workiva.net/browse/FEA-2422)
![Issue Status](https://h.inf-dev.workiva.org/s/wk-backend/jira/status/FEA-2422)

## Motivation
Having an unbounded request is rarely desirable and has caused issues with too many open, long-running connections.

## Changes
Set a (customizable) default timeout.

#### Release Notes
A new `defaultTimeoutThreshold` setter allows all requests without an explicit timeout to inherit that default.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
