### PR TITLE
Prepare for dart_dev v4.0.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers: ^3.0.0
   collection: ^1.14.6
-  dart_dev: ^3.7.0
+  dart_dev: '>=3.7.0 <5.0.0'
   dependency_validator: ^3.0.0
   http_server: ^1.0.0
   over_react: ^4.0.0


### PR DESCRIPTION
This PR widens the allowable version ranges of dart_dev so that all repos at Workiva can consume dart_dev 4.0.0 without updating all repositories in lock step.
For more info, reach out to Timothy Steward or `#link23-state-of-the-dart-jam` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dev_widen_ranges_v4`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dev_widen_ranges_v4)