### PR TITLE
FEA-1797: Bug fix for the `send` method's `body` param on fall through requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [4.1.6] (https://github.com/Workiva/w_transport/compare/4.1.5...4.1.6)
 
+- **Bug Fix:** When using `MockTransports.install(fallThrough: true)`, the
+optional `body` param on the `send()` method will now properly be applied when
+the request "falls through" the mock config to a real request.
 - **Docs:** Suggest using `.streamGet()` over `.get()` for binary responses that
 will be read as bytes (via `body.asBytes()`).
 

--- a/lib/src/http/common/request.dart
+++ b/lib/src/http/common/request.dart
@@ -748,8 +748,8 @@ abstract class CommonRequest extends Object
             this.method, this.uri, this.headers)) {
       final realRequest = switchToRealRequest();
       return streamResponse
-          ? realRequest.streamSend(method)
-          : realRequest.send(method);
+          ? realRequest.streamSend(method, body: body)
+          : realRequest.send(method, body: body);
     }
 
     // Otherwise, carry on with the send logic and the mocks will do the rest.


### PR DESCRIPTION
## Motivation
When using `MockTransports.install(fallThrough: true)`, each request (when `.send()` is called) is checked against the mocks configured at that time. If no matching mocks are found, the request "falls through" and is converted to a real request. The `send()` method has an optional `body` parameter that is lost in this specific corner case - when the request is converted to a real request, the `body` parameter is not being passed on.

## Changes
Forward on the `body` parameter after switching to a real request.