### PR TITLE
RM-167470 Release w_transport 4.1.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 4.1.5
+version: 4.1.6
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Raise analyzer minimum & unpin meta](https://github.com/Workiva/w_transport/pull/384)
	* [Pin mockito 5](https://github.com/Workiva/w_transport/pull/387)
	* [FEA-1542: Suggest using `.streamGet()` for binary responses](https://github.com/Workiva/w_transport/pull/388)
	* [FEA-1543: Run CI on newer Dart SDK versions](https://github.com/Workiva/w_transport/pull/389)
	* [Prepare for dart_dev v4.0.0](https://github.com/Workiva/w_transport/pull/391)
	* [FEA-1797: Bug fix for the `send` method's `body` param on fall through requests](https://github.com/Workiva/w_transport/pull/393)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/4.1.5...Workiva:release_w_transport_4.1.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/4.1.5...4.1.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6059304149581824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6059304149581824/?repo_name=Workiva%2Fw_transport&pull_number=394)