### PR TITLE
Nullable fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
-## [5.0.0] (<https://github.com/Workiva/w_transport/compare/4.1.6...5.0.0>)
+## [5.0.1](https://github.com/Workiva/w_transport/compare/5.0.0...5.0.1)
 
-- Updated to null safety
+- Made `RequestException.request` nullable and re-add the null check, as we
+found unsound consumer usages where this could be null.
+- Bumped `collection` dependency to a non-pre-release version.
 
-## [4.1.6] (https://github.com/Workiva/w_transport/compare/4.1.5...4.1.6)
+## [5.0.0](https://github.com/Workiva/w_transport/compare/4.1.6...5.0.0)
+
+- Updated to null safety:
+  - Made as much of the public API non-nullable as safely possible.
+  - One notable behavioral change that was required in order to make the request
+  dispatch methods (like `.get()` and `.post()`) return non-nullable: if any
+  response interceptor takes a non-null response but returns a null response,
+  the original non-null response will be used instead. In practice, we don't
+  think this is common, and being able to make request methods return
+  non-nullable was worth it.
+
+## [4.1.6](https://github.com/Workiva/w_transport/compare/4.1.5...4.1.6)
 
 - **Bug Fix:** When using `MockTransports.install(fallThrough: true)`, the
 optional `body` param on the `send()` method will now properly be applied when
@@ -10,11 +23,11 @@ the request "falls through" the mock config to a real request.
 - **Docs:** Suggest using `.streamGet()` over `.get()` for binary responses that
 will be read as bytes (via `body.asBytes()`).
 
-## [4.1.4] (https://github.com/Workiva/w_transport/compare/4.1.3...4.1.4)
+## [4.1.4](https://github.com/Workiva/w_transport/compare/4.1.3...4.1.4)
 
 - Widen ranges on `fluri` and `http_parser`
 
-## [4.1.3] (https://github.com/Workiva/w_transport/compare/4.1.2...4.1.3)
+## [4.1.3](https://github.com/Workiva/w_transport/compare/4.1.2...4.1.3)
 
 - **Improvement** JSON content will always decode as utf-8. Previously it would
 fall back to the encoding specified for the body, or to ISO-8859-1, which was

--- a/lib/src/http/request_exception.dart
+++ b/lib/src/http/request_exception.dart
@@ -25,7 +25,7 @@ class RequestException implements Exception {
   final String? method;
 
   /// Failed request.
-  final BaseRequest request;
+  final BaseRequest? request;
 
   /// Response to the failed request (some of the properties may be unavailable).
   final BaseResponse? response;
@@ -42,10 +42,11 @@ class RequestException implements Exception {
   /// response status.
   String get message {
     String msg;
-    if (request.autoRetry.numAttempts > 1) {
+    var r = request;
+    if (r != null && r.autoRetry.numAttempts > 1) {
       msg = '$method $uri';
-      for (int i = 0; i < request.autoRetry.failures.length; i++) {
-        final failure = request.autoRetry.failures[i];
+      for (int i = 0; i < r.autoRetry.failures.length; i++) {
+        final failure = r.autoRetry.failures[i];
         String attempt = '\n\tAttempt #${i + 1}:';
         if (failure.response != null) {
           attempt +=

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   mime: '>=0.9.6+3 <2.0.0'
   quiver: '>=2.1.5 <4.0.0'
   sockjs_client_wrapper: ^1.0.14
-  collection: ^1.15.0-nullsafety.4
+  collection: ^1.15.0
 
 dev_dependencies:
   _test_server:

--- a/test/unit/http/request_test.dart
+++ b/test/unit/http/request_test.dart
@@ -380,7 +380,7 @@ void _runCommonRequestSuiteFor(String name,
       request.abort();
       expect(future, throwsA(predicate((dynamic error) {
         return error is transport.RequestException &&
-            error.request.autoRetry.numAttempts == 1;
+            error.request?.autoRetry.numAttempts == 1;
       })));
     });
 


### PR DESCRIPTION
## Motivation
A runtime error was uncovered when testing the 5.0.0 release more.
The collection dependency minimum was on a pre-release version.


## Changes
Make RequestException.request nullable too
Use `collection: ^1.15.0` instead of `^1.15.0-nullsafety.4`

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
