### PR TITLE
Test compatibility with w_module 3 and w_transport 5

### DIFF
--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -13,3 +13,7 @@ dev_dependencies:
   workiva_analysis_options: ^1.0.0
   w_transport:
     path: ../
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,3 +20,7 @@ dev_dependencies:
   workiva_analysis_options: ^1.0.2
   w_transport:
     path: ../
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,3 +34,7 @@ dependency_validator:
     - example/**
   ignore:
     - mockito
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0


### PR DESCRIPTION
DO NOT MERGE. This PR adds a dependency override to test whether this repo is compatible with w_module 3 and w_transport 5
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_wmodule_wtransport`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_wmodule_wtransport)