### PR TITLE
FEA-2879: Include SockJS debug URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.2.0](https://github.com/Workiva/w_transport/compare/5.1.0...5.2.0)
+
+- Added `debugUrl` to `WebSocketConnectEvent` which is emitted via the
+`GlobalWebSocketMonitor`. When using SockJS, this will be populated with the
+full URL that the underlying transport is using, which can be useful information
+for debugging.
+
 ## [5.1.0](https://github.com/Workiva/w_transport/compare/5.0.1...5.1.0)
 
 - Added `defaultTimeoutThreshold` top level field to add a timeout for all requests by default.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,6 +6,12 @@ homepage: https://github.com/Workiva/w_transport
 environment:
   sdk: ">=2.11.0 <3.0.0"
 
+dependency_overrides:
+  sockjs_client_wrapper:
+    git:
+      url: git@github.com:Workiva/sockjs_client_wrapper.git
+      ref: expose-debug-transport-url
+
 dev_dependencies:
   _test_server:
     path: ../_test_server

--- a/lib/src/web_socket/browser/sockjs_wrapper.dart
+++ b/lib/src/web_socket/browser/sockjs_wrapper.dart
@@ -79,10 +79,12 @@ class SockJSWrapperWebSocket extends CommonWebSocket implements WebSocket {
     client.onOpen.listen((event) {
       connected.complete();
       emitWebSocketConnectEvent(newWebSocketConnectEvent(
-          url: uri.toString(),
-          wasSuccessful: true,
-          sockJsProtocolsWhitelist: protocolsWhitelist,
-          sockJsSelectedProtocol: event.transport));
+        url: uri.toString(),
+        wasSuccessful: true,
+        debugUrl: event.debugUrl.toString(),
+        sockJsProtocolsWhitelist: protocolsWhitelist,
+        sockJsSelectedProtocol: event.transport,
+      ));
     });
     // ignore: unawaited_futures
     closed.future.then((_) {
@@ -90,9 +92,10 @@ class SockJSWrapperWebSocket extends CommonWebSocket implements WebSocket {
         connected
             .completeError(WebSocketException('Could not connect to $uri'));
         emitWebSocketConnectEvent(newWebSocketConnectEvent(
-            url: uri.toString(),
-            wasSuccessful: false,
-            sockJsProtocolsWhitelist: protocolsWhitelist));
+          url: uri.toString(),
+          wasSuccessful: false,
+          sockJsProtocolsWhitelist: protocolsWhitelist,
+        ));
       }
     });
 

--- a/lib/src/web_socket/global_web_socket_monitor.dart
+++ b/lib/src/web_socket/global_web_socket_monitor.dart
@@ -25,16 +25,20 @@ void emitWebSocketConnectEvent(WebSocketConnectEvent connectEvent) {
 GlobalWebSocketMonitor newGlobalWebSocketMonitor() =>
     GlobalWebSocketMonitor._();
 
-WebSocketConnectEvent newWebSocketConnectEvent(
-        {required String url,
-        required bool wasSuccessful,
-        String? sockJsSelectedProtocol,
-        List<String>? sockJsProtocolsWhitelist}) =>
+WebSocketConnectEvent newWebSocketConnectEvent({
+  required String url,
+  required bool wasSuccessful,
+  String? debugUrl,
+  String? sockJsSelectedProtocol,
+  List<String>? sockJsProtocolsWhitelist,
+}) =>
     WebSocketConnectEvent._(
-        url: url,
-        wasSuccessful: wasSuccessful,
-        sockJsProtocolsWhitelist: sockJsProtocolsWhitelist,
-        sockJsSelectedProtocol: sockJsSelectedProtocol);
+      url: url,
+      wasSuccessful: wasSuccessful,
+      debugUrl: debugUrl,
+      sockJsProtocolsWhitelist: sockJsProtocolsWhitelist,
+      sockJsSelectedProtocol: sockJsSelectedProtocol,
+    );
 
 class GlobalWebSocketMonitor {
   StreamController<WebSocketConnectEvent> _didAttemptToConnect =
@@ -54,14 +58,17 @@ class GlobalWebSocketMonitor {
 }
 
 class WebSocketConnectEvent {
+  final String? debugUrl;
   final List<String>? sockJsProtocolsWhitelist;
   final String? sockJsSelectedProtocol;
   final String url;
   final bool wasSuccessful;
 
-  WebSocketConnectEvent._(
-      {required this.url,
-      required this.wasSuccessful,
-      this.sockJsProtocolsWhitelist,
-      this.sockJsSelectedProtocol});
+  WebSocketConnectEvent._({
+    required this.url,
+    required this.wasSuccessful,
+    this.debugUrl,
+    this.sockJsProtocolsWhitelist,
+    this.sockJsSelectedProtocol,
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,12 @@ homepage: https://github.com/Workiva/w_transport
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependency_overrides:
+  sockjs_client_wrapper:
+    git:
+      url: git@github.com:Workiva/sockjs_client_wrapper.git
+      ref: expose-debug-transport-url
+
 dependencies:
   fluri: ^2.0.0
   http_parser: '>=3.1.4 <5.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,19 +6,13 @@ homepage: https://github.com/Workiva/w_transport
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
-dependency_overrides:
-  sockjs_client_wrapper:
-    git:
-      url: git@github.com:Workiva/sockjs_client_wrapper.git
-      ref: expose-debug-transport-url
-
 dependencies:
   fluri: ^2.0.0
   http_parser: '>=3.1.4 <5.0.0'
   meta: ^1.6.0
   mime: '>=0.9.6+3 <2.0.0'
   quiver: '>=2.1.5 <4.0.0'
-  sockjs_client_wrapper: ^1.0.14
+  sockjs_client_wrapper: ^1.3.0
   collection: ^1.15.0
 
 dev_dependencies:

--- a/test/integration/global_web_socket_monitor/sockjs_common.dart
+++ b/test/integration/global_web_socket_monitor/sockjs_common.dart
@@ -24,8 +24,7 @@ import 'common.dart';
 
 const _sockjsPort = 8026;
 
-void runCommonSockJSSuite(List<String> protocolsToTest,
-    {bool usingSockjsPort = true}) {
+void runCommonSockJSSuite(List<String> protocolsToTest) {
   final naming = Naming()
     ..platform = platformBrowserSockjsWrapper
     ..testType = testTypeIntegration
@@ -62,11 +61,13 @@ void runCommonSockJSSuite(List<String> protocolsToTest,
 
         expect(events[0].url, equals(echoUri.toString()));
         expect(events[0].wasSuccessful, isTrue);
+        expect(events[0].debugUrl, isNotEmpty);
         expect(events[0].sockJsProtocolsWhitelist, equals([protocol]));
         expect(events[0].sockJsSelectedProtocol, equals(protocol));
 
         expect(events[1].url, equals(fourOhFourUri.toString()));
         expect(events[1].wasSuccessful, isFalse);
+        expect(events[1].debugUrl, isNull);
         expect(events[1].sockJsProtocolsWhitelist, equals([protocol]));
         expect(events[1].sockJsSelectedProtocol, isNull);
       });

--- a/test/integration/global_web_socket_monitor/sockjs_wrapper_test.dart
+++ b/test/integration/global_web_socket_monitor/sockjs_wrapper_test.dart
@@ -29,5 +29,5 @@ const _protocolsToTest = [
 ];
 
 void main() {
-  runCommonSockJSSuite(_protocolsToTest, usingSockjsPort: false);
+  runCommonSockJSSuite(_protocolsToTest);
 }

--- a/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
+++ b/test/integration/global_web_socket_monitor/sockjs_wrapper_test.html
@@ -12,7 +12,7 @@
           }
         }
     </script>
-    <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
+    <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>
   </head>

--- a/test/integration/ws/sockjs_wrapper_test.html
+++ b/test/integration/ws/sockjs_wrapper_test.html
@@ -12,7 +12,7 @@
           }
         }
     </script>
-    <script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>
+    <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
     <link rel="x-dart-test"  href="sockjs_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>
   </head>


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We need a way to pipe the websocket debug url to consumers

## Changes
  <!-- What this PR changes to fix the problem. -->
* Add `debugUrl` to `WebSocketConnectEvent` which is emitted via the
`GlobalWebSocketMonitor`. When using SockJS, this will be populated with the
full URL that the underlying transport is using, which can be useful information
for debugging.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_transport/blob/master/CONTRIBUTING.md#manual-testing-criteria
