### PR TITLE
RM-222302 Release w_transport 5.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 5.1.1
+version: 5.2.0
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION


Requested by: @corwinweber-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/5.1.1...Workiva:release_w_transport_5.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/5.1.1...5.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6059304149581824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6059304149581824/?repo_name=Workiva%2Fw_transport&pull_number=417)