### PR TITLE
Allow consumption of null-safe over_react and over_react_test versions

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   dart_dev: ^4.0.0
   dependency_validator: ^3.0.0
   http_server: ^1.0.0
-  over_react: ^4.0.0
+  over_react: '>=4.0.0 <6.0.0'
   uuid: ^3.0.5
   workiva_analysis_options: ^1.0.2
   w_transport:


### PR DESCRIPTION
This PR widens the allowable version ranges to over_react 5.0.0 / over_react_test 3.0.0 so that all repos at Workiva can consume without updating all repositories in lock step.
These major versions are a critical step towards unlocking null safety in Workiva's Dart ecosystem - and **have already been tested and verified as safe for consumption** using the `w_transport` test PR [listed in this SourceGraph batch](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/over_react_5_test).
Due to the exhaustive consumption testing already performed in this repository by the FED team prior to releasing over_react 5.0.0, **these changes can be merged without approval from a FED team member.**
---
For more information about these changes, see [this post](https://workiva.slack.com/archives/C05GYDT1Z0E/p1711564946578809) in the [#frontend-advocate-network](https://workiva.enterprise.slack.com/archives/C05GYDT1Z0E) channel. Otherwise, reach out to the FED team in [#support-ui-platform](https://workiva.enterprise.slack.com/archives/CEFTMBPAA) with any specific questions or concerns.

[_Created by Sourcegraph batch change `Workiva/over_react-5.0_raise-upper`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/over_react-5.0_raise-upper)