### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   fluri: ^2.0.0
   http_parser: '>=3.1.4 <5.0.0'
-  meta: ^1.6.0
+  meta: ^1.16.0
   mime: '>=0.9.6+3 <2.0.0'
   quiver: '>=2.1.5 <4.0.0'
   sockjs_client_wrapper: ^1.3.0


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)