### PR TITLE
RM-251053 Release w_transport 5.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 5.2.1
+version: 5.2.2
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [DSC-10121 - Complete transition to GHA](https://github.com/Workiva/w_transport/pull/425)
	* [Replace mockito with mocktail](https://github.com/Workiva/w_transport/pull/427)
	* [Workiva Analysis Options v2](https://github.com/Workiva/w_transport/pull/428)
	* [Raise the build_web_compilers dependency max to v5.0.0](https://github.com/Workiva/w_transport/pull/429)
	* [Raise the meta dependency min to v1.16.0](https://github.com/Workiva/w_transport/pull/430)
	* [raise_min_dart_sdk_2_19](https://github.com/Workiva/w_transport/pull/432)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/5.2.1...Workiva:release_w_transport_5.2.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/5.2.1...5.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6059304149581824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6059304149581824/?repo_name=Workiva%2Fw_transport&pull_number=433)