### PR TITLE
ESG-11074 Don't log bytes / body in the error message

### DIFF
--- a/lib/src/http/response_format_exception.dart
+++ b/lib/src/http/response_format_exception.dart
@@ -34,25 +34,21 @@ class ResponseFormatException implements Exception {
   ResponseFormatException(this.contentType, this.encoding,
       {this.body, this.bytes});
 
-  /// Descriptive error message that includes the content-type, encoding, as
-  /// well as the string or bytes that could not be encoded or decoded,
-  /// respectively.
+  /// Error message that includes the content-type an encoding
   String get message {
     String description;
-    String bodyLine;
     if (body != null) {
       description = 'Body could not be encoded.';
-      bodyLine = 'Body: $body';
     } else {
       description = 'Bytes could not be decoded.';
-      bodyLine = 'Bytes: $bytes';
     }
 
     String msg = description;
     final encodingName = encoding?.name ?? 'null';
     msg += '\n\tContent-Type: $contentType';
     msg += '\n\tEncoding: $encodingName';
-    msg += '\n\t$bodyLine';
+    // WARNING: Do not include `bytes` or `body` in the error message. It may contain
+    // sensitive information that we do not want logged.
 
     return msg;
   }

--- a/test/unit/http/http_body_test.dart
+++ b/test/unit/http/http_body_test.dart
@@ -210,8 +210,8 @@ void main() {
         expect(exception.toString(), contains('Bytes could not be decoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
-        expect(
-            exception.toString(), isNot(contains(utf8.encode('bodyçå®')).toString()));
+        expect(exception.toString(),
+            isNot(contains(utf8.encode('bodyçå®')).toString()));
       });
     });
 

--- a/test/unit/http/http_body_test.dart
+++ b/test/unit/http/http_body_test.dart
@@ -187,7 +187,7 @@ void main() {
         expect(exception.toString(), contains('Body could not be encoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
-        expect(exception.toString(), contains('bodyçå®'));
+        expect(exception.toString(), isNot(contains('bodyçå®')));
       });
 
       test('should throw ResponseFormatException if bytes cannot be decoded',
@@ -211,7 +211,7 @@ void main() {
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
         expect(
-            exception.toString(), contains(utf8.encode('bodyçå®').toString()));
+            exception.toString(), isNot(contains(utf8.encode('bodyçå®')).toString()));
       });
     });
 

--- a/test/unit/http/response_format_exception_test.dart
+++ b/test/unit/http/response_format_exception_test.dart
@@ -37,8 +37,7 @@ void main() {
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
         // Do not log bytes, which may contain sensitive information
-        expect(
-            exception.toString(), isNot(contains(bytes).toString()));
+        expect(exception.toString(), isNot(contains(bytes).toString()));
       });
 
       test('should detail why string could not be encoded', () {

--- a/test/unit/http/response_format_exception_test.dart
+++ b/test/unit/http/response_format_exception_test.dart
@@ -36,8 +36,9 @@ void main() {
         expect(exception.toString(), contains('Bytes could not be decoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
+        // Do not log bytes, which may contain sensitive information
         expect(
-            exception.toString(), contains(utf8.encode('bodyçå®').toString()));
+            exception.toString(), isNot(contains(bytes).toString()));
       });
 
       test('should detail why string could not be encoded', () {
@@ -49,7 +50,8 @@ void main() {
         expect(exception.toString(), contains('Body could not be encoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: ${ascii.name}'));
-        expect(exception.toString(), contains('bodyçå®'));
+        // Do not log body, which may contain sensitive information
+        expect(exception.toString(), isNot(contains(body)));
       });
 
       test('should warn if encoding is null', () {
@@ -61,7 +63,8 @@ void main() {
         expect(exception.toString(), contains('Body could not be encoded'));
         expect(exception.toString(), contains('Content-Type: $contentType'));
         expect(exception.toString(), contains('Encoding: null'));
-        expect(exception.toString(), contains('bodyçå®'));
+        // Do not log body, which may contain sensitive information
+        expect(exception.toString(), isNot(contains(body)));
       });
     });
   });


### PR DESCRIPTION
## Motivation
  <!--
    High-level overview of what you are trying to fix or improve, and why.
    Include any relevant background information that reviewers should know.
  -->
The `toString()` of a `ResponseFormatException` produces a message that contains the contents of the response. This is far too easy for a logging system to dump information that should not be in the logs.

## Changes
  <!--
    What this PR changes to fix the problem.
  -->
Stop including the body in the ResponseFormatException

## Testing/QA Instructions
  <!--
    List manual testing instructions here if necessary, or indicate passing CI suffices if the changes are well covered by automated tests.
  -->