### PR TITLE
Raise the uuid dependency max to v5.0.0

### DIFF
--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -9,7 +9,7 @@ dev_dependencies:
   http_server: ^1.0.0
   mime: ^1.0.4
   mockito: ^5.3.1
-  uuid: ^3.0.5
+  uuid: '>=3.0.5 <5.0.0'
   workiva_analysis_options: ^1.0.0
   w_transport:
     path: ../

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   dependency_validator: ^3.0.0
   http_server: ^1.0.0
   over_react: ^5.0.0
-  uuid: ^3.0.5
+  uuid: '>=3.0.5 <5.0.0'
   workiva_analysis_options: ^1.0.2
   w_transport:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   http_server: ^1.0.0
   mocktail: ^1.0.3
   test: ^1.16.5
-  uuid: ^3.0.5
+  uuid: '>=3.0.5 <5.0.0'
   workiva_analysis_options: ^1.0.2
 dependency_validator:
   exclude:


### PR DESCRIPTION
This PR raises the max version of uuid to 5.0.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/uuid_raise_max_v5_0_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/uuid_raise_max_v5_0_0)