### PR TITLE
add sockjs connect span

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   http_parser: '>=3.1.4 <5.0.0'
   meta: ^1.16.0
   mime: '>=0.9.6+3 <2.0.0'
+  opentelemetry: ^0.18.8
   quiver: '>=2.1.5 <4.0.0'
   sockjs_client_wrapper: ^1.3.0
   collection: ^1.15.0


### PR DESCRIPTION
## Motivation
  <!--
    High-level overview of what you are trying to fix or improve, and why.
    Include any relevant background information that reviewers should know.
  -->

Establishing a web socket connection incurs [750 ms](https://onenr.io/0nQxdyanaQV) of latency during initial app load. This is a large amount of time that we should capture via traces to help categorize opportunities of improvement based on impact.

Additionally, adding the chosen transport as an attribute will help guide future decisions w.r.t. browser messaging.

## Changes
  <!--
    What this PR changes to fix the problem.
  -->

I added a span encompassing the duration it takes to establish a SockJS connection (usually a web socket connection). The span gets an attribute that's the chosen transport.

I also cleaned up the connect logic. We have a timeout parameter we aren't using that can apply to the info request of SockJS. SockJS has its own timeouts, but they don't pertain to the initial info request.

## Testing/QA Instructions
  <!--
    List manual testing instructions here if necessary, or indicate passing CI suffices if the changes are well covered by automated tests.
  -->

Pull the changes into a wdesk build and load an experience.