### PR TITLE
TEST: Running tests on React 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@f988281bd53b73a1429dda93bf7b0333885eebee
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.7
 
   build:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.7
@@ -27,12 +27,12 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6
-
+  
       - name: Install Node dependencies
         run: npm install
-
+  
       - name: Install Dart dependencies
         run: dart pub get
-
+  
       - name: Run tests
         run: dart run dart_dev test -P ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.7
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@f988281bd53b73a1429dda93bf7b0333885eebee
 
   build:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.7
@@ -27,12 +27,12 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6
-  
+
       - name: Install Node dependencies
         run: npm install
-  
+
       - name: Install Dart dependencies
         run: dart pub get
-  
+
       - name: Run tests
         run: dart run dart_dev test -P ci

--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -17,5 +17,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -19,7 +19,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18

--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -15,10 +15,6 @@ dev_dependencies:
     path: ../
 
 dependency_overrides:
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18
   react:
     git:
       url: git@github.com:Workiva/react-dart.git

--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -13,3 +13,17 @@ dev_dependencies:
   workiva_analysis_options: ^1.0.0
   w_transport:
     path: ../
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/_test_server/pubspec.yaml
+++ b/_test_server/pubspec.yaml
@@ -15,15 +15,15 @@ dev_dependencies:
     path: ../
 
 dependency_overrides:
+  dart_dev_workiva:
+    git:
+      url: git@github.com:Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,23 +7,23 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependency_overrides:
+  dart_dev_workiva:
+    git:
+      url: git@github.com:Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18
+  react:
+    git:
+      url: git@github.com:Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: git@github.com:Workiva/react_testing_library.git
+      ref: r18
   sockjs_client_wrapper:
     git:
       url: git@github.com:Workiva/sockjs_client_wrapper.git
       ref: expose-debug-transport-url
 
-  react:
-    git:
-      url: https://github.com/Workiva/react-dart.git
-      ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: https://github.com/Workiva/react_testing_library.git
-      ref: r18
-  dart_dev_workiva:
-    git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18
 dev_dependencies:
   _test_server:
     path: ../_test_server

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,10 +11,6 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18
   sockjs_client_wrapper:
     git:
       url: git@github.com:Workiva/sockjs_client_wrapper.git

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,8 +9,12 @@ environment:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
   sockjs_client_wrapper:
     git:
       url: git@github.com:Workiva/sockjs_client_wrapper.git

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,10 +7,6 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependency_overrides:
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18
   react:
     git:
       url: git@github.com:Workiva/react-dart.git

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,18 @@ dependency_overrides:
       url: git@github.com:Workiva/sockjs_client_wrapper.git
       ref: expose-debug-transport-url
 
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18
 dev_dependencies:
   _test_server:
     path: ../_test_server

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,10 +36,6 @@ dependency_validator:
     - mockito
 
 dependency_overrides:
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18
   react:
     git:
       url: git@github.com:Workiva/react-dart.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,5 +38,9 @@ dependency_validator:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,3 +34,17 @@ dependency_validator:
     - example/**
   ignore:
     - mockito
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,15 +36,15 @@ dependency_validator:
     - mockito
 
 dependency_overrides:
+  dart_dev_workiva:
+    git:
+      url: git@github.com:Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18


### PR DESCRIPTION
DO NOT MERGE. No action needed. This PR adds dependency overrides to https://github.com/Workiva/react-dart/pull/416
in order to test all consumers before rolling out React 18 in all repos.
For more info, see [our Wiki page with the rollout plan](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) and reach out to `#support-ui-platform` on Slack with any questions.

[_Created by Sourcegraph batch change `Workiva/react_18_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test)