### PR TITLE
Support setting `Websocket.binaryType`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   publish:
-    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.7
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added `WebSocket.binaryType` field to allow configuring the [binary type](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType)
+for WebSocket connections in the browser. Has no impact on the VM or when using SockJS.
+
 ## [5.2.0](https://github.com/Workiva/w_transport/compare/5.1.0...5.2.0)
 
 - Added `debugUrl` to `WebSocketConnectEvent` which is emitted via the

--- a/lib/src/web_socket/browser/web_socket.dart
+++ b/lib/src/web_socket/browser/web_socket.dart
@@ -73,6 +73,14 @@ class BrowserWebSocket extends CommonWebSocket implements WebSocket {
   }
 
   @override
+  String? get binaryType => _webSocket.binaryType;
+
+  @override
+  set binaryType(String? value) {
+    _webSocket.binaryType = value;
+  }
+
+  @override
   void closeWebSocket(int code, String? reason) {
     _webSocket.close(code, reason);
   }

--- a/lib/src/web_socket/common/web_socket.dart
+++ b/lib/src/web_socket/common/web_socket.dart
@@ -20,6 +20,11 @@ import 'package:w_transport/src/web_socket/w_socket_subscription.dart';
 /// Implementation of the [WebSocket] class that is common across all platforms.
 /// Platform-dependent pieces are left as unimplemented abstract members.
 abstract class CommonWebSocket extends Stream implements WebSocket {
+  /// The binary type of the WebSocket connection.
+  /// This only applies to native WebSockets in the browser.
+  @override
+  String? binaryType;
+
   /// The close code set when the WebSocket connection is closed. If there is
   /// no close code available this property will be `null`.
   @override

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -122,6 +122,10 @@ abstract class WebSocket implements Stream, StreamSink {
   static GlobalWebSocketMonitor getGlobalEventMonitor() =>
       newGlobalWebSocketMonitor();
 
+  /// The binary type of the WebSocket connection.
+  /// This only applies to native WebSockets in the browser.
+  String? binaryType;
+
   /// The close code set when the WebSocket connection is closed. If there is
   /// no close code available this property will be `null`.
   int? get closeCode;

--- a/test/integration/ws/browser_test.dart
+++ b/test/integration/ws/browser_test.dart
@@ -58,6 +58,24 @@ void main() {
       await socket?.close();
     });
 
+    test('should support configuring the binaryType to blob', () async {
+      final socket = await transport.WebSocket.connect(IntegrationPaths.pingUri,
+          transportPlatform: browserTransportPlatform);
+      socket?.binaryType = 'blob';
+      expect(socket?.binaryType, equals('blob'));
+      socket?.add('data');
+      await socket?.close();
+    });
+
+    test('should support configuring the binaryType to arraybuffer', () async {
+      final socket = await transport.WebSocket.connect(IntegrationPaths.pingUri,
+          transportPlatform: browserTransportPlatform);
+      socket?.binaryType = 'arraybuffer';
+      expect(socket?.binaryType, equals('arraybuffer'));
+      socket?.add('data');
+      await socket?.close();
+    });
+
     test('should throw when attempting to send invalid data', () async {
       final socket = await transport.WebSocket.connect(IntegrationPaths.pingUri,
           transportPlatform: browserTransportPlatform);

--- a/test/unit/ws/web_socket_test.dart
+++ b/test/unit/ws/web_socket_test.dart
@@ -247,4 +247,14 @@ void _runWebSocketSuite(Future<transport.WebSocket?> getWebSocket(Uri uri)) {
     expect(connection.closeReason, equals('closed'));
     await webSocket?.close().catchError((_) {});
   });
+
+  test('should allow setting the binaryType field', () async {
+    MockTransports.webSocket.expect(webSocketUri, connectTo: mockServer);
+    final webSocket = await getWebSocket(webSocketUri);
+
+    webSocket?.binaryType = 'arraybuffer';
+    expect(webSocket?.binaryType, equals('arraybuffer'));
+
+    await webSocket?.close();
+  });
 }


### PR DESCRIPTION
## Motivation
`WebSocket`s in the browser support a `binaryType` field (see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType) that we want to allow consumers of our `WebSocket` class to use.

## Changes
Add a `binaryType` field to the `WebSocket` abstraction. It will be a no-op on the Dart VM or when using SockJS, but will work when using native `WebSocket`s.

## Testing/QA Instructions
- [ ] CI passes (tests added)