### PR TITLE
Rollout React 18 to tests and example apps

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   dart_dev: ^4.0.0
   dependency_validator: ^3.0.0
   http_server: ^1.0.0
-  over_react: ^5.0.0
+  over_react: ^5.4.5
   uuid: ^4.0.0
   workiva_analysis_options: ^1.0.2
   w_transport:

--- a/example/web/http/cross_origin_credentials/index.html
+++ b/example/web/http/cross_origin_credentials/index.html
@@ -39,8 +39,7 @@ limitations under the License.
         </div>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/web/http/cross_origin_file_transfer/index.html
+++ b/example/web/http/cross_origin_file_transfer/index.html
@@ -36,8 +36,7 @@ limitations under the License.
         <div id="app"></div>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/web/http/simple_client/index.html
+++ b/example/web/http/simple_client/index.html
@@ -46,8 +46,7 @@ limitations under the License.
         </div>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script defer src="client.dart.js"></script>
     
 </body>

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -44,8 +44,7 @@ limitations under the License.
         </ul>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script defer src="index.dart.js"></script>
     
 </body>

--- a/example/web/web_socket/echo/index.html
+++ b/example/web/web_socket/echo/index.html
@@ -76,8 +76,7 @@ limitations under the License.
 
 <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
 <!--<script src="packages/sockjs_client_wrapper/sockjs_prod.js"></script>-->
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 <script defer src="client.dart.js"></script>
 
 </body>


### PR DESCRIPTION
This PR updates all references to React JS files from the React 17 to [React 18 versions](https://github.com/Workiva/react-dart?tab=readme-ov-file#react-18) which will cause most tests and example apps to run on React 18.

This is Step 2 in our [React 18 migration plan](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=405122049&spaceKey=FEF&title=React%2B18%2BUpgrade#tab-Step+2): `opt most of CI and example apps into React 18, finalize manual testing`.

**Note**: Prod will still be running on React 17 until we roll out React 18 in LaunchDarkly so there will be a period of time after this PR merges
that tests will run on React 18 while prod is still on React 17. This should not cause issues and we will try to keep this period of time as short as possible. Please reach out to `#support-ui-platform` with any questions!

We request that repo owners perform the QA instructions and review/merge these PRs as soon as CI passes. Thank you!

## QA Instructions

- [ ] Verify that updates in this PR affect only tests or example/dev apps, and not HTML files deployed to end-users
- [ ] Passing CI
- [ ] Passing CI on [React 18 Test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) in this repo
- [ ] Manually QA and smoke test your app on React 18 - either by using the `?ld.fews-enable-react-18-in-dart=true` LD flag or by serving the [React 18 test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) locally (see [full instructions on React 18 manual testing here](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade#React18Upgrade-test-in-react-18HowcanItestmyappinReact18?))
  - From our testing, we do not anticipate there being any issues, but would like owning teams to manually smoke test their apps on React 18, focusing on areas of code with more complex components or less test coverage in CI.

For more info, refer to the [React 18 Upgrade wiki page](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) or reach out to `#support-ui-platform` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_18_upgrade`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_upgrade)