### PR TITLE
FEDX-3766: no_entrypoint_imports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,12 @@ on:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.10
-
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.11
+    with:
+      additional-checks: |
+        no_entrypoint_imports
   build:
-    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.10
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.11
 
   # note, we're not using the test-unit workflow here because of
   # the need to install npm dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   publish:
-    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.10
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.11

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async';
 
-import 'package:w_transport/mock.dart';
+import 'package:w_transport/src/http/finalized_request.dart';
 import 'package:w_transport/src/http/base_request.dart';
 import 'package:w_transport/src/http/request_exception.dart';
 import 'package:w_transport/src/http/response.dart';

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -14,7 +14,10 @@
 
 import 'dart:async';
 
-
+import 'package:w_transport/mock.dart';
+import 'package:w_transport/src/http/base_request.dart';
+import 'package:w_transport/src/http/request_exception.dart';
+import 'package:w_transport/src/http/response.dart';
 
 /// Base class representing an interceptor that can be registered with a
 /// HttpClient instance to intercept HTTP requests and responses in order to

--- a/lib/src/http/http_interceptor.dart
+++ b/lib/src/http/http_interceptor.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async';
 
-import 'package:w_transport/w_transport.dart';
+
 
 /// Base class representing an interceptor that can be registered with a
 /// HttpClient instance to intercept HTTP requests and responses in order to

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -37,7 +37,7 @@ import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 ///
 /// To establish a connection, use the static [connect] method:
 ///
-///
+/// import 'package:w_transport/w_transport.dart';
 ///
 ///     main() async {
 ///       Uri uri = Uri.parse('ws://echo.websocket.org');

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -37,7 +37,7 @@ import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 ///
 /// To establish a connection, use the static [connect] method:
 ///
-///     import 'package:w_transport/w_transport.dart';
+///     
 ///
 ///     main() async {
 ///       Uri uri = Uri.parse('ws://echo.websocket.org');

--- a/lib/src/web_socket/web_socket.dart
+++ b/lib/src/web_socket/web_socket.dart
@@ -37,7 +37,7 @@ import 'package:w_transport/src/web_socket/global_web_socket_monitor.dart';
 ///
 /// To establish a connection, use the static [connect] method:
 ///
-///     
+///
 ///
 ///     main() async {
 ///       Uri uri = Uri.parse('ws://echo.websocket.org');


### PR DESCRIPTION
# [FEDX-3766](https://jira.atl.workiva.net/browse/FEDX-3766)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-3766)

## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)