### PR TITLE
RM-343161 Release w_transport 5.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 5.3.0
+version: 5.4.0
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Rollout React 18 to tests and example apps](https://github.com/Workiva/w_transport/pull/445)
	* [FEA-8447: Add `BinaryRequest` for sending requests and reading responses as ArrayBuffers in the browser](https://github.com/Workiva/w_transport/pull/446)
	* [FEDX-3766: no_entrypoint_imports](https://github.com/Workiva/w_transport/pull/447)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/5.3.0...Workiva:release_w_transport_5.4.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/5.3.0...5.4.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6059304149581824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6059304149581824/?repo_name=Workiva%2Fw_transport&pull_number=448)