### PR TITLE
FEA-8530: Fix late init error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Removed possibility for a LateInitializationError when transforming a ProgressEvent stream from an HttpRequest into
+a RequestProgress stream.
+
 - Added `BinaryRequest` for sending raw bytes with proper browser support using
 the `responseType` field on the XHR instance.
 

--- a/lib/src/http/browser/utils.dart
+++ b/lib/src/http/browser/utils.dart
@@ -18,7 +18,7 @@ import 'dart:html';
 import 'package:w_transport/src/http/request_progress.dart';
 
 /// Transforms an [ProgressEvent] stream from an [HttpRequest] into
-/// a [WProgress] stream.
+/// a [RequestProgress] stream.
 StreamTransformer<ProgressEvent, RequestProgress> transformProgressEvents =
     StreamTransformer<ProgressEvent, RequestProgress>(
         (Stream<ProgressEvent> input, bool cancelOnError) {

--- a/lib/src/http/browser/utils.dart
+++ b/lib/src/http/browser/utils.dart
@@ -22,10 +22,9 @@ import 'package:w_transport/src/http/request_progress.dart';
 StreamTransformer<ProgressEvent, RequestProgress> transformProgressEvents =
     StreamTransformer<ProgressEvent, RequestProgress>(
         (Stream<ProgressEvent> input, bool cancelOnError) {
-  late StreamController<RequestProgress> controller;
-  StreamSubscription<ProgressEvent>? subscription;
-  controller = StreamController<RequestProgress>(onListen: () {
-    subscription = input.listen((ProgressEvent event) {
+  final controller = StreamController<RequestProgress>(sync: true);
+  controller.onListen = () {
+    final subscription = input.listen((ProgressEvent event) {
       controller.add(event.lengthComputable
           ? RequestProgress(event.loaded!, event.total!)
           : RequestProgress());
@@ -33,12 +32,10 @@ StreamTransformer<ProgressEvent, RequestProgress> transformProgressEvents =
         onError: controller.addError,
         onDone: controller.close,
         cancelOnError: cancelOnError);
-  }, onPause: () {
-    subscription?.pause();
-  }, onResume: () {
-    subscription?.resume();
-  }, onCancel: () {
-    subscription?.cancel();
-  });
+    controller
+      ..onPause = subscription.pause
+      ..onResume = subscription.resume
+      ..onCancel = subscription.cancel;
+  };
   return controller.stream.listen(null);
 });

--- a/lib/src/http/browser/utils.dart
+++ b/lib/src/http/browser/utils.dart
@@ -23,7 +23,7 @@ StreamTransformer<ProgressEvent, RequestProgress> transformProgressEvents =
     StreamTransformer<ProgressEvent, RequestProgress>(
         (Stream<ProgressEvent> input, bool cancelOnError) {
   late StreamController<RequestProgress> controller;
-  late StreamSubscription<ProgressEvent> subscription;
+  StreamSubscription<ProgressEvent>? subscription;
   controller = StreamController<RequestProgress>(onListen: () {
     subscription = input.listen((ProgressEvent event) {
       controller.add(event.lengthComputable
@@ -34,11 +34,11 @@ StreamTransformer<ProgressEvent, RequestProgress> transformProgressEvents =
         onDone: controller.close,
         cancelOnError: cancelOnError);
   }, onPause: () {
-    subscription.pause();
+    subscription?.pause();
   }, onResume: () {
-    subscription.resume();
+    subscription?.resume();
   }, onCancel: () {
-    subscription.cancel();
+    subscription?.cancel();
   });
   return controller.stream.listen(null);
 });


### PR DESCRIPTION
## Motivation
  <!--
    High-level overview of what you are trying to fix or improve, and why.
    Include any relevant background information that reviewers should know.
  -->
We're seeing late initialization errors [here](https://github.com/Workiva/w_transport/blob/master/lib/src/http/browser/utils.dart#L37). 

It seems that pause can get called and execute onPause before onListen executes

## Changes
  <!--
    What this PR changes to fix the problem.
  -->
Updated this to be a bit safer and to align more closely with the [Dart-sdk example of how to do a stream transform. ](https://github.com/dart-lang/sdk/blob/2.19.6/sdk/lib/async/stream.dart#L2348-L2381)

This will fix the late init error. 

## Testing/QA Instructions
  <!--
    List manual testing instructions here if necessary, or indicate passing CI suffices if the changes are well covered by automated tests.
  -->
* CI passes