### PR TITLE
RM-349935 Release w_transport 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## Unreleased
 
+## [5.4.1](https://github.com/Workiva/w_transport/compare/5.4.0...5.4.1)
+
 - Removed possibility for a LateInitializationError when transforming a ProgressEvent stream from an HttpRequest into
 a RequestProgress stream.
+
+## [5.4.0](https://github.com/Workiva/w_transport/compare/5.3.0...5.4.0)
 
 - Added `BinaryRequest` for sending raw bytes with proper browser support using
 the `responseType` field on the XHR instance.
 
-## 5.3.0
+## [5.3.0](https://github.com/Workiva/w_transport/compare/5.2.0...5.3.0)
 
 - Added `WebSocket.binaryType` field to allow configuring the [binary type](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType)
 for WebSocket connections in the browser. Has no impact on the VM or when using SockJS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_transport
-version: 5.4.0
+version: 5.4.1
 description: Transport library for sending HTTP requests and opening WebSockets. Platform-independent with builtin support for browser and Dart VM (even supports SockJS). Includes mock utilities for testing.
 homepage: https://github.com/Workiva/w_transport
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-8530: Fix late init error](https://github.com/Workiva/w_transport/pull/449)


Requested by: @corwinweber-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_transport/compare/5.4.0...Workiva:release_w_transport_5.4.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_transport/compare/5.4.0...5.4.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6059304149581824/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6059304149581824/?repo_name=Workiva%2Fw_transport&pull_number=450)